### PR TITLE
Add an addressof tool, like the one in stdlib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(subspace STATIC
     "assertions/unreachable.h"
     "marker/unsafe.h"
     "mem/__private/relocate.h"
+    "mem/addressof.h"
     "lib/lib.cc"
 )
 set_target_properties(subspace PROPERTIES LINKER_LANGUAGE CXX)
@@ -31,6 +32,7 @@ add_executable(subspace_unittests
     "assertions/panic_unittest.cc"
     "assertions/unreachable_unittest.cc"
     "mem/__private/relocate_unittest.cc"
+    "mem/addressof_unittest.cc"
 )
 set_target_properties(subspace_unittests PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(subspace_unittests

--- a/mem/addressof.h
+++ b/mem/addressof.h
@@ -1,0 +1,34 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+namespace sus::mem {
+
+template <class T>
+typename std::enable_if<std::is_object<T>::value, T*>::type addressof(
+    T& arg) noexcept {
+  return reinterpret_cast<T*>(
+      &const_cast<char&>(reinterpret_cast<const volatile char&>(arg)));
+}
+
+template <class T>
+typename std::enable_if<!std::is_object<T>::value, T*>::type addressof(
+    T& arg) noexcept {
+  return &arg;
+}
+
+}  // namespace sus::mem

--- a/mem/addressof_unittest.cc
+++ b/mem/addressof_unittest.cc
@@ -1,0 +1,54 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mem/addressof.h"
+
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace sus::mem {
+namespace {
+
+TEST(AddressOf, Object) {
+  struct S {
+    int i;
+  };
+  S s;
+  static_assert(std::is_object_v<decltype(s)>, "");
+  EXPECT_EQ(::sus::mem::addressof(s), &s);
+}
+
+TEST(AddressOf, OperatorOverride) {
+  struct T {
+    int i;
+    unsigned char* operator&() const { return 0; }
+  };
+  struct S {
+    T t;
+  };
+  S s;
+  EXPECT_EQ(0, &s.t);
+  EXPECT_EQ(reinterpret_cast<unsigned char*>(::sus::mem::addressof(s.t)),
+            reinterpret_cast<unsigned char*>(&s));
+}
+
+TEST(AddressOf, NonObject) {
+  struct S {};
+  S s;
+  S& r = s;
+  static_assert(!std::is_object_v<decltype(r)>, "");
+  EXPECT_EQ(::sus::mem::addressof(r), &s);
+}
+
+}  // namespace
+}  // namespace sus::mem


### PR DESCRIPTION
This should always be used in place of `operator&` for types that
are not known, and could be defined by the user (ie. template
variable types).

We roll our own to avoid pulling in all of memory.h and the stdlib
binary size.