### PR TITLE
Stop downloading cmake in github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,45 +52,27 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Download Ninja and CMake
-        id: cmake_and_ninja
+      - name: Download Ninja
+        id: ninja
         shell: cmake -P {0}
         run: |
           set(ninja_version "1.9.0")
-          set(cmake_version "3.16.2")
-
-          message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
 
           if ("${{ runner.os }}" STREQUAL "Windows")
             set(ninja_suffix "win.zip")
-            set(cmake_suffix "win64-x64.zip")
-            set(cmake_dir "cmake-${cmake_version}-win64-x64/bin")
           elseif ("${{ runner.os }}" STREQUAL "Linux")
             set(ninja_suffix "linux.zip")
-            set(cmake_suffix "Linux-x86_64.tar.gz")
-            set(cmake_dir "cmake-${cmake_version}-Linux-x86_64/bin")
           elseif ("${{ runner.os }}" STREQUAL "macOS")
             set(ninja_suffix "mac.zip")
-            set(cmake_suffix "Darwin-x86_64.tar.gz")
-            set(cmake_dir "cmake-${cmake_version}-Darwin-x86_64/CMake.app/Contents/bin")
           endif()
 
           set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
           file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
           execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
 
-          set(cmake_url "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-${cmake_suffix}")
-          file(DOWNLOAD "${cmake_url}" ./cmake.zip SHOW_PROGRESS)
-          execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./cmake.zip)
-
-          # Save the path for other steps
-          file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/${cmake_dir}" cmake_dir)
-          message("::set-output name=cmake_dir::${cmake_dir}")
-
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             execute_process(
               COMMAND chmod +x ninja
-              COMMAND chmod +x ${cmake_dir}/cmake
             )
           endif()
 
@@ -116,7 +98,7 @@ jobs:
           file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 
           execute_process(
-            COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/cmake
+            COMMAND cmake
               -S .
               -B build
               -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
@@ -143,7 +125,7 @@ jobs:
           endif()
 
           execute_process(
-            COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/cmake --build build
+            COMMAND cmake --build build
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)
@@ -157,7 +139,7 @@ jobs:
           ProcessorCount(N)
 
           execute_process(
-            COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/ctest -j ${N}
+            COMMAND ctest -j ${N}
             WORKING_DIRECTORY build
             RESULT_VARIABLE result
           )
@@ -166,11 +148,11 @@ jobs:
           endif()
 
       - name: Install Strip
-        run: ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/cmake --install build --prefix instdir --strip
+        run: cmake --install build --prefix instdir --strip
 
       - name: Pack
         working-directory: instdir
-        run: ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/cmake -E tar cJfv ../${{ matrix.config.artifact }} .
+        run: cmake -E tar cJfv ../${{ matrix.config.artifact }} .
 
       - name: Upload
         uses: actions/upload-artifact@v1

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -52,45 +52,27 @@ jobs:
     steps:
       - uses: actions/checkout@v1
 
-      - name: Download Ninja and CMake
-        id: cmake_and_ninja
+      - name: Download Ninja
+        id: ninja
         shell: cmake -P {0}
         run: |
           set(ninja_version "1.9.0")
-          set(cmake_version "3.16.2")
-
-          message(STATUS "Using host CMake version: ${CMAKE_VERSION}")
 
           if ("${{ runner.os }}" STREQUAL "Windows")
             set(ninja_suffix "win.zip")
-            set(cmake_suffix "win64-x64.zip")
-            set(cmake_dir "cmake-${cmake_version}-win64-x64/bin")
           elseif ("${{ runner.os }}" STREQUAL "Linux")
             set(ninja_suffix "linux.zip")
-            set(cmake_suffix "Linux-x86_64.tar.gz")
-            set(cmake_dir "cmake-${cmake_version}-Linux-x86_64/bin")
           elseif ("${{ runner.os }}" STREQUAL "macOS")
             set(ninja_suffix "mac.zip")
-            set(cmake_suffix "Darwin-x86_64.tar.gz")
-            set(cmake_dir "cmake-${cmake_version}-Darwin-x86_64/CMake.app/Contents/bin")
           endif()
 
           set(ninja_url "https://github.com/ninja-build/ninja/releases/download/v${ninja_version}/ninja-${ninja_suffix}")
           file(DOWNLOAD "${ninja_url}" ./ninja.zip SHOW_PROGRESS)
           execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./ninja.zip)
 
-          set(cmake_url "https://github.com/Kitware/CMake/releases/download/v${cmake_version}/cmake-${cmake_version}-${cmake_suffix}")
-          file(DOWNLOAD "${cmake_url}" ./cmake.zip SHOW_PROGRESS)
-          execute_process(COMMAND ${CMAKE_COMMAND} -E tar xvf ./cmake.zip)
-
-          # Save the path for other steps
-          file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/${cmake_dir}" cmake_dir)
-          message("::set-output name=cmake_dir::${cmake_dir}")
-
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             execute_process(
               COMMAND chmod +x ninja
-              COMMAND chmod +x ${cmake_dir}/cmake
             )
           endif()
 
@@ -116,7 +98,7 @@ jobs:
           file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 
           execute_process(
-            COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/cmake
+            COMMAND cmake
               -S .
               -B build
               -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
@@ -143,7 +125,7 @@ jobs:
           endif()
 
           execute_process(
-            COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/cmake --build build
+            COMMAND cmake --build build
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)
@@ -157,7 +139,7 @@ jobs:
           ProcessorCount(N)
 
           execute_process(
-            COMMAND ${{ steps.cmake_and_ninja.outputs.cmake_dir }}/ctest -j ${N}
+            COMMAND ctest -j ${N}
             WORKING_DIRECTORY build
             RESULT_VARIABLE result
           )


### PR DESCRIPTION
Downloading ninja is kinda slow, and building with ninja isn't
doing that much (yet).