### PR TITLE
Add memory functions swap(), replace(), take().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ add_library(subspace STATIC
     "assertions/unreachable.h"
     "marker/unsafe.h"
     "mem/__private/relocate.h"
+    "mem/replace.h"
+    "mem/swap.h"
+    "mem/take.h"
     "mem/addressof.h"
     "lib/lib.cc"
 )
@@ -33,6 +36,9 @@ add_executable(subspace_unittests
     "assertions/unreachable_unittest.cc"
     "mem/__private/relocate_unittest.cc"
     "mem/addressof_unittest.cc"
+    "mem/replace_unittest.cc"
+    "mem/swap_unittest.cc"
+    "mem/take_unittest.cc"
 )
 set_target_properties(subspace_unittests PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(subspace_unittests

--- a/mem/replace.h
+++ b/mem/replace.h
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string.h>
+
+#include <type_traits>
+
+#include "mem/__private/relocate.h"
+#include "mem/addressof.h"
+
+namespace sus::mem {
+
+// It would be nice to have an array overload of replace() but functions can't
+// return arrays.
+template <class T, class = std::enable_if_t<!std::is_array_v<T>, void>>
+constexpr T replace(T& dest, T src) noexcept {
+  T old(static_cast<T&&>(dest));
+
+  // memcpy() is not constexpr so we can't use it in constexpr evaluation.
+  if (::sus::mem::__private::relocate_one_by_memcpy_v<T> &&
+      !std::is_constant_evaluated()) {
+    memcpy(::sus::mem::addressof(dest), ::sus::mem::addressof(src), sizeof(T));
+  } else {
+    dest = T(static_cast<T&&>(src));
+  }
+
+  return old;
+}
+
+}  // namespace sus::mem

--- a/mem/replace_unittest.cc
+++ b/mem/replace_unittest.cc
@@ -1,0 +1,170 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mem/replace.h"
+
+#include <type_traits>
+
+#include "assertions/builtin.h"
+#include "mem/__private/relocate.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace sus::mem {
+namespace {
+
+TEST(Replace, ConstexprTrivialRelocate) {
+  using T = int;
+  static_assert(__private::relocate_one_by_memcpy_v<T>, "");
+
+  auto i = []() constexpr {
+    T i(2);
+    T j(::sus::mem::replace(i, T(5)));
+    return i;
+  };
+  auto j = []() constexpr {
+    T i(2);
+    T j(::sus::mem::replace(i, T(5)));
+    return j;
+  };
+  static_assert(i() == T(5), "");
+  static_assert(j() == T(2), "");
+}
+
+TEST(Replace, ConstexprTrivialAbi) {
+  struct [[clang::trivial_abi]] S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), assigns(other.assigns) {}
+    constexpr void operator=(S&& other) {
+      num = other.num;
+      assigns = other.assigns + 1;
+    }
+    int num;
+    int assigns = 0;
+  };
+  // This means `S` is only "trivially relocatable" if achieved through
+  // [[clang::trivial_abi]].
+  static_assert(!std::is_trivially_move_constructible_v<S>, "");
+  static_assert(__private::relocate_one_by_memcpy_v<S> ==
+                    __has_extension(trivially_relocatable),
+                "");
+
+  auto i = []() constexpr {
+    S i(2);
+    S j(::sus::mem::replace(i, S(5)));
+    return i;
+  };
+  auto j = []() constexpr {
+    S i(2);
+    S j(::sus::mem::replace(i, S(5)));
+    return j;
+  };
+  static_assert(i().num == 5, "");
+  static_assert(j().num == 2, "");
+  // The replace was done by move operations, since memcpy is not constexpr.
+  static_assert(i().assigns == 1, "");
+}
+
+TEST(Replace, ConstexprNonTrivial) {
+  struct S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), assigns(other.assigns) {}
+    constexpr void operator=(S&& other) {
+      num = other.num;
+      assigns = other.assigns + 1;
+    }
+    int num;
+    int assigns = 0;
+  };
+  static_assert(!__private::relocate_one_by_memcpy_v<S>, "");
+
+  auto i = []() constexpr {
+    S i(2);
+    S j(::sus::mem::replace(i, S(5)));
+    return i;
+  };
+  auto j = []() constexpr {
+    S i(2);
+    S j(::sus::mem::replace(i, S(5)));
+    return j;
+  };
+  static_assert(i().num == 5, "");
+  static_assert(j().num == 2, "");
+  // The replace was done by move operations, since memcpy is not constexpr.
+  static_assert(i().assigns == 1, "");
+}
+
+TEST(Replace, TrivialRelocate) {
+  using T = int;
+  static_assert(__private::relocate_one_by_memcpy_v<T>, "");
+
+  T i(2);
+  T j(::sus::mem::replace(i, T(5)));
+  EXPECT_EQ(i, T(5));
+  EXPECT_EQ(j, T(2));
+}
+
+TEST(Replace, TrivialAbi) {
+  struct [[clang::trivial_abi]] S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), assigns(other.assigns) {}
+    constexpr void operator=(S&& other) {
+      num = other.num;
+      assigns = other.assigns + 1;
+    }
+    int num;
+    int assigns = 0;
+  };
+  // This means `S` is only "trivially relocatable" if achieved through
+  // [[clang::trivial_abi]].
+  static_assert(!std::is_trivially_move_constructible_v<S>, "");
+  static_assert(__private::relocate_one_by_memcpy_v<S> ==
+                    __has_extension(trivially_relocatable),
+                "");
+
+  S i(2);
+  S j(::sus::mem::replace(i, S(5)));
+  EXPECT_EQ(i.num, 5);
+  EXPECT_EQ(j.num, 2);
+#if __has_extension(trivially_relocatable)
+  // The replace was done by memcpy.
+  EXPECT_EQ(0, i.assigns);
+#else
+  // The replace was done by move operations.
+  EXPECT_EQ(1, i.assigns);
+#endif
+}
+
+TEST(Replace, NonTrivial) {
+  struct S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), assigns(other.assigns) {}
+    constexpr void operator=(S&& other) {
+      num = other.num;
+      assigns = other.assigns + 1;
+    }
+    int num;
+    int assigns = 0;
+  };
+  static_assert(!__private::relocate_one_by_memcpy_v<S>, "");
+
+  S i(2);
+  S j(::sus::mem::replace(i, S(5)));
+  EXPECT_EQ(i.num, 5);
+  EXPECT_EQ(j.num, 2);
+  // The replace was done by move operations.
+  EXPECT_EQ(1, i.assigns);
+}
+
+}  // namespace
+}  // namespace sus::mem

--- a/mem/swap.h
+++ b/mem/swap.h
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string.h>
+
+#include <type_traits>
+
+#include "mem/__private/relocate.h"
+#include "mem/addressof.h"
+
+namespace sus::mem {
+
+template <class T>
+constexpr void swap(T& lhs, T& rhs) noexcept {
+  // memcpy() is not constexpr so we can't use it in constexpr evaluation.
+  if (::sus::mem::__private::relocate_one_by_memcpy_v<T> &&
+      !std::is_constant_evaluated()) {
+    char temp[sizeof(T)];
+    memcpy(temp, ::sus::mem::addressof(lhs), sizeof(T));
+    memcpy(::sus::mem::addressof(lhs), ::sus::mem::addressof(rhs), sizeof(T));
+    memcpy(::sus::mem::addressof(rhs), temp, sizeof(T));
+  } else {
+    T temp(static_cast<T&&>(lhs));
+    lhs = T(static_cast<T&&>(rhs));
+    rhs = T(static_cast<T&&>(temp));
+  }
+}
+
+template <class T, /* TODO: usize */ size_t N>
+constexpr void swap(T (&lhs)[N], T (&rhs)[N]) noexcept {
+  // memcpy() is not constexpr so we can't use it in constexpr evaluation.
+  if (::sus::mem::__private::relocate_array_by_memcpy_v<T> &&
+      !std::is_constant_evaluated()) {
+    char temp[sizeof(T[N])];
+    memcpy(temp, lhs, sizeof(T[N]));
+    memcpy(lhs, rhs, sizeof(T[N]));
+    memcpy(rhs, temp, sizeof(T[N]));
+  } else {
+    for (/*TODO: usize*/ size_t i = 0; i < N; ++i) {
+      T temp(static_cast<T&&>(lhs[i]));
+      lhs[i] = T(static_cast<T&&>(rhs[i]));
+      rhs[i] = T(static_cast<T&&>(temp));
+    }
+  }
+}
+}  // namespace sus::mem

--- a/mem/swap_unittest.cc
+++ b/mem/swap_unittest.cc
@@ -1,0 +1,285 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mem/swap.h"
+
+#include <type_traits>
+
+#include "assertions/builtin.h"
+#include "mem/__private/relocate.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace sus::mem {
+namespace {
+
+TEST(Swap, ConstexprTrivialRelocate) {
+  using T = int;
+  static_assert(__private::relocate_one_by_memcpy_v<T>, "");
+
+  auto i = []() constexpr {
+    T i(2);
+    T j(5);
+    ::sus::mem::swap(i, j);
+    return i;
+  };
+  auto j = []() constexpr {
+    T i(2);
+    T j(5);
+    ::sus::mem::swap(i, j);
+    return j;
+  };
+  static_assert(i() == T(5), "");
+  static_assert(j() == T(2), "");
+
+  // Array.
+  {
+    using T = int[5];
+    static_assert(__private::relocate_array_by_memcpy_v<T>, "");
+
+    auto i = []() constexpr {
+      T i{2, 2, 3, 4, 2};
+      T j{5, 5, 6, 7, 5};
+      ::sus::mem::swap(i, j);
+      return i[3];
+    };
+    auto j = []() constexpr {
+      T i{2, 2, 3, 4, 2};
+      T j{5, 5, 6, 7, 5};
+      ::sus::mem::swap(i, j);
+      return j[3];
+    };
+    static_assert(i() == 7, "");
+    static_assert(j() == 4, "");
+  }
+}
+
+TEST(Swap, ConstexprTrivialAbi) {
+  struct [[clang::trivial_abi]] S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), moves(other.moves + 1) {}
+    constexpr void operator=(S&& other) { num = other.num; }
+    int num;
+    int moves = 0;
+  };
+  // This means `S` is only "trivially relocatable" if achieved through
+  // [[clang::trivial_abi]].
+  static_assert(!std::is_trivially_move_constructible_v<S>, "");
+  static_assert(__private::relocate_one_by_memcpy_v<S> ==
+                    __has_extension(trivially_relocatable),
+                "");
+
+  auto i = []() constexpr {
+    S i(2);
+    S j(5);
+    ::sus::mem::swap(i, j);
+    return i;
+  };
+  auto j = []() constexpr {
+    S i(2);
+    S j(5);
+    ::sus::mem::swap(i, j);
+    return j;
+  };
+  static_assert(i().num == 5, "");
+  static_assert(j().num == 2, "");
+  // The swap was done by move operations, since memcpy is not constexpr.
+  static_assert(i().moves == 1, "");
+  static_assert(j().moves == 1, "");
+
+  // Array.
+  {
+    using T = S[2];
+
+    auto i = []() constexpr {
+      T i{1, 2};
+      T j{4, 5};
+      ::sus::mem::swap(i, j);
+      return static_cast<S&&>(i[1]);
+    };
+    auto j = []() constexpr {
+      T i{1, 2};
+      T j{4, 5};
+      ::sus::mem::swap(i, j);
+      return static_cast<S&&>(j[1]);
+    };
+    static_assert(i().num == 5, "");
+    static_assert(j().num == 2, "");
+    // The swap was done by move operations, since memcpy is not constexpr.
+    static_assert(i().moves == 1, "");
+    static_assert(j().moves == 1, "");
+  }
+}
+
+TEST(Swap, ConstexprNonTrivial) {
+  struct S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), moves(other.moves + 1) {}
+    constexpr void operator=(S&& other) { num = other.num; }
+    int num;
+    int moves = 0;
+  };
+  static_assert(!__private::relocate_one_by_memcpy_v<S>, "");
+
+  auto i = []() constexpr {
+    S i(2);
+    S j(5);
+    ::sus::mem::swap(i, j);
+    return i;
+  };
+  auto j = []() constexpr {
+    S i(2);
+    S j(5);
+    ::sus::mem::swap(i, j);
+    return j;
+  };
+  static_assert(i().num == 5, "");
+  static_assert(j().num == 2, "");
+  // The swap was done by move operations, since memcpy is not constexpr.
+  static_assert(i().moves == 1, "");
+  static_assert(j().moves == 1, "");
+
+  // Array.
+  {
+    using T = S[2];
+
+    auto i = []() constexpr {
+      T i{1, 2};
+      T j{4, 5};
+      ::sus::mem::swap(i, j);
+      return static_cast<S&&>(i[1]);
+    };
+    auto j = []() constexpr {
+      T i{1, 2};
+      T j{4, 5};
+      ::sus::mem::swap(i, j);
+      return static_cast<S&&>(j[1]);
+    };
+    static_assert(i().num == 5, "");
+    static_assert(j().num == 2, "");
+    // The swap was done by move operations, since memcpy is not constexpr.
+    static_assert(i().moves == 1, "");
+    static_assert(j().moves == 1, "");
+  }
+}
+
+TEST(Swap, TrivialRelocate) {
+  using T = int;
+  static_assert(__private::relocate_one_by_memcpy_v<T>, "");
+
+  T i(2);
+  T j(5);
+  ::sus::mem::swap(i, j);
+  EXPECT_EQ(i, T(5));
+  EXPECT_EQ(j, T(2));
+
+  // Array.
+  {
+    using T = int[2];
+    T i{1, 2};
+    T j{4, 5};
+    ::sus::mem::swap(i, j);
+    EXPECT_EQ(i[1], 5);
+    EXPECT_EQ(j[1], 2);
+  }
+}
+
+TEST(Swap, TrivialAbi) {
+  struct [[clang::trivial_abi]] S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), moves(other.moves + 1) {}
+    constexpr void operator=(S&& other) {
+      num = other.num;
+      moves = other.moves + 1;
+    }
+    int num;
+    int moves = 0;
+  };
+  // This means `S` is only "trivially relocatable" if achieved through
+  // [[clang::trivial_abi]].
+  static_assert(!std::is_trivially_move_constructible_v<S>, "");
+  static_assert(__private::relocate_one_by_memcpy_v<S> ==
+                    __has_extension(trivially_relocatable),
+                "");
+
+  S i(2);
+  S j(5);
+  ::sus::mem::swap(i, j);
+  EXPECT_EQ(i.num, 5);
+  EXPECT_EQ(j.num, 2);
+#if __has_extension(trivially_relocatable)
+  // The swap was done by memcpy.
+  EXPECT_EQ(i.moves, 0);
+#else
+  // The swap was done by move operations.
+  EXPECT_GE(i.moves, 2);
+#endif
+
+  // Array.
+  {
+    using T = S[2];
+
+    T i{1, 2};
+    T j{4, 5};
+    ::sus::mem::swap(i, j);
+    EXPECT_EQ(i[1].num, 5);
+    EXPECT_EQ(j[1].num, 2);
+#if __has_extension(trivially_relocatable)
+    // The swap was done by memcpy.
+    EXPECT_EQ(i[1].moves, 0);
+#else
+    // The swap was done by move operations.
+    EXPECT_GE(i[1].moves, 2);
+#endif
+  }
+}
+
+TEST(Swap, NonTrivial) {
+  struct S {
+    constexpr S(int n) : num(n) {}
+    constexpr S(S&& other) : num(other.num), moves(other.moves + 1) {}
+    void operator=(S&& other) {
+      num = other.num;
+      moves = other.moves + 1;
+    }
+    int num;
+    int moves = 0;
+  };
+  static_assert(!__private::relocate_one_by_memcpy_v<S>, "");
+
+  S i(2);
+  S j(5);
+  ::sus::mem::swap(i, j);
+  EXPECT_EQ(i.num, 5);
+  EXPECT_EQ(j.num, 2);
+  // The swap was done by move operations.
+  EXPECT_GE(i.moves, 2);
+  EXPECT_GE(j.moves, 2);
+
+  // Array.
+  {
+    using T = S[2];
+
+    T i{1, 2};
+    T j{4, 5};
+    ::sus::mem::swap(i, j);
+    EXPECT_EQ(i[1].num, 5);
+    EXPECT_EQ(j[1].num, 2);
+    // The swap was done by move operations.
+    EXPECT_GE(i[1].moves, 2);
+    EXPECT_GE(j[1].moves, 2);
+  }
+}
+
+}  // namespace
+}  // namespace sus::mem

--- a/mem/take.h
+++ b/mem/take.h
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+#include "marker/unsafe.h"
+#include "mem/__private/relocate.h"
+#include "mem/addressof.h"
+
+namespace sus::mem {
+
+template <class T,
+          class = std::enable_if_t<std::is_default_constructible_v<T>, void>>
+inline constexpr T take(T& t) noexcept {
+  T taken(static_cast<T&&>(t));
+  t.~T();
+  // TODO: Support classes with a `with_default()` constructor as well.
+  new (&t) T();
+  return taken;
+}
+
+// SAFETY: This does *not* re-construct the object pointed to by `t`. It must
+// not be used (or destructed again) afterward.
+template <class T>
+constexpr T take_and_destruct(::sus::marker::UnsafeFnMarker, T& t) noexcept {
+  T taken(static_cast<T&&>(t));
+  t.~T();
+  return taken;
+}
+
+}  // namespace sus::mem

--- a/mem/take_unittest.cc
+++ b/mem/take_unittest.cc
@@ -1,0 +1,137 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "mem/take.h"
+
+#include <type_traits>
+
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace sus::mem {
+namespace {
+
+TEST(Take, Take) {
+  static /* TODO: usize */ size_t take_destructors;
+
+  struct S {
+    S() { ++default_constucted; }
+    S(int i) : num(i) {}
+    S(S&& other) : num(other.num), moved(other.moved + 1) {}
+    ~S() { ++take_destructors; }
+
+    int num = 101;
+    int default_constucted = 0;
+    int moved = 0;
+  };
+
+  take_destructors = 0;
+  S s(404);
+  EXPECT_EQ(s.default_constucted, 0);
+  S out(::sus::mem::take(s));
+  // `out` was moved from `s`. `s` was taken-from and default-constructed.
+  EXPECT_EQ(out.num, 404);
+  EXPECT_EQ(s.num, 101);
+
+  // Destructions:
+  // 1. `s` being destroyed before being default-constructed.
+  // 2. The output of take() being destroyed when returned. However this one can
+  //    be elided, in which case `out` would have been moved only once.
+  EXPECT_EQ(take_destructors, 1 + (out.moved - 1));
+}
+
+TEST(Take, TakeConstexpr) {
+  struct S {
+    constexpr S() { ++default_constucted; }
+    constexpr S(int i) : num(i) {}
+    constexpr S(S&& other) : num(other.num), moved(other.moved + 1) {}
+
+    int num = 101;
+    int default_constucted = 0;
+    int moved = 0;
+  };
+
+  auto out = []() constexpr {
+    S s(404);
+    S out(::sus::mem::take(s));
+    return out.num;
+  };
+  auto s = []() constexpr {
+    S s(404);
+    S out(::sus::mem::take(s));
+    return s.num;
+  };
+  // `out` was moved from `s`. `s` was taken-from and default-constructed.
+  EXPECT_EQ(out(), 404);
+  EXPECT_EQ(s(), 101);
+}
+
+TEST(Take, TakeAndDestruct) {
+  static /* TODO: usize */ size_t take_destructors;
+
+  struct S {
+    S() { ++default_constucted; }
+    S(int i) : num(i) {}
+    S(S&& other) : num(other.num), moved(other.moved + 1) {}
+    ~S() { ++take_destructors; }
+
+    int num = 101;
+    int default_constucted = 0;
+    int moved = 0;
+  };
+
+  union U {
+    U() {}
+    ~U() {}
+    S s;
+  } u;
+
+  take_destructors = 0;
+  new (&u.s) S(404);
+  EXPECT_EQ(u.s.default_constucted, 0);
+  EXPECT_EQ(u.s.num, 404);
+  S out(::sus::mem::take_and_destruct(unsafe_fn, u.s));
+  // `out` was moved from `s`. `s` was taken-from and destroyed but not
+  // reconstructed, so we can't test its values, only its destruction.
+  EXPECT_EQ(out.num, 404);
+
+  // Destructions:
+  // 1. `s` being destroyed before being default-constructed.
+  // 2. The output of take() being destroyed when returned. However this one can
+  //    be elided, in which case `out` would have been moved only once.
+  EXPECT_EQ(take_destructors, 1 + (out.moved - 1));
+}
+
+TEST(Take, TakeAndDestructConstexpr) {
+  struct S {
+    constexpr S() { ++default_constucted; }
+    constexpr S(int i) : num(i) {}
+    constexpr S(S&& other) : num(other.num), moved(other.moved + 1) {}
+
+    int num = 101;
+    int default_constucted = 0;
+    int moved = 0;
+  };
+
+  auto out = []() constexpr {
+    S s(404);
+    S out(::sus::mem::take_and_destruct(unsafe_fn, s));
+    return out.num;
+  };
+  // `out` was moved from `s`. `s` was taken-from and destroyed, and we can not
+  // use it anymore.
+  EXPECT_EQ(out(), 404);
+}
+
+}  // namespace
+}  // namespace sus::mem


### PR DESCRIPTION
- swap(a&, b&) swaps the values in a and b.
- replace(a&, b) assigns b into a, and returns the old value
  of a.
- take(&a) destructs and default-constructs a, and then
  returns the old value of a.