### PR TITLE
Build with C++20 support using GCC and MSVC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,33 +24,47 @@ jobs:
           #    os: windows-latest,
           #    build_type: "Release", cc: "gcc", cxx: "g++"
           #  }
-          - {
-              name: "Ubuntu Latest Clang",
-              artifact: "Linux-Clang.tar.xz",
-              os: ubuntu-latest,
-              build_type: "Release",
-              cc: "clang-12",
-              cxx: "clang++-12",
-            }
+
+          # Clang doesn't have good enough C++20 support to compile this library
+          # yet.
+          #- {
+          #    name: "Ubuntu Latest Clang",
+          #    artifact: "Linux-Clang.tar.xz",
+          #    os: ubuntu-latest,
+          #    build_type: "Release",
+          #    cc: "clang",
+          #    cxx: "clang++",
+          #  }
+
           - {
               name: "Ubuntu Latest GCC",
               artifact: "Linux-GCC.tar.xz",
-              os: ubuntu-latest,
+              # 22.04 is in public beta, and has GCC 11 which we need for C++20
+              # support. Switch to `ubuntu-latest` when it's out of beta.
+              os: ubuntu-22.04,
               build_type: "Release",
-              cc: "gcc-10",
-              cxx: "g++-10",
+              cc: "gcc-11",
+              cxx: "g++-11",
             }
-          - {
-              name: "macOS Latest Clang",
-              artifact: "macOS.tar.xz",
-              os: macos-latest,
-              build_type: "Release",
-              cc: "clang",
-              cxx: "clang++",
-            }
+
+          # Clang doesn't have good enough C++20 support to compile this library
+          # yet.
+          #- {
+          #    name: "macOS Latest Clang",
+          #    artifact: "macOS.tar.xz",
+          #    os: macos-latest,
+          #    build_type: "Release",
+          #    cc: "clang",
+          #    cxx: "clang++",
+          #  }
 
     steps:
       - uses: actions/checkout@v1
+
+      #- name: Install LLVM and Clang
+      #  uses: KyleMayes/install-llvm-action@v1
+      #  with:
+      #    version: "13.0"
 
       - name: Download Ninja
         id: ninja

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -24,33 +24,47 @@ jobs:
           #    os: windows-latest,
           #    build_type: "Release", cc: "gcc", cxx: "g++"
           #  }
-          - {
-              name: "Ubuntu Latest Clang",
-              artifact: "Linux-Clang.tar.xz",
-              os: ubuntu-latest,
-              build_type: "Release",
-              cc: "clang-12",
-              cxx: "clang++-12",
-            }
+
+          # Clang doesn't have good enough C++20 support to compile this library
+          # yet.
+          #- {
+          #    name: "Ubuntu Latest Clang",
+          #    artifact: "Linux-Clang.tar.xz",
+          #    os: ubuntu-latest,
+          #    build_type: "Release",
+          #    cc: "clang",
+          #    cxx: "clang++",
+          #  }
+
           - {
               name: "Ubuntu Latest GCC",
               artifact: "Linux-GCC.tar.xz",
-              os: ubuntu-latest,
+              # 22.04 is in public beta, and has GCC 11 which we need for C++20
+              # support. Switch to `ubuntu-latest` when it's out of beta.
+              os: ubuntu-22.04,
               build_type: "Release",
-              cc: "gcc-10",
-              cxx: "g++-10",
+              cc: "gcc-11",
+              cxx: "g++-11",
             }
-          - {
-              name: "macOS Latest Clang",
-              artifact: "macOS.tar.xz",
-              os: macos-latest,
-              build_type: "Release",
-              cc: "clang",
-              cxx: "clang++",
-            }
+
+          # Clang doesn't have good enough C++20 support to compile this library
+          # yet.
+          #- {
+          #    name: "macOS Latest Clang",
+          #    artifact: "macOS.tar.xz",
+          #    os: macos-latest,
+          #    build_type: "Release",
+          #    cc: "clang",
+          #    cxx: "clang++",
+          #  }
 
     steps:
       - uses: actions/checkout@v1
+
+      #- name: Install LLVM and Clang
+      #  uses: KyleMayes/install-llvm-action@v1
+      #  with:
+      #    version: "13.0"
 
       - name: Download Ninja
         id: ninja

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,12 @@
     ],
     "C_Cpp.default.cppStandard": "c++20",
     "cmake.buildDirectory": "${workspaceFolder}/out",
+    "clangd.arguments": [
+        "-compile-commands-dir=out"
+    ],
     "cmake.configureSettings": {
         "CMAKE_MAKE_PROGRAM": "ninja"
     },
     "cmake.generator": "Ninja",
-    "cmake.copyCompileCommands": "${workspaceRoot}/compile_commands.json",
     "files.eol": "\n",
 }


### PR DESCRIPTION
Clang doesn't have C++20 support to build even trivial stuff it
seems so we can't use it. We would need to make extensive use of
macros to support Clang at this point, and that is counter to
our goals of being a simple and readable library built on the
most current C++.