### PR TITLE
Add a MakeDefault trait.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(subspace STATIC
     "mem/swap.h"
     "mem/take.h"
     "mem/addressof.h"
+    "traits/make_default.h"
     "lib/lib.cc"
 )
 set_target_properties(subspace PROPERTIES LINKER_LANGUAGE CXX)
@@ -40,6 +41,7 @@ add_executable(subspace_unittests
     "mem/replace_unittest.cc"
     "mem/swap_unittest.cc"
     "mem/take_unittest.cc"
+    "traits/make_default_unittest.cc"
 )
 set_target_properties(subspace_unittests PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(subspace_unittests

--- a/traits/make_default.h
+++ b/traits/make_default.h
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+namespace sus::traits {
+
+namespace __private {
+
+template <class T, class Signature>
+static constexpr bool has_with_default(...) {
+  return false;
+}
+
+template <class T, class R, class... Args>
+  requires(
+      std::is_same_v<decltype(T::with_default(std::declval<Args>()...)), R>)
+static constexpr bool has_with_default(int) {
+  return true;
+}
+
+}  // namespace __private
+
+template <class T>
+struct MakeDefault {
+  static constexpr bool has_trait =
+      std::is_default_constructible_v<T> ^ __private::has_with_default<T, T>(0);
+
+  static constexpr T make_default() noexcept {
+    static_assert(has_trait,
+                  "MakeDefault trait used when the trait is not present for "
+                  "type T. Verify with MakeDefault<T>::has_trait.");
+    if constexpr (std::is_default_constructible_v<T>)
+      return T();
+    else
+      return T::with_default();
+  }
+};
+
+}  // namespace sus::traits

--- a/traits/make_default_unittest.cc
+++ b/traits/make_default_unittest.cc
@@ -1,0 +1,86 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traits/make_default.h"
+
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace sus::traits {
+namespace {
+
+struct DefaultConstructible {
+  const int i = 2;
+};
+struct NotDefaultConstructible {
+  constexpr NotDefaultConstructible(int i) noexcept : i(i) {}
+  const int i = 2;
+};
+struct WithDefaultConstructible {
+  constexpr static WithDefaultConstructible with_default() noexcept {
+    return WithDefaultConstructible(3);
+  }
+
+  const int i = 2;
+
+ private:
+  constexpr WithDefaultConstructible(int i) noexcept : i(i) {}
+};
+// DefaultConstructible and WithDefaultConstructible.
+struct BothConstructible {
+  constexpr BothConstructible() noexcept {}
+  constexpr static BothConstructible with_default() noexcept {
+    return BothConstructible(3);
+  }
+
+  const int i = 2;
+
+ private:
+  constexpr BothConstructible(int i) noexcept : i(i) {}
+};
+
+static_assert(MakeDefault<DefaultConstructible>::has_trait == true, "");
+static_assert(MakeDefault<NotDefaultConstructible>::has_trait == false, "");
+static_assert(MakeDefault<WithDefaultConstructible>::has_trait == true, "");
+static_assert(MakeDefault<BothConstructible>::has_trait == false, "");
+
+// Verify constexpr construction.
+constexpr auto default_constructible =
+    MakeDefault<DefaultConstructible>::make_default();
+static_assert(default_constructible.i == 2, "");
+constexpr auto with_default_constructible =
+    MakeDefault<WithDefaultConstructible>::make_default();
+static_assert(with_default_constructible.i == 3, "");
+
+// Verify no type coersions are happening.
+static_assert(
+    std::is_same_v<decltype(MakeDefault<DefaultConstructible>::make_default()),
+                   DefaultConstructible>,
+    "");
+static_assert(
+    std::is_same_v<
+        decltype(MakeDefault<WithDefaultConstructible>::make_default()),
+        WithDefaultConstructible>,
+    "");
+
+TEST(MakeDefault, NonConstexprConstruction) {
+  auto default_constructible =
+      MakeDefault<DefaultConstructible>::make_default();
+  EXPECT_EQ(default_constructible.i, 2);
+  auto with_default_constructible =
+      MakeDefault<WithDefaultConstructible>::make_default();
+  EXPECT_EQ(with_default_constructible.i, 3);
+}
+
+}  // namespace
+}  // namespace sus::traits


### PR DESCRIPTION
The MakeDefault trait allows construction of a type T if it either
- is default-constructible
- or has a static with_default() method that returns type T.

MakeDefault<T>::has_trait reports if T has the trait. A type
must be either default-constructible or provide with_default()
but can not be both in order to implement the trait.

MakeDefault<T>::make_default() returns a T constructed with its
default value, and requires that T is MakeDefault.