### PR TITLE
Add sus::option::Option type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(subspace STATIC
     "mem/swap.h"
     "mem/take.h"
     "mem/addressof.h"
+    "option/option.h"
     "traits/make_default.h"
     "lib/lib.cc"
 )
@@ -41,6 +42,7 @@ add_executable(subspace_unittests
     "mem/replace_unittest.cc"
     "mem/swap_unittest.cc"
     "mem/take_unittest.cc"
+    "option/option_unittest.cc"
     "traits/make_default_unittest.cc"
 )
 set_target_properties(subspace_unittests PROPERTIES LINKER_LANGUAGE CXX)

--- a/option/option.h
+++ b/option/option.h
@@ -1,0 +1,165 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+#include "assertions/check.h"
+#include "marker/unsafe.h"
+#include "mem/replace.h"
+#include "mem/take.h"
+#include "traits/make_default.h"
+
+namespace sus::option {
+
+/// The representation of an Option's state, which can either be #None to
+/// represent it has no value, or #Some for when it is holding a value.
+enum class State : bool {
+  /// The Option is not holding any value.
+  None,
+  /// The Option is holding a value.
+  Some,
+};
+using State::None;
+using State::Some;
+
+/// A type which either holds #Some value of type T, or #None.
+template <class T>
+class Option {
+ public:
+  /// Construct an Option that is holding the given value.
+  static inline constexpr Option some(T t) noexcept {
+    return Option(static_cast<T&&>(t));
+  }
+  /// Construct an Option that is holding no value.
+  static inline constexpr Option none() noexcept { return Option(); }
+
+  /// Construct an Option with the default value for the type it contains.
+  ///
+  /// The type `T` must be #MakeDefault, and will be constructed through that
+  /// trait.
+  template <class U = T>
+    requires(sus::traits::MakeDefault<U>::has_trait)
+  static inline constexpr Option<U> with_default() noexcept {
+    return Option<U>::some(sus::traits::MakeDefault<U>::make_default());
+  }
+
+  /// Destructor for the Option.
+  ///
+  /// Destroys the value contained within the option, if there is one.
+  constexpr inline ~Option() noexcept {
+    if (state_ == State::Some) t_.~T();
+  }
+
+  /// Drop the current value from the Option, if there is one.
+  ///
+  /// Afterward the option will unconditionally be #None.
+  constexpr void clear() & noexcept {
+    if (::sus::mem::replace(state_, State::None) == State::Some) t_.~T();
+  }
+
+  /// Returns whether the Option currently contains a value.
+  ///
+  /// If there is a value present, it can be extracted with <unwrap>() or
+  /// <expect>().
+  constexpr bool is_some() const noexcept { return state_ == State::Some; }
+  /// Returns whether the Option is currently empty, containing no value.
+  constexpr bool is_none() const noexcept { return state_ == State::None; }
+
+  /// An operator which returns the state of the Option, either #Some or #None.
+  ///
+  /// This supports the use of an Option in a `switch()`, allowing it to act as
+  /// a tagged union between "some value" and "no value".
+  ///
+  /// # Example
+  ///
+  /// ```cpp
+  /// auto x = Option<int>::some();
+  /// switch (x) {
+  ///  case Some:
+  ///   return static_cast<decltype(x)&&>(x).unwrap_unchecked(unsafe_fn);
+  ///  case None:
+  ///   return -1;
+  /// }
+  /// ```
+  operator State() { return state_; }
+
+  /// Unwraps the contained value inside the Option.
+  ///
+  /// The function will panic with the given message if the Option's state is
+  /// currently `None`.
+  constexpr T expect(/* TODO: string view type */ const char* msg) && noexcept
+      [[nonnull]] {
+    ::sus::check_with_message(state_ == State::Some, *msg);
+    return static_cast<Option&&>(*this).unwrap_unchecked(unsafe_fn);
+  }
+  /// Unwraps the contained value inside the Option.
+  ///
+  /// The function will panic without a message if the Option's state is
+  /// currently `None`.
+  constexpr T unwrap() && noexcept {
+    ::sus::check(state_ == State::Some);
+    return static_cast<Option&&>(*this).unwrap_unchecked(unsafe_fn);
+  }
+  /// Unwraps the contained value inside the Option.
+  ///
+  /// # Safety
+  ///
+  /// It is Undefined Behaviour to call this function when the Option's state is
+  /// `None`. The caller is responsible for ensuring the Option contains a value
+  /// beforehand, and the safer <unwrap>() or <expect>() should almost always be
+  /// preferred.
+  constexpr inline T unwrap_unchecked(
+      ::sus::marker::UnsafeFnMarker) && noexcept {
+    state_ = State::None;
+    return static_cast<T&&>(t_);
+  }
+
+  /// Returns a new Option containing whatever was inside the current Option.
+  ///
+  /// If this Option contains #None then it is left unchanged and returns an
+  /// Option containing #None. If this Option contains #Some with a value, the
+  /// value is moved into the returned Option and this Option will contain
+  /// #None afterward.
+  constexpr Option take() & noexcept {
+    return (::sus::mem::replace(state_, State::None) == State::Some)
+               ? Option::some(sus::mem::take_and_destruct(unsafe_fn, t_))
+               : Option::none();
+  }
+
+ private:
+  /// Constructor for #None.
+  constexpr explicit Option() : state_(State::None) {}
+  /// Constructor for #Some.
+  constexpr explicit Option(T&& t)
+      : t_(static_cast<T&&>(t)), state_(State::Some) {}
+
+  // TODO: determine if we can put the tag into `T` from its type (e.g. sizeof
+  // < alignment?), and then do so?
+  union {
+    T t_;
+  };
+
+  State state_;
+};
+
+}  // namespace sus::option
+
+// Promote Option and its enum values into the `sus` namespace.
+namespace sus {
+using ::sus::option::None;
+using ::sus::option::Option;
+using ::sus::option::Some;
+}  // namespace sus

--- a/option/option_unittest.cc
+++ b/option/option_unittest.cc
@@ -1,0 +1,195 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "option/option.h"
+
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+using sus::option::None;
+using sus::option::Option;
+using sus::option::Some;
+
+namespace {
+
+struct DefaultConstructible {
+  int i = 2;
+};
+
+struct NotDefaultConstructible {
+  int i;
+
+  constexpr NotDefaultConstructible(int i) : i(i) {}
+};
+
+struct WithDefaultConstructible {
+  int i;
+
+  static inline constexpr WithDefaultConstructible with_default() {
+    return WithDefaultConstructible(3);
+  }
+
+ private:
+  constexpr WithDefaultConstructible(int i) : i(i) {}
+};
+
+#define IS_SOME(x)             \
+  do {                         \
+    EXPECT_TRUE(x.is_some());  \
+    EXPECT_FALSE(x.is_none()); \
+    switch (x) {               \
+      case Some:               \
+        break;                 \
+      case None:               \
+        ADD_FAILURE();         \
+    }                          \
+  } while (false)
+
+#define IS_NONE(x)             \
+  do {                         \
+    EXPECT_TRUE(x.is_none());  \
+    EXPECT_FALSE(x.is_some()); \
+    switch (x) {               \
+      case None:               \
+        break;                 \
+      case Some:               \
+        ADD_FAILURE();         \
+    }                          \
+  } while (false)
+
+TEST(Option, Some) {
+  auto x = Option<DefaultConstructible>::some(DefaultConstructible());
+  IS_SOME(x);
+
+  auto y = Option<NotDefaultConstructible>::some(NotDefaultConstructible(3));
+  IS_SOME(y);
+
+  constexpr auto cx(
+      Option<DefaultConstructible>::some(DefaultConstructible()).unwrap());
+  static_assert(cx.i == 2, "");
+
+  constexpr auto cy(
+      Option<NotDefaultConstructible>::some(NotDefaultConstructible(3))
+          .unwrap());
+  static_assert(cy.i == 3, "");
+}
+
+TEST(Option, None) {
+  auto x = Option<DefaultConstructible>::none();
+  IS_NONE(x);
+
+  auto y = Option<NotDefaultConstructible>::none();
+  IS_NONE(y);
+
+  constexpr auto cx(Option<DefaultConstructible>::none());
+  static_assert(cx.is_none(), "");
+
+  constexpr auto cy(Option<NotDefaultConstructible>::none());
+  static_assert(cy.is_none(), "");
+}
+
+TEST(Option, WithDefault) {
+  auto x = Option<DefaultConstructible>::with_default();
+  IS_SOME(x);
+  EXPECT_EQ(static_cast<decltype(x)&&>(x).unwrap().i, 2);
+
+  auto y = Option<WithDefaultConstructible>::with_default();
+  IS_SOME(y);
+  EXPECT_EQ(static_cast<decltype(y)&&>(y).unwrap().i, 3);
+
+  constexpr auto cx(Option<DefaultConstructible>::with_default());
+  static_assert(cx.is_some(), "");
+
+  constexpr auto cy(Option<WithDefaultConstructible>::with_default());
+  static_assert(cy.is_some(), "");
+
+  using sus::traits::MakeDefault;
+  static_assert(MakeDefault<Option<DefaultConstructible>>::has_trait, "");
+  static_assert(MakeDefault<Option<WithDefaultConstructible>>::has_trait, "");
+  static_assert(!MakeDefault<Option<NotDefaultConstructible>>::has_trait, "");
+
+  auto x2 = MakeDefault<Option<DefaultConstructible>>::make_default();
+  IS_SOME(x2);
+  EXPECT_EQ(static_cast<decltype(x2)&&>(x2).unwrap().i, 2);
+
+  auto y2 = MakeDefault<Option<WithDefaultConstructible>>::make_default();
+  IS_SOME(y2);
+  EXPECT_EQ(static_cast<decltype(y2)&&>(y2).unwrap().i, 3);
+}
+
+TEST(Option, Destructor) {
+  static int count = 0;
+  struct WatchDestructor {
+    ~WatchDestructor() { ++count; }
+  };
+  {
+    auto x = Option<WatchDestructor>::with_default();
+    count = 0;  // Without optimizations, moves may run a destructor.
+  }
+  EXPECT_EQ(1, count);
+}
+
+TEST(Option, Clear) {
+  static int count = 0;
+  struct WatchDestructor {
+    ~WatchDestructor() { ++count; }
+  };
+  {
+    auto x = Option<WatchDestructor>::with_default();
+    count = 0;  // Without optimizations, moves may run a destructor.
+    IS_SOME(x);
+    x.clear();
+    IS_NONE(x);
+    EXPECT_EQ(1, count);
+  }
+  EXPECT_EQ(1, count);
+}
+
+TEST(Option, ExpectSome) {
+  auto x = Option<int>::with_default().expect("hello world");
+  EXPECT_EQ(x, 0);
+}
+
+TEST(OptionDeathTest, ExpectNone) {
+#if GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(Option<int>::none().expect("hello world"), "hello world");
+#endif
+}
+
+TEST(Option, UnwrapSome) {
+  auto x = Option<int>::with_default().unwrap();
+  EXPECT_EQ(x, 0);
+}
+
+TEST(OptionDeathTest, UnwrapNone) {
+#if GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(Option<int>::none().unwrap(), "");
+#endif
+}
+
+TEST(Option, UnwrapUncheckedSome) {
+  auto x = Option<int>::with_default().unwrap_unchecked(unsafe_fn);
+  EXPECT_EQ(x, 0);
+}
+
+TEST(Option, Take) {
+  auto x = Option<int>::some(404);
+  IS_SOME(x);
+  auto y = x.take();
+  // The value has moved from `x` to `y`.
+  IS_NONE(x);
+  IS_SOME(y);
+  EXPECT_EQ(static_cast<decltype(y)&&>(y).unwrap(), 404);
+}
+
+}  // namespace


### PR DESCRIPTION
The type has clear inspiration from Rust:
https://doc.rust-lang.org/std/option/enum.Option.html

This introduces the minimum methods to make the type useful and we'll
add more in further commits.

There's a question about whether we should push toward objects being
consumed as rvalues more like Rust does (with &&-qualified methods)
or not, which this CL does not answer. For now, it's matching Rust more
than normative-till-now C++.