### PR TITLE
Add Option insert() and get_or_insert{_default,_with}()

### DIFF
--- a/mem/replace.h
+++ b/mem/replace.h
@@ -26,7 +26,7 @@ namespace sus::mem {
 // It would be nice to have an array overload of replace() but functions can't
 // return arrays.
 template <class T>
-  requires(!std::is_array_v<T>)
+  requires(!std::is_array_v<T> && std::is_move_constructible_v<T>)
 constexpr T replace(T& dest, T src) noexcept {
   T old(static_cast<T&&>(dest));
 

--- a/mem/swap.h
+++ b/mem/swap.h
@@ -24,6 +24,7 @@
 namespace sus::mem {
 
 template <class T>
+  requires(std::is_move_constructible_v<T> && std::is_move_assignable_v<T>)
 constexpr void swap(T& lhs, T& rhs) noexcept {
   // memcpy() is not constexpr so we can't use it in constexpr evaluation.
   if (::sus::mem::__private::relocate_one_by_memcpy_v<T> &&
@@ -40,6 +41,7 @@ constexpr void swap(T& lhs, T& rhs) noexcept {
 }
 
 template <class T, /* TODO: usize */ size_t N>
+  requires(std::is_move_constructible_v<T> && std::is_move_assignable_v<T>)
 constexpr void swap(T (&lhs)[N], T (&rhs)[N]) noexcept {
   // memcpy() is not constexpr so we can't use it in constexpr evaluation.
   if (::sus::mem::__private::relocate_array_by_memcpy_v<T> &&

--- a/mem/take.h
+++ b/mem/take.h
@@ -23,7 +23,7 @@
 namespace sus::mem {
 
 template <class T>
-  requires std::is_default_constructible_v<T>
+  requires std::is_move_constructible_v<T> && std::is_default_constructible_v<T>
 inline constexpr T take(T& t) noexcept {
   T taken(static_cast<T&&>(t));
   t.~T();
@@ -35,6 +35,7 @@ inline constexpr T take(T& t) noexcept {
 // SAFETY: This does *not* re-construct the object pointed to by `t`. It must
 // not be used (or destructed again) afterward.
 template <class T>
+  requires std::is_move_constructible_v<T>
 constexpr T take_and_destruct(::sus::marker::UnsafeFnMarker, T& t) noexcept {
   T taken(static_cast<T&&>(t));
   t.~T();

--- a/option/option.h
+++ b/option/option.h
@@ -144,6 +144,39 @@ class Option {
     ::sus::check_with_message(state_ == Some, *msg);
     return static_cast<Option&&>(*this).unwrap_unchecked(unsafe_fn);
   }
+
+  /// Returns a const reference to the contained value inside the Option.
+  ///
+  /// This is a shortcut for `option.as_ref().expect()`.
+  ///
+  /// The function will panic with the given message if the Option's state is
+  /// currently `None`.
+  constexpr const std::remove_reference_t<T>& expect_ref(
+      /* TODO: string view type */ const char* msg) const& noexcept
+      [[nonnull]] {
+    ::sus::check_with_message(state_ == Some, *msg);
+    if constexpr (!std::is_reference_v<T>)
+      return t_.val_;
+    else
+      return const_cast<const T>(*t_.ptr_);
+  }
+  std::remove_reference_t<T>& expect_ref() && noexcept = delete;
+
+  /// Returns a mutable reference to the contained value inside the Option.
+  ///
+  /// This is a shortcut for `option.as_mut().expect()`.
+  ///
+  /// The function will panic with the given message if the Option's state is
+  /// currently `None`.
+  constexpr std::remove_reference_t<T>& expect_mut(
+      /* TODO: string view type */ const char* msg) & noexcept [[nonnull]] {
+    ::sus::check_with_message(state_ == Some, *msg);
+    if constexpr (!std::is_reference_v<T>)
+      return t_.val_;
+    else
+      return *t_.ptr_;
+  }
+
   /// Returns the contained value inside the Option.
   ///
   /// The function will panic without a message if the Option's state is
@@ -152,6 +185,7 @@ class Option {
     ::sus::check(state_ == Some);
     return static_cast<Option&&>(*this).unwrap_unchecked(unsafe_fn);
   }
+
   /// Returns the contained value inside the Option.
   ///
   /// # Safety
@@ -165,6 +199,35 @@ class Option {
     state_ = None;
     if constexpr (!std::is_reference_v<T>)
       return static_cast<T&&>(t_.val_);
+    else
+      return *t_.ptr_;
+  }
+
+  /// Returns a const reference to the contained value inside the Option.
+  ///
+  /// This is a shortcut for `option.as_ref().unwrap()`.
+  ///
+  /// The function will panic without a message if the Option's state is
+  /// currently `None`.
+  constexpr const std::remove_reference_t<T>& unwrap_ref() const& noexcept {
+    ::sus::check(state_ == Some);
+    if constexpr (!std::is_reference_v<T>)
+      return t_.val_;
+    else
+      return const_cast<const T>(*t_.ptr_);
+  }
+  const std::remove_reference_t<T>& unwrap_ref() && noexcept = delete;
+
+  /// Returns a mutable reference to the contained value inside the Option.
+  ///
+  /// This is a shortcut for `option.as_mut().unwrap()`.
+  ///
+  /// The function will panic without a message if the Option's state is
+  /// currently `None`.
+  constexpr std::remove_reference_t<T>& unwrap_mut() & noexcept {
+    ::sus::check(state_ == Some);
+    if constexpr (!std::is_reference_v<T>)
+      return t_.val_;
     else
       return *t_.ptr_;
   }

--- a/option/option.h
+++ b/option/option.h
@@ -77,17 +77,26 @@ class Option {
   ///
   /// Destroys the value contained within the option, if there is one.
   constexpr inline ~Option() noexcept {
-    if (state_ == Some) t_.~T();
+    if constexpr (!std::is_reference_v<T>)
+      if (state_ == Some) t_.val_.~T();
   }
 
   Option(Option&& o) noexcept : state_(o.state_) {
     // If this could be done in a `constexpr` way, methods that receive an
     // Option could also be constexpr.
-    if (state_ == Some) new (&t_) T(static_cast<T&&>(o.t_));
+    if constexpr (!std::is_reference_v<T>) {
+      if (state_ == Some) new (&t_.val_) T(static_cast<T&&>(o.t_.val_));
+    } else {
+      if (state_ == Some) t_.ptr_ = o.t_.ptr_;
+    }
   }
   Option& operator=(Option&& o) noexcept {
-    if (state_ == Some) t_.~T();
-    if (o.state_ == Some) new (&t_) T(static_cast<T&&>(o.t_));
+    if constexpr (!std::is_reference_v<T>) {
+      if (state_ == Some) t_.val_.~T();
+      if (o.state_ == Some) new (&t_.val_) T(static_cast<T&&>(o.t_.val_));
+    } else {
+      if (o.state_ == Some) t_.ptr_ = o.t_.ptr_;
+    }
     state_ = o.state_;
     return *this;
   }
@@ -96,7 +105,8 @@ class Option {
   ///
   /// Afterward the option will unconditionally be #None.
   constexpr void clear() & noexcept {
-    if (::sus::mem::replace(state_, None) == Some) t_.~T();
+    if constexpr (!std::is_reference_v<T>)
+      if (::sus::mem::replace(state_, None) == Some) t_.val_.~T();
   }
 
   /// Returns whether the Option currently contains a value.
@@ -153,7 +163,10 @@ class Option {
   constexpr inline T unwrap_unchecked(
       ::sus::marker::UnsafeFnMarker) && noexcept {
     state_ = None;
-    return static_cast<T&&>(t_);
+    if constexpr (!std::is_reference_v<T>)
+      return static_cast<T&&>(t_.val_);
+    else
+      return *t_.ptr_;
   }
 
   /// Returns the contained value inside the Option, if there is one. Otherwise,
@@ -163,20 +176,28 @@ class Option {
   /// <unwrap_or_else>() should be used instead, as it will only construct the
   /// default value if required.
   constexpr T unwrap_or(T default_result) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return ::sus::mem::take_and_destruct(unsafe_fn, t_);
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>)
+        return ::sus::mem::take_and_destruct(unsafe_fn, t_.val_);
+      else
+        return *t_.ptr_;
+    } else {
       return default_result;
+    }
   }
   /// Returns the contained value inside the Option, if there is one. Otherwise,
   /// returns the result of the given function.
   template <class Functor>
     requires(std::is_same_v<std::invoke_result_t<Functor>, T>)
   constexpr T unwrap_or_else(Functor f) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return ::sus::mem::take_and_destruct(unsafe_fn, t_);
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>)
+        return ::sus::mem::take_and_destruct(unsafe_fn, t_.val_);
+      else
+        return *t_.ptr_;
+    } else {
       return f();
+    }
   }
   /// Returns the contained value inside the Option, if there is one. Otherwise,
   /// constructs a default value for the type and returns that.
@@ -186,20 +207,30 @@ class Option {
   template <class U = T>
     requires(::sus::traits::MakeDefault<U>::has_trait && std::is_same_v<U, T>)
   constexpr T unwrap_or_default() && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return ::sus::mem::take_and_destruct(unsafe_fn, t_);
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>)
+        return ::sus::mem::take_and_destruct(unsafe_fn, t_.val_);
+      else
+        return *t_.ptr_;
+    } else {
       return ::sus::traits::MakeDefault<T>::make_default();
+    }
   }
 
   /// Stores the value `t` inside this Option, replacing any previous value, and
   /// returns a mutable reference to the new value.
   T& insert(T t) & noexcept {
-    if (::sus::mem::replace(state_, Some) == None)
-      new (&t_) T(static_cast<T&&>(t));
-    else
-      t_ = static_cast<T&&>(t);
-    return t_;
+    if constexpr (!std::is_reference_v<T>) {
+      if (::sus::mem::replace(state_, Some) == None)
+        new (&t_.val_) T(static_cast<T&&>(t));
+      else
+        t_.val_ = static_cast<T&&>(t);
+      return t_.val_;
+    } else {
+      state_ = Some;
+      t_.ptr_ = &t;
+      return *t_.ptr_;
+    }
   }
 
   /// If the Option holds a value, returns a mutable reference to it. Otherwise,
@@ -209,9 +240,15 @@ class Option {
   /// If it is non-trivial to construct `T`, the <get_or_insert_with>() method
   /// would be preferable, as it only constructs a `T` if needed.
   T& get_or_insert(T t) & noexcept {
-    if (::sus::mem::replace(state_, Some) == None)
-      new (&t_) T(static_cast<T&&>(t));
-    return t_;
+    if constexpr (!std::is_reference_v<T>) {
+      if (::sus::mem::replace(state_, Some) == None)
+        new (&t_.val_) T(static_cast<T&&>(t));
+      return t_.val_;
+    } else {
+      state_ = Some;
+      t_.ptr_ = &t;
+      return *t_.ptr_;
+    }
   }
 
   /// If the Option holds a value, returns a mutable reference to it. Otherwise,
@@ -229,9 +266,10 @@ class Option {
   template <class U = T>
     requires(::sus::traits::MakeDefault<U>::has_trait && std::is_same_v<U, T>)
   T& get_or_insert_default() & noexcept {
+    static_assert(!std::is_reference_v<T>, "");  // We require MakeDefault<T>.
     if (::sus::mem::replace(state_, Some) == None)
-      new (&t_) T(::sus::traits::MakeDefault<T>::make_default());
-    return t_;
+      new (&t_.val_) T(::sus::traits::MakeDefault<T>::make_default());
+    return t_.val_;
   }
 
   /// If the Option holds a value, returns a mutable reference to it. Otherwise,
@@ -243,8 +281,14 @@ class Option {
   template <class WithFn>
     requires(std::is_same_v<std::invoke_result_t<WithFn>, T>)
   T& get_or_insert_with(WithFn f) & noexcept {
-    if (::sus::mem::replace(state_, Some) == None) new (&t_) T(f());
-    return t_;
+    if constexpr (!std::is_reference_v<T>) {
+      if (::sus::mem::replace(state_, Some) == None) new (&t_.val_) T(f());
+      return t_.val_;
+    } else {
+      state_ = Some;
+      t_.ptr_ = &f();
+      return *t_.ptr_;
+    }
   }
 
   /// Returns a new Option containing whatever was inside the current Option.
@@ -254,10 +298,14 @@ class Option {
   /// value is moved into the returned Option and this Option will contain
   /// #None afterward.
   constexpr Option take() & noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_));
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>)
+        return Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_.val_));
+      else
+        return Option::some(*t_.ptr_);
+    } else {
       return Option::none();
+    }
   }
 
   /// Maps the Option's value through a function.
@@ -270,10 +318,16 @@ class Option {
   template <class MapFn, int&..., class R = std::invoke_result_t<MapFn, T&&>>
     requires(!std::is_void_v<R>)
   constexpr Option<R> map(MapFn m) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return Option<R>::some(m(::sus::mem::take_and_destruct(unsafe_fn, t_)));
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>) {
+        return Option<R>::some(
+            m(::sus::mem::take_and_destruct(unsafe_fn, t_.val_)));
+      } else {
+        return Option<R>::some(m(*t_.ptr_));
+      }
+    } else {
       return Option<R>::none();
+    }
   }
 
   /// Maps the Option's value through a function, or returns a default value.
@@ -287,10 +341,16 @@ class Option {
             class R = std::invoke_result_t<MapFn, T&&>>
     requires(!std::is_void_v<R> && std::is_same_v<D, R>)
   constexpr Option<R> map_or(D default_result, MapFn m) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return Option<R>::some(m(::sus::mem::take_and_destruct(unsafe_fn, t_)));
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>) {
+        return Option<R>::some(
+            m(::sus::mem::take_and_destruct(unsafe_fn, t_.val_)));
+      } else {
+        return Option<R>::some(m(*t_.ptr_));
+      }
+    } else {
       return Option<R>::some(static_cast<R&&>(default_result));
+    }
   }
 
   /// Maps the Option's value through a function, or returns a default value
@@ -306,10 +366,15 @@ class Option {
             class R = std::invoke_result_t<MapFn, T&&>>
     requires(!std::is_void_v<R> && std::is_same_v<D, R>)
   constexpr Option<R> map_or_else(DefaultFn default_fn, MapFn m) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return Option<R>::some(m(::sus::mem::take_and_destruct(unsafe_fn, t_)));
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>)
+        return Option<R>::some(
+            m(::sus::mem::take_and_destruct(unsafe_fn, t_.val_)));
+      else
+        return Option<R>::some(m(*t_.ptr_));
+    } else {
       return Option<R>::some(default_fn());
+    }
   }
 
   /// Consumes the Option and applies a predicate function to the value
@@ -322,12 +387,18 @@ class Option {
     requires(std::is_same_v<std::invoke_result_t<Predicate, const T&>, bool>)
   constexpr Option<T> filter(Predicate p) && noexcept {
     if (::sus::mem::replace(state_, None) == Some) {
-      if (p(const_cast<const T&>(t_))) {
-        return Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_));
+      if constexpr (!std::is_reference_v<T>) {
+        if (p(const_cast<const T&>(t_.val_))) {
+          return Option::some(
+              ::sus::mem::take_and_destruct(unsafe_fn, t_.val_));
+        } else {
+          // state_ has become None, so we must not keep `t_` alive.
+          t_.val_.~T();
+          return Option::none();
+        }
       } else {
-        // state_ has become None, so we must not keep `t_` alive.
-        t_.~T();
-        return Option::none();
+        return p(const_cast<const T>(*t_.ptr_)) ? Option::some(*t_.ptr_)
+                                                : Option::none();
       }
     } else {
       return Option::none();
@@ -339,7 +410,7 @@ class Option {
   template <class U>
   Option<U> and_opt(Option<U> opt) && noexcept {
     if (::sus::mem::replace(state_, None) == Some) {
-      t_.~T();
+      if constexpr (!std::is_reference_v<T>) t_.val_.~T();
       return opt;
     } else {
       return Option<U>::none();
@@ -355,19 +426,29 @@ class Option {
             class InnerR = ::sus::option::__private::IsOptionType<R>::type>
     requires(::sus::option::__private::IsOptionType<R>::value)
   constexpr Option<InnerR> and_then(AndFn f) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return f(::sus::mem::take_and_destruct(unsafe_fn, t_));
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>) {
+        return f(::sus::mem::take_and_destruct(unsafe_fn, t_.val_));
+      } else {
+        return f(*t_.ptr_);
+      }
+    } else {
       return Option<InnerR>::none();
+    }
   }
 
   /// Consumes and returns an Option with the same value if this Option contains
   /// a value, otherwise returns the given `opt`.
   Option<T> or_opt(Option<T> opt) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_));
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>) {
+        return Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_.val_));
+      } else {
+        return Option::some(*t_.ptr_);
+      }
+    } else {
       return opt;
+    }
   }
 
   /// Consumes and returns an Option with the same value if this Option contains
@@ -375,10 +456,15 @@ class Option {
   template <class ElseFn, int&..., class R = std::invoke_result_t<ElseFn>>
     requires(std::is_same_v<R, Option<T>>)
   constexpr Option<T> or_else(ElseFn f) && noexcept {
-    if (::sus::mem::replace(state_, None) == Some)
-      return Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_));
-    else
+    if (::sus::mem::replace(state_, None) == Some) {
+      if constexpr (!std::is_reference_v<T>) {
+        return Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_.val_));
+      } else {
+        return Option::some(*t_.ptr_);
+      }
+    } else {
       return f();
+    }
   }
 
   /// Consumes this Option and returns an Option, holding the value from either
@@ -388,12 +474,14 @@ class Option {
     State lhs = ::sus::mem::replace(state_, None);
     State rhs = opt.state_;
     if (lhs != None) {
-      Option<T> self =
-          Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_));
-      if (rhs == None)
-        return self;
-      else
-        return Option::none();
+      if constexpr (!std::is_reference_v<T>) {
+        Option<T> self =
+            Option::some(::sus::mem::take_and_destruct(unsafe_fn, t_.val_));
+        if (rhs == None) return self;
+      } else {
+        if (rhs == None) return Option::some(*t_.ptr_);
+      }
+      return Option::none();
     } else if (rhs != None) {
       return opt;
     } else {
@@ -401,16 +489,57 @@ class Option {
     }
   }
 
+  /// Returns an Option<const T&> from this Option<T>, that either holds #None
+  /// or a reference to the value in this Option.
+  constexpr Option<const std::remove_reference_t<T>&> as_ref() const& noexcept {
+    if (state_ == None) {
+      return Option<const std::remove_reference_t<T>&>::none();
+    } else {
+      if constexpr (!std::is_reference_v<T>)
+        return Option<const std::remove_reference_t<T>&>::some(t_.val_);
+      else
+        return Option<const std::remove_reference_t<T>&>::some(
+            const_cast<const T>(*t_.ptr_));
+    }
+  }
+  Option<const std::remove_reference_t<T>&> as_ref() && noexcept = delete;
+
+  /// Returns an Option<T&> from this Option<T>, that either holds #None or a
+  /// reference to the value in this Option.
+  Option<std::remove_reference_t<T>&> as_mut() & noexcept {
+    if (state_ == None) {
+      return Option<std::remove_reference_t<T>&>::none();
+    } else {
+      if constexpr (!std::is_reference_v<T>)
+        return Option<std::remove_reference_t<T>&>::some(t_.val_);
+      else
+        return Option<std::remove_reference_t<T>&>::some(*t_.ptr_);
+    }
+  }
+
  private:
   /// Constructor for #None.
   constexpr explicit Option() : state_(None) {}
   /// Constructor for #Some.
-  constexpr explicit Option(T&& t) : state_(Some), t_(static_cast<T&&>(t)) {}
+  constexpr explicit Option(std::remove_reference_t<T>& t)
+      : state_(Some), t_(&t) {}
+  /// Constructor for #Some.
+  constexpr explicit Option(std::remove_reference_t<T>&& t)
+      : state_(Some), t_(static_cast<T&&>(t)) {}
+
+  template <class U>
+  struct Storage {
+    U val_;
+  };
+  template <class U>
+  struct Storage<U&> {
+    U* ptr_;
+  };
 
   // TODO: determine if we can put the tag into `T` from its type (e.g. sizeof
   // < alignment?), and then do so?
   union {
-    T t_;
+    Storage<T> t_;
   };
 
   State state_;

--- a/option/option_unittest.cc
+++ b/option/option_unittest.cc
@@ -639,4 +639,41 @@ TEST(Option, GetOrInsertWith) {
   EXPECT_EQ(static_cast<decltype(y)&&>(y).unwrap(), 18);
 }
 
+TEST(Option, AsRef) {
+  auto x = Option<int>::some(11);
+  auto mx = x.as_ref();
+  static_assert(std::is_same_v<decltype(mx), Option<const int&>>, "");
+  EXPECT_EQ(&x.get_or_insert(0), &static_cast<decltype(mx)&&>(mx).unwrap());
+
+  auto y = Option<int>::some(3);
+  auto& my = y.as_ref().unwrap();
+  static_assert(std::is_same_v<decltype(my), const int&>, "");
+  EXPECT_EQ(my, 3);
+
+  auto n = Option<int>::none();
+  IS_NONE(n.as_ref());
+
+  // Verify constexpr.
+  constexpr auto cn = Option<int>::some(3);
+  static_assert(cn.as_ref().unwrap() == 3, "");
+}
+
+TEST(Option, AsMut) {
+  auto x = Option<int>::some(11);
+  auto mx = x.as_mut();
+  static_assert(std::is_same_v<decltype(mx), Option<int&>>, "");
+  EXPECT_EQ(&x.get_or_insert(0), &static_cast<decltype(mx)&&>(mx).unwrap());
+
+  auto y = Option<int>::some(3);
+  auto& my = y.as_mut().unwrap();
+  static_assert(std::is_same_v<decltype(my), int&>, "");
+  EXPECT_EQ(my, 3);
+  my = 4;
+  auto& my2 = y.as_mut().unwrap();
+  EXPECT_EQ(my2, 4);
+
+  auto n = Option<int>::none();
+  IS_NONE(n.as_mut());
+}
+
 }  // namespace

--- a/option/option_unittest.cc
+++ b/option/option_unittest.cc
@@ -645,17 +645,56 @@ TEST(Option, AsRef) {
   static_assert(std::is_same_v<decltype(mx), Option<const int&>>, "");
   EXPECT_EQ(&x.get_or_insert(0), &static_cast<decltype(mx)&&>(mx).unwrap());
 
-  auto y = Option<int>::some(3);
-  auto& my = y.as_ref().unwrap();
-  static_assert(std::is_same_v<decltype(my), const int&>, "");
-  EXPECT_EQ(my, 3);
-
   auto n = Option<int>::none();
   IS_NONE(n.as_ref());
 
   // Verify constexpr.
-  constexpr auto cn = Option<int>::some(3);
-  static_assert(cn.as_ref().unwrap() == 3, "");
+  constexpr auto cx = Option<int>::some(3);
+  static_assert(cx.as_ref().unwrap() == 3, "");
+}
+
+TEST(Option, UnwrapRefSome) {
+  auto x = Option<int>::some(11);
+  auto& mx = x.unwrap_ref();
+  static_assert(std::is_same_v<decltype(mx), const int&>, "");
+  EXPECT_EQ(mx, 11);
+  EXPECT_EQ(&mx, &x.as_ref().unwrap());
+  auto rx = x.as_ref();
+  static_assert(std::is_same_v<decltype(rx), Option<const int&>>, "");
+  EXPECT_EQ(&mx, &rx.unwrap_ref());
+
+  // Verify constexpr.
+  constexpr auto cx = Option<int>::some(3);
+  static_assert(cx.unwrap_ref() == 3, "");
+}
+
+TEST(OptionDeathTest, UnwrapRefNone) {
+  auto n = Option<int>::none();
+#if GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(n.unwrap_ref(), "");
+#endif
+}
+
+TEST(Option, ExpectRefSome) {
+  auto x = Option<int>::some(11);
+  auto& mx = x.expect_ref("");
+  static_assert(std::is_same_v<decltype(mx), const int&>, "");
+  EXPECT_EQ(mx, 11);
+  EXPECT_EQ(&mx, &x.as_ref().unwrap());
+  auto rx = x.as_ref();
+  static_assert(std::is_same_v<decltype(rx), Option<const int&>>, "");
+  EXPECT_EQ(&mx, &rx.expect_ref(""));
+
+  // Verify constexpr.
+  constexpr auto cx = Option<int>::some(3);
+  static_assert(cx.expect_ref("") == 3, "");
+}
+
+TEST(OptionDeathTest, ExpectRefNone) {
+  auto n = Option<int>::none();
+#if GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(n.expect_ref("hello world"), "hello world");
+#endif
 }
 
 TEST(Option, AsMut) {
@@ -676,4 +715,43 @@ TEST(Option, AsMut) {
   IS_NONE(n.as_mut());
 }
 
+TEST(Option, UnwrapMutSome) {
+  auto x = Option<int>::some(11);
+  auto& mx = x.unwrap_mut();
+  static_assert(std::is_same_v<decltype(mx), int&>, "");
+  EXPECT_EQ(mx, 11);
+  mx = 13;
+  EXPECT_EQ(&mx, &x.as_mut().unwrap());
+  auto rx = x.as_mut();
+  static_assert(std::is_same_v<decltype(rx), Option<int&>>, "");
+  EXPECT_EQ(&mx, &rx.unwrap_mut());
+  EXPECT_EQ(x.unwrap_mut(), 13);
+}
+
+TEST(OptionDeathTest, UnwrapMutNone) {
+  auto n = Option<int>::none();
+#if GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(n.unwrap_mut(), "");
+#endif
+}
+
+TEST(Option, ExpectMutSome) {
+  auto x = Option<int>::some(11);
+  auto& mx = x.expect_mut("");
+  static_assert(std::is_same_v<decltype(mx), int&>, "");
+  EXPECT_EQ(mx, 11);
+  mx = 13;
+  EXPECT_EQ(&mx, &x.as_mut().unwrap());
+  auto rx = x.as_mut();
+  static_assert(std::is_same_v<decltype(rx), Option<int&>>, "");
+  EXPECT_EQ(&mx, &rx.expect_mut(""));
+  EXPECT_EQ(x.expect_mut(""), 13);
+}
+
+TEST(OptionDeathTest, ExpectMutNone) {
+  auto n = Option<int>::none();
+#if GTEST_HAS_DEATH_TEST
+  EXPECT_DEATH(n.expect_mut("hello world"), "hello world");
+#endif
+}
 }  // namespace

--- a/traits/make_default.h
+++ b/traits/make_default.h
@@ -50,4 +50,17 @@ struct MakeDefault {
   }
 };
 
+template <class T>
+struct MakeDefault<T&&> {
+  static constexpr bool has_trait = false;
+};
+template <class T>
+struct MakeDefault<T&> {
+  static constexpr bool has_trait = false;
+};
+template <class T>
+struct MakeDefault<const T&> {
+  static constexpr bool has_trait = false;
+};
+
 }  // namespace sus::traits


### PR DESCRIPTION
insert() will replace whatever value is there, if any.

get_or_insert() will get a mutable reference to the value,
and insert a value if there is none in order to be able to
create a reference.

get_or_insert_default() is similar, but you don't specify
the value at the callsite.

get_or_insert_with() is similar too, but you give a function
to construct the value to insert, which avoids expensive
constructions.