### PR TITLE
Add Option iter(), iter_mut(), into_iter().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,10 @@ add_library(subspace STATIC
     "mem/replace.h"
     "mem/swap.h"
     "mem/take.h"
+    "option/__private/is_option_type.h"
     "option/option.h"
+    "traits/iterator.h"
+    "traits/iterator.cc"
     "lib/lib.cc"
 )
 set_target_properties(subspace PROPERTIES LINKER_LANGUAGE CXX)

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -127,8 +127,9 @@ This library is an experiment and not intended for use. See the
       value-or-none.
 1. Traits, SFINAE and type tags to define behaviour on data. No inheritance
    unless from an abstract interface. All other classes are marked `final`.
+    * Always use `final` instead of `override`.
     * Inheritance is [no longer
-      needed](https://en.cppreference.com/w/cpp/language/ebo).
+      needed](https://en.cppreference.com/w/cpp/language/ebo) for object sizes.
     * We will provide a public set of traits with defined behaviour and tools or
       guidance to ensure consistent behaviour in implementations of traits.
 1. Tools to use SFINAE for common patterns, such as traits, without having to

--- a/option/__private/is_option_type.h
+++ b/option/__private/is_option_type.h
@@ -1,0 +1,34 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace sus::option {
+template <class T>
+class Option;
+}
+
+namespace sus::option::__private {
+
+template <class U>
+struct IsOptionType : std::false_type {
+  using inner_type = void;
+};
+
+template <class U>
+struct IsOptionType<Option<U>> : std::true_type {
+  using inner_type = U;
+};
+
+}  // namespace sus::option::__private

--- a/traits/iterator.cc
+++ b/traits/iterator.cc
@@ -1,0 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traits/iterator.h"
+
+namespace sus::traits {
+const IteratorEnd iterator_end;
+}

--- a/traits/iterator.h
+++ b/traits/iterator.h
@@ -1,0 +1,69 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace sus::option {
+template <class T>
+class Option;
+}
+
+namespace sus::traits {
+
+using ::sus::option::Option;
+
+template <class Item>
+class Iterator;
+
+struct IteratorEnd {};
+extern const IteratorEnd iterator_end;
+
+template <class Item>
+struct IteratorStep {
+  Option<Item> item_;
+  Iterator<Item>& iter_;
+
+  inline bool operator==(const IteratorEnd&) const { return item_.is_nome(); }
+  inline bool operator!=(const IteratorEnd&) const { return item_.is_some(); }
+  inline void operator++() & { item_ = iter_.next(); }
+  inline Item operator*() & { return item_.take().unwrap(); }
+};
+
+template <class Item>
+class Iterator {
+ public:
+  virtual Option<Item> next() = 0;
+
+  Iterator(const Iterator&) = delete;
+  Iterator& operator=(const Iterator&) = delete;
+  Iterator(Iterator&&) = delete;
+  Iterator& operator=(Iterator&&) = delete;
+
+  IteratorStep<Item> begin() & {
+    return IteratorStep{first_item_.take().flatten(), *this};
+  }
+  IteratorEnd end() & { return iterator_end; }
+
+ protected:
+  Iterator() : first_item_(Option<Option<Item>>::some(next())) {}
+  Iterator(Option<Item> first)
+      : first_item_(
+            Option<Option<Item>>::some(static_cast<decltype(first)&&>(first))) {
+  }
+
+ private:
+  Option<Option<Item>> first_item_;
+};
+
+}  // namespace sus::traits


### PR DESCRIPTION
We introduce an Iterator trait, which has a single abstract function,
next() that returns Option<Item>.

The Option's Iterator impl initializes the first Item, and then
always returns None from next().

The Iterator type has begin() which returns an IteratorStep that
holds the current Item. It starts with the first item. And it has
end() which is a sentinel. When next() returns None, then the
operator==(end) will be true.