### PR TITLE
Add a test template for testing type properties, use it for option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,15 @@ add_library(subspace STATIC
 )
 set_target_properties(subspace PROPERTIES LINKER_LANGUAGE CXX)
 
+add_library(subspace_test_support STATIC
+    "test/behaviour_types.h"
+    "test/behaviour_types_unittest.cc"
+)
+set_target_properties(subspace_test_support PROPERTIES LINKER_LANGUAGE CXX)
+target_link_libraries(subspace_test_support
+    subspace
+)
+
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 add_subdirectory("third_party/googletest")
 
@@ -54,11 +63,13 @@ add_executable(subspace_unittests
     "mem/swap_unittest.cc"
     "mem/take_unittest.cc"
     "option/option_unittest.cc"
+    "option/option_types_unittest.cc"
     "traits/iter/iterator_unittest.cc"
 )
 set_target_properties(subspace_unittests PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(subspace_unittests
     subspace
+    subspace_test_support
     gtest_main
 )
 

--- a/option/option_types_unittest.cc
+++ b/option/option_types_unittest.cc
@@ -1,0 +1,309 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "concepts/make_default.h"
+#include "mem/__private/relocate.h"
+#include "option/option.h"
+#include "test/behaviour_types.h"
+
+using sus::option::Option;
+using sus::concepts::MakeDefault;
+using sus::mem::__private::relocate_array_by_memcpy_v;
+using sus::mem::__private::relocate_one_by_memcpy_v;
+
+namespace default_constructible {
+using T = Option<sus::test::DefaultConstructible>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace default_constructible
+
+namespace not_default_constructible {
+using T = Option<sus::test::NotDefaultConstructible>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace not_default_constructible
+
+namespace with_default_constructible {
+using T = Option<sus::test::WithDefaultConstructible>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace with_default_constructible
+
+namespace trivially_copyable {
+using T = Option<sus::test::TriviallyCopyable>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(!std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(!std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(!std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_copyable
+
+namespace trivially_moveable_and_relocatable {
+using T = Option<sus::test::TriviallyMoveableAndRelocatable>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_moveable_and_relocatable
+
+namespace trivially_copyable_not_destructible {
+using T = Option<sus::test::TriviallyCopyableNotDestructible>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(!std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(!std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(!std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_copyable_not_destructible
+
+namespace trivially_moveable_not_destructible {
+using T = Option<sus::test::TriviallyMoveableNotDestructible>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_moveable_not_destructible
+
+namespace not_trivially_relocatable_copyable_or_moveable {
+using T = Option<sus::test::NotTriviallyRelocatableCopyableOrMoveable>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace not_trivially_relocatable_copyable_or_moveable
+
+namespace trivial_abi_relocatable {
+using T = Option<sus::test::TrivialAbiRelocatable>;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+#if __has_extension(trivially_relocatable)
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+#else
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+#endif
+}  // namespace trivial_abi_relocatable

--- a/test/behaviour_types.h
+++ b/test/behaviour_types.h
@@ -1,0 +1,91 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <type_traits>
+
+namespace sus::test {
+
+struct DefaultConstructible {
+  int i = 2;
+};
+
+struct NotDefaultConstructible {
+  int i;
+  constexpr NotDefaultConstructible(int i) : i(i) {}
+};
+
+struct WithDefaultConstructible {
+  int i;
+  static inline constexpr WithDefaultConstructible with_default() {
+    return WithDefaultConstructible(3);
+  }
+  constexpr WithDefaultConstructible(int i) : i(i) {}
+};
+
+struct TriviallyCopyable {
+  TriviallyCopyable(const TriviallyCopyable&) = default;
+  TriviallyCopyable& operator=(const TriviallyCopyable&) = default;
+  TriviallyCopyable(TriviallyCopyable&&) = delete;
+  TriviallyCopyable& operator=(TriviallyCopyable&&) = delete;
+  ~TriviallyCopyable() = default;
+  TriviallyCopyable(int i) : i(i) {}
+  int i;
+};
+
+struct TriviallyMoveableAndRelocatable {
+  TriviallyMoveableAndRelocatable(TriviallyMoveableAndRelocatable&&) = default;
+  TriviallyMoveableAndRelocatable& operator=(
+      TriviallyMoveableAndRelocatable&&) = default;
+  ~TriviallyMoveableAndRelocatable() = default;
+  TriviallyMoveableAndRelocatable(int i) : i(i) {}
+  int i;
+};
+
+struct TriviallyCopyableNotDestructible {
+  TriviallyCopyableNotDestructible(const TriviallyCopyableNotDestructible&) =
+      default;
+  TriviallyCopyableNotDestructible& operator=(
+      const TriviallyCopyableNotDestructible&) = default;
+  TriviallyCopyableNotDestructible(TriviallyCopyableNotDestructible&&) = delete;
+  TriviallyCopyableNotDestructible& operator=(
+      TriviallyCopyableNotDestructible&&) = delete;
+  ~TriviallyCopyableNotDestructible() {}
+  int i;
+};
+
+struct TriviallyMoveableNotDestructible {
+  TriviallyMoveableNotDestructible(TriviallyMoveableNotDestructible&&) =
+      default;
+  TriviallyMoveableNotDestructible& operator=(
+      TriviallyMoveableNotDestructible&&) = default;
+  ~TriviallyMoveableNotDestructible(){};
+  int i;
+};
+
+struct NotTriviallyRelocatableCopyableOrMoveable {
+  NotTriviallyRelocatableCopyableOrMoveable(
+      NotTriviallyRelocatableCopyableOrMoveable&&) {}
+  ~NotTriviallyRelocatableCopyableOrMoveable() {}
+  int i;
+};
+
+struct [[clang::trivial_abi]] TrivialAbiRelocatable {
+  TrivialAbiRelocatable(TrivialAbiRelocatable&&) {}
+  ~TrivialAbiRelocatable() {}
+  int i;
+};
+
+}  // namespace sus::test

--- a/test/behaviour_types_unittest.cc
+++ b/test/behaviour_types_unittest.cc
@@ -1,0 +1,307 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "concepts/make_default.h"
+#include "mem/__private/relocate.h"
+#include "test/behaviour_types.h"
+
+using sus::concepts::MakeDefault;
+using sus::mem::__private::relocate_array_by_memcpy_v;
+using sus::mem::__private::relocate_one_by_memcpy_v;
+
+namespace default_constructible {
+using T = sus::test::DefaultConstructible;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace default_constructible
+
+namespace not_default_constructible {
+using T = sus::test::NotDefaultConstructible;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace not_default_constructible
+
+namespace with_default_constructible {
+using T = sus::test::WithDefaultConstructible;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace with_default_constructible
+
+namespace trivially_copyable {
+using T = sus::test::TriviallyCopyable;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(!std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(!std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(!std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_copyable
+
+namespace trivially_moveable_and_relocatable {
+using T = sus::test::TriviallyMoveableAndRelocatable;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_moveable_and_relocatable
+
+namespace trivially_copyable_not_destructible {
+using T = sus::test::TriviallyCopyableNotDestructible;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(std::is_copy_constructible_v<T>, "");
+static_assert(std::is_copy_assignable_v<T>, "");
+static_assert(!std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(!std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(std::is_constructible_v<T, const From&>, "");
+static_assert(std::is_assignable_v<T, const From&>, "");
+static_assert(!std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_copyable_not_destructible
+
+namespace trivially_moveable_not_destructible {
+using T = sus::test::TriviallyMoveableNotDestructible;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(std::is_move_assignable_v<T>, "");
+static_assert(std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace trivially_moveable_not_destructible
+
+namespace not_trivially_relocatable_copyable_or_moveable {
+using T = sus::test::NotTriviallyRelocatableCopyableOrMoveable;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+}  // namespace not_trivially_relocatable_copyable_or_moveable
+
+namespace trivial_abi_relocatable {
+using T = sus::test::TrivialAbiRelocatable;
+using From = T;
+static_assert(!std::is_trivially_constructible_v<T>, "");
+static_assert(!std::is_trivial_v<T>, "");
+static_assert(!std::is_aggregate_v<T>, "");
+static_assert(std::is_standard_layout_v<T>, "");
+static_assert(!std::is_trivially_default_constructible_v<T>, "");
+static_assert(!std::is_default_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_constructible_v<T>, "");
+static_assert(!std::is_trivially_copy_assignable_v<T>, "");
+static_assert(!std::is_trivially_move_constructible_v<T>, "");
+static_assert(!std::is_trivially_move_assignable_v<T>, "");
+static_assert(!std::is_trivially_destructible_v<T>, "");
+static_assert(!std::is_copy_constructible_v<T>, "");
+static_assert(!std::is_copy_assignable_v<T>, "");
+static_assert(std::is_move_constructible_v<T>, "");
+static_assert(!std::is_move_assignable_v<T>, "");
+static_assert(!std::is_nothrow_swappable_v<T>, "");
+static_assert(std::is_constructible_v<T, From&&>, "");
+static_assert(!std::is_assignable_v<T, From&&>, "");
+static_assert(!std::is_constructible_v<T, const From&>, "");
+static_assert(!std::is_assignable_v<T, const From&>, "");
+static_assert(std::is_constructible_v<T, From>, "");
+static_assert(!std::is_assignable_v<T, From>, "");
+static_assert(std::is_nothrow_destructible_v<T>, "");
+static_assert(!MakeDefault<T>::has_concept, "");
+#if __has_extension(trivially_relocatable)
+static_assert(relocate_one_by_memcpy_v<T>, "");
+static_assert(relocate_array_by_memcpy_v<T>, "");
+#else
+static_assert(!relocate_one_by_memcpy_v<T>, "");
+static_assert(!relocate_array_by_memcpy_v<T>, "");
+#endif
+}  // namespace trivial_abi_relocatable


### PR DESCRIPTION
We use the test template to find differences between T and
Option<T>, and fix those differences so that Option<T> can
be used in the same ways (and only the same ways) as T can.
For example, if T is moveable but not copyable, then Option<T>
should be also.

This uncovered an issue where a non-moveable type was being
move-constructed into Option's storage. So add requires
on Option's storage and a const& override such that non-
move-constructible types, even if given as an rvalue, get
copied instead.