### PR TITLE
Remove support for native arrays.

### DIFF
--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -105,6 +105,10 @@ This library is an experiment and not intended for use. See the
     possible. They only use internal heap allocations when strictly required:
     for instance, because they have a dynamic size. Instead, the user can choose
     what lives on the heap through the use of heap-based smart pointers.
+1. No native arrays. Use an Array type instead.
+    * Native arrays can't be bounds-checked, and decay to pointers, making them
+      a bit invisible. A library type has the same overheads, unless it
+      explicitly chooses to provide more.
 1. Deep constness. Const methods do not mutate state in visible ways.
     * No const methods return non-const pointers or references.
     * No const methods call non-const methods through pointers or references.

--- a/mem/mref.h
+++ b/mem/mref.h
@@ -44,93 +44,27 @@ namespace sus::mem {
 /// int i;
 /// receive_ref(mref(i));   // Explicitly pass lvalue ref.
 /// ```
-template <class T, size_t N = 0>
+template <class T>
 class Mref;
 
 /// Pass a variable to a function as a mutable reference.
 template <class T>
-constexpr inline Mref<T&, 0> mref(T& t) {
+constexpr inline Mref<T&> mref(T& t) {
   return Mref<T&>(t);
 }
 
-/// Pass a variable to a function as a mutable reference.
-template <class T, size_t N>
-constexpr inline Mref<T, N> mref(T (&t)[N]) {
-  return Mref<T, N>(t);
-}
-
 template <class T>
-constexpr inline Mref<T> mref(const T& t) = delete;
-template <class T, size_t N>
-constexpr inline Mref<T, N> mref(const T (&t)[N]) = delete;
+constexpr inline Mref<T&> mref(const T& t) = delete;
 
 /// An Mref can be passed along as an Mref.
-template <class T, size_t N>
-constexpr inline Mref<T, N> mref(Mref<T, N>& t) {
-  return Mref<T, N>(t.inner());
+template <class T>
+constexpr inline Mref<T> mref(Mref<T>& t) {
+  return Mref<T>(t.inner());
 }
 
-/// Implementation of Mref for an array reference with `N elements.
-template <class T, size_t N>
-struct Mref {
- private:
-  template <class U>
-  using RefType = U (&)[N];
-  template <class U>
-  using RvalueRefType = U (&&)[N];
-
- public:
-  constexpr Mref(Mref&&) noexcept = default;
-  constexpr Mref& operator=(Mref&&) noexcept = default;
-
-  // Prevent passing an Mref argument along without writing mref() again.
-  Mref(Mref&) = delete;
-
-  // Act like a T&. It can convert to a T&.
-  constexpr operator RefType<T>() & noexcept { return t_; }
-  // Act like a T&. Arrays are not assignable.
-  constexpr RefType<T> operator=(const RefType<T> t) = delete;
-  // Act like a T&. Arrays are not assignable.
-  constexpr T& operator=(RvalueRefType<T> t) = delete;
-  // Act like a T&. Arrays can access by operator[].
-  constexpr const T& operator[](size_t i) const& {
-    ::sus::check(i < N);
-    return t_[i];
-  }
-  constexpr const T& operator[](size_t i) && = delete;
-  // Act like a T&. Arrays can access by operator[].
-  constexpr T& operator[](size_t i) & {
-    ::sus::check(i < N);
-    return t_[i];
-  }
-
-  // mref() should only be used to construct Mref, not T&.
-  constexpr operator RefType<T>() && = delete;
-
-  /// Get access to the inner type without doing an explicit type conversion to
-  /// `T&`.
-  constexpr RefType<T> inner() & { return t_; }
-
- private:
-  friend constexpr Mref<T, N> mref<>(RefType<T>);
-  friend constexpr Mref<T, N> mref<>(Mref<T, N>&);
-
-  // TODO: Errors are confusing when you do it wrong:
-  //
-  //   error: ‘constexpr sus::mem::Mref<T>::Mref(T&) [with T =
-  //   {anonymous}::MoveOnly]’ is private within this context
-  //
-  // Could we fix it with an intermediate type. mref() returns MrefPass, and
-  // Mref is constructed form MrefPass. Then we could delete Mref(T&) instead
-  // of making it private. Does it codegen the same though?
-  constexpr Mref(RefType<T> t) noexcept : t_(t) {}
-
-  RefType<T> t_;
-};
-
-/// Implementation of Mref for a regular type reference (non-array).
 template <class T>
-struct Mref<T&, 0> {
+  requires(!std::is_array_v<T>)
+struct Mref<T&> {
   constexpr Mref(Mref&&) noexcept = default;
   constexpr Mref& operator=(Mref&&) noexcept = default;
 

--- a/mem/mref_unittest.cc
+++ b/mem/mref_unittest.cc
@@ -39,9 +39,6 @@ static_assert(!std::is_convertible_v<Mref<const int&>,
               "");
 
 void increment(Mref<int&> i) { ++i; }
-void increment(Mref<int, 2> i) {
-  for (int& ii : i.inner()) ++ii;
-}
 
 TEST(Mref, Pass) {
   int i = 0;
@@ -77,30 +74,6 @@ TEST(Mref, AssignRvalueRef) {
   Mref<int&> m = mref(i);
   m = 4;
   EXPECT_EQ(i, 4);
-}
-
-TEST(MrefArray, Pass) {
-  int i[] = {1, 2};
-  increment(mref(i));
-  EXPECT_EQ(i[0], 2);
-  EXPECT_EQ(i[1], 3);
-}
-
-TEST(MrefArray, PassMref) {
-  auto f = [](Mref<int, 2> i) { increment(mref(i)); };
-  int i[] = {1, 2};
-  f(mref(i));
-  EXPECT_EQ(i[0], 2);
-  EXPECT_EQ(i[1], 3);
-}
-
-TEST(MrefArray, Convertible) {
-  int i[] = {3, 4};
-  Mref<int, 2> m = mref(i);
-  int(&j)[] = m;
-  j[1]++;  // Increments `i` too.
-  EXPECT_EQ(i[0], 3);
-  EXPECT_EQ(i[1], 5);
 }
 
 }  // namespace

--- a/mem/swap.h
+++ b/mem/swap.h
@@ -43,25 +43,4 @@ constexpr void swap(Mref<T&> lhs_ref, Mref<T&> rhs_ref) noexcept {
   }
 }
 
-template <class T, /* TODO: usize */ size_t N>
-  requires(std::is_move_constructible_v<T> && std::is_move_assignable_v<T>)
-constexpr void swap(Mref<T, N> lhs_ref, Mref<T, N> rhs_ref) noexcept {
-  T(&lhs)[N] = lhs_ref;
-  T(&rhs)[N] = rhs_ref;
-  // memcpy() is not constexpr so we can't use it in constexpr evaluation.
-  if (::sus::mem::__private::relocate_array_by_memcpy_v<T> &&
-      !std::is_constant_evaluated()) {
-    char temp[sizeof(T[N])];
-    memcpy(temp, lhs, sizeof(T[N]));
-    memcpy(lhs, rhs, sizeof(T[N]));
-    memcpy(rhs, temp, sizeof(T[N]));
-  } else {
-    for (/*TODO: usize*/ size_t i = 0; i < N; ++i) {
-      T temp(static_cast<T&&>(lhs[i]));
-      lhs[i] = T(static_cast<T&&>(rhs[i]));
-      rhs[i] = T(static_cast<T&&>(temp));
-    }
-  }
-}
-
 }  // namespace sus::mem

--- a/mem/swap_unittest.cc
+++ b/mem/swap_unittest.cc
@@ -41,27 +41,6 @@ TEST(Swap, ConstexprTrivialRelocate) {
   };
   static_assert(i() == T(5), "");
   static_assert(j() == T(2), "");
-
-  // Array.
-  {
-    using T = int[5];
-    static_assert(__private::relocate_array_by_memcpy_v<T>, "");
-
-    auto i = []() constexpr {
-      T i{2, 2, 3, 4, 2};
-      T j{5, 5, 6, 7, 5};
-      ::sus::mem::swap(mref(i), mref(j));
-      return i[3];
-    };
-    auto j = []() constexpr {
-      T i{2, 2, 3, 4, 2};
-      T j{5, 5, 6, 7, 5};
-      ::sus::mem::swap(mref(i), mref(j));
-      return j[3];
-    };
-    static_assert(i() == 7, "");
-    static_assert(j() == 4, "");
-  }
 }
 
 TEST(Swap, ConstexprTrivialAbi) {
@@ -96,29 +75,6 @@ TEST(Swap, ConstexprTrivialAbi) {
   // The swap was done by move operations, since memcpy is not constexpr.
   static_assert(i().moves == 1, "");
   static_assert(j().moves == 1, "");
-
-  // Array.
-  {
-    using T = S[2];
-
-    auto i = []() constexpr {
-      T i{1, 2};
-      T j{4, 5};
-      ::sus::mem::swap(mref(i), mref(j));
-      return static_cast<S&&>(i[1]);
-    };
-    auto j = []() constexpr {
-      T i{1, 2};
-      T j{4, 5};
-      ::sus::mem::swap(mref(i), mref(j));
-      return static_cast<S&&>(j[1]);
-    };
-    static_assert(i().num == 5, "");
-    static_assert(j().num == 2, "");
-    // The swap was done by move operations, since memcpy is not constexpr.
-    static_assert(i().moves == 1, "");
-    static_assert(j().moves == 1, "");
-  }
 }
 
 TEST(Swap, ConstexprNonTrivial) {
@@ -148,29 +104,6 @@ TEST(Swap, ConstexprNonTrivial) {
   // The swap was done by move operations, since memcpy is not constexpr.
   static_assert(i().moves == 1, "");
   static_assert(j().moves == 1, "");
-
-  // Array.
-  {
-    using T = S[2];
-
-    auto i = []() constexpr {
-      T i{1, 2};
-      T j{4, 5};
-      ::sus::mem::swap(mref(i), mref(j));
-      return static_cast<S&&>(i[1]);
-    };
-    auto j = []() constexpr {
-      T i{1, 2};
-      T j{4, 5};
-      ::sus::mem::swap(mref(i), mref(j));
-      return static_cast<S&&>(j[1]);
-    };
-    static_assert(i().num == 5, "");
-    static_assert(j().num == 2, "");
-    // The swap was done by move operations, since memcpy is not constexpr.
-    static_assert(i().moves == 1, "");
-    static_assert(j().moves == 1, "");
-  }
 }
 
 TEST(Swap, TrivialRelocate) {
@@ -182,16 +115,6 @@ TEST(Swap, TrivialRelocate) {
   ::sus::mem::swap(mref(i), mref(j));
   EXPECT_EQ(i, T(5));
   EXPECT_EQ(j, T(2));
-
-  // Array.
-  {
-    using T = int[2];
-    T i{1, 2};
-    T j{4, 5};
-    ::sus::mem::swap(mref(i), mref(j));
-    EXPECT_EQ(i[1], 5);
-    EXPECT_EQ(j[1], 2);
-  }
 }
 
 TEST(Swap, TrivialAbi) {
@@ -224,24 +147,6 @@ TEST(Swap, TrivialAbi) {
   // The swap was done by move operations.
   EXPECT_GE(i.moves, 2);
 #endif
-
-  // Array.
-  {
-    using T = S[2];
-
-    T i{1, 2};
-    T j{4, 5};
-    ::sus::mem::swap(mref(i), mref(j));
-    EXPECT_EQ(i[1].num, 5);
-    EXPECT_EQ(j[1].num, 2);
-#if __has_extension(trivially_relocatable)
-    // The swap was done by memcpy.
-    EXPECT_EQ(i[1].moves, 0);
-#else
-    // The swap was done by move operations.
-    EXPECT_GE(i[1].moves, 2);
-#endif
-  }
 }
 
 TEST(Swap, NonTrivial) {
@@ -265,20 +170,6 @@ TEST(Swap, NonTrivial) {
   // The swap was done by move operations.
   EXPECT_GE(i.moves, 2);
   EXPECT_GE(j.moves, 2);
-
-  // Array.
-  {
-    using T = S[2];
-
-    T i{1, 2};
-    T j{4, 5};
-    ::sus::mem::swap(mref(i), mref(j));
-    EXPECT_EQ(i[1].num, 5);
-    EXPECT_EQ(j[1].num, 2);
-    // The swap was done by move operations.
-    EXPECT_GE(i[1].moves, 2);
-    EXPECT_GE(j[1].moves, 2);
-  }
 }
 
 }  // namespace


### PR DESCRIPTION
Native arrays are unsafe and lead to memory bugs. And they can't
provide nice APIs like an Array type. And they decay to pointers.

We won't use them in the library, so we don't need to provide APIs
that work with them.