### PR TITLE
Move iterators from the traits namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,13 +30,13 @@ add_library(subspace STATIC
     "mem/take.h"
     "option/__private/is_option_type.h"
     "option/option.h"
-    "traits/iter/filter.h"
-    "traits/iter/iterator.h"
-    "traits/iter/iterator.cc"
-    "traits/iter/iterator_defn.h"
-    "traits/iter/iterator_fns.h"
-    "traits/iter/once.h"
-    "traits/iter/sized_iterator.h"
+    "iter/filter.h"
+    "iter/iterator.h"
+    "iter/iterator.cc"
+    "iter/iterator_defn.h"
+    "iter/iterator_fns.h"
+    "iter/once.h"
+    "iter/sized_iterator.h"
     "lib/lib.cc"
 )
 set_target_properties(subspace PROPERTIES LINKER_LANGUAGE CXX)
@@ -70,7 +70,7 @@ add_executable(subspace_unittests
     "mem/take_unittest.cc"
     "option/option_unittest.cc"
     "option/option_types_unittest.cc"
-    "traits/iter/iterator_unittest.cc"
+    "iter/iterator_unittest.cc"
 )
 set_target_properties(subspace_unittests PROPERTIES LINKER_LANGUAGE CXX)
 target_link_libraries(subspace_unittests

--- a/iter/filter.h
+++ b/iter/filter.h
@@ -18,14 +18,14 @@
 
 #include "mem/__private/relocatable_storage.h"
 #include "mem/__private/relocate.h"
-#include "traits/iter/iterator_defn.h"
-#include "traits/iter/sized_iterator.h"
+#include "iter/iterator_defn.h"
+#include "iter/sized_iterator.h"
 
-namespace sus::traits::iter {
+namespace sus::iter {
 
 using ::sus::mem::__private::RelocatableStorage;
 using ::sus::mem::__private::relocate_one_by_memcpy_v;
-using ::sus::traits::iter::IteratorBase;
+using ::sus::iter::IteratorBase;
 
 template <class Item, size_t InnerIterSize, size_t InnerIterAlign>
 class Filter : public IteratorBase<Item> {
@@ -68,4 +68,4 @@ class Filter : public IteratorBase<Item> {
   sus_class_maybe_trivial_relocatable_types(unsafe_fn, decltype(data_));
 };
 
-}  // namespace sus::traits::iter
+}  // namespace sus::iter

--- a/iter/iterator.cc
+++ b/iter/iterator.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "traits/iter/iterator.h"
+#include "iter/iterator.h"
 
-namespace sus::traits::iter {
+namespace sus::iter {
 const IteratorEnd iterator_end;
 }

--- a/iter/iterator.h
+++ b/iter/iterator.h
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include "traits/iter/iterator_defn.h"
-#include "traits/iter/iterator_fns.h"
+#include "iter/iterator_defn.h"
+#include "iter/iterator_fns.h"
 
 // Once is included here, because there is a cycle between
 // Option->Once->IteratorBase, so Option can't include Once itself. But as long as
 // the user includes "iterator.h" they should be able to use the iterators on
 // Option.
-#include "traits/iter/once.h"
+#include "iter/once.h"

--- a/iter/iterator_defn.h
+++ b/iter/iterator_defn.h
@@ -18,7 +18,7 @@
 
 #include "option/option.h"
 
-namespace sus::traits::iter {
+namespace sus::iter {
 
 using ::sus::mem::__private::relocate_one_by_memcpy_v;
 using ::sus::option::Option;
@@ -127,4 +127,4 @@ class Iterator final : public I {
           pred) && noexcept;
 };
 
-}  // namespace sus::traits::iter
+}  // namespace sus::iter

--- a/iter/iterator_fns.h
+++ b/iter/iterator_fns.h
@@ -16,14 +16,14 @@
 
 #include <functional>  // TODO: Replace std::function with something.
 
-#include "traits/iter/iterator_defn.h"
-#include "traits/iter/sized_iterator.h"
+#include "iter/iterator_defn.h"
+#include "iter/sized_iterator.h"
 
 // IteratorBase provided functions are implemented in this file, so that they
 // can be easily included by library users, but don't have to be included in
 // every library header that returns an IteratorBase.
 
-namespace sus::traits::iter {
+namespace sus::iter {
 
 struct IteratorEnd {};
 extern const IteratorEnd iterator_end;
@@ -113,4 +113,4 @@ Iterator<Filter<typename I::Item, sizeof(I), alignof(I)>> Iterator<I>::filter(
           make_sized_iterator(static_cast<I&&>(*this))};
 }
 
-}  // namespace sus::traits::iter
+}  // namespace sus::iter

--- a/iter/iterator_unittest.cc
+++ b/iter/iterator_unittest.cc
@@ -12,17 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "traits/iter/iterator.h"
+#include "iter/iterator.h"
 
 #include "assertions/unreachable.h"
 #include "containers/array.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
-#include "traits/iter/filter.h"
+#include "iter/filter.h"
 
 using ::sus::containers::Array;
 using ::sus::option::Option;
-using ::sus::traits::iter::Iterator;
-using ::sus::traits::iter::IteratorBase;
+using ::sus::iter::Iterator;
+using ::sus::iter::IteratorBase;
 
 namespace {
 

--- a/iter/once.h
+++ b/iter/once.h
@@ -15,13 +15,13 @@
 #pragma once
 
 #include "mem/__private/relocatable_storage.h"
-#include "traits/iter/iterator_defn.h"
+#include "iter/iterator_defn.h"
 
-namespace sus::traits::iter {
+namespace sus::iter {
 
 using ::sus::mem::__private::RelocatableStorage;
 using ::sus::option::Option;
-using ::sus::traits::iter::IteratorBase;
+using ::sus::iter::IteratorBase;
 
 /// An IteratorBase implementation that walks over at most a single Item.
 template <class Item>
@@ -46,4 +46,4 @@ inline Once<Item> once(Option<Item>&& single)
   return Once(static_cast<decltype(single)&&>(single));
 }
 
-}  // namespace sus::traits::iter
+}  // namespace sus::iter

--- a/iter/sized_iterator.h
+++ b/iter/sized_iterator.h
@@ -15,9 +15,9 @@
 #pragma once
 
 #include "mem/__private/relocate.h"
-#include "traits/iter/iterator_defn.h"
+#include "iter/iterator_defn.h"
 
-namespace sus::traits::iter {
+namespace sus::iter {
 
 template <class Item, size_t SubclassSize, size_t SubclassAlign>
 struct SizedIterator {
@@ -58,4 +58,4 @@ inline SizedIteratorType make_sized_iterator(IteratorSubclass&& subclass)
   return it;
 }
 
-}  // namespace sus::traits::iter
+}  // namespace sus::iter

--- a/option/option.h
+++ b/option/option.h
@@ -37,17 +37,17 @@
 #include "mem/take.h"
 #include "option/__private/is_option_type.h"
 
-namespace sus::traits::iter {
+namespace sus::iter {
 template <class Item>
 class Once;
 template <class I>
 class Iterator;
-}  // namespace sus::traits::iter
+}  // namespace sus::iter
 
 namespace sus::option {
 
-using sus::traits::iter::Iterator;
-using sus::traits::iter::Once;
+using sus::iter::Iterator;
+using sus::iter::Once;
 
 template <class T>
 class Option;

--- a/option/option_unittest.cc
+++ b/option/option_unittest.cc
@@ -18,7 +18,7 @@
 #include "mem/__private/relocate.h"
 #include "test/behaviour_types.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
-#include "traits/iter/iterator.h"
+#include "iter/iterator.h"
 
 using ::sus::concepts::MakeDefault;
 using ::sus::mem::Mref;


### PR DESCRIPTION
We will put them in iter:: since there will be a lot of
stuff in there, and to avoid deep nesting with double
namespaces (or triple, including sus).