### PR TITLE
Store pointers as const with sus_bind().

### DIFF
--- a/fn/fn_defn.h
+++ b/fn/fn_defn.h
@@ -373,7 +373,7 @@ class [[sus_trivial_abi]] Fn<R(CallArgs...)> : public FnMut<R(CallArgs...)> {
   Fn(F ptr) noexcept : FnMut<R(CallArgs...)>(static_cast<F&&>(ptr)) {}
 
   /// Construction from the output of `sus_bind()`.
-  template <::sus::concepts::callable::LambdaReturns<R, CallArgs...> F>
+  template <::sus::concepts::callable::LambdaReturnsConst<R, CallArgs...> F>
   Fn(__private::SusBind<F>&& holder) noexcept
       : FnMut<R(CallArgs...)>(__private::StorageConstructionFn,
                               static_cast<F&&>(holder.lambda)) {}


### PR DESCRIPTION
Use sus_bind_mut() to store mutable pointers. This
helps to ensure a Fn is safe to call concurrently,
as it will not mutate its environment (unless it
is through internal mutability).