### PR TITLE
Add mixed signed/unsigned math

### DIFF
--- a/num/__private/signed_integer_macros.h
+++ b/num/__private/signed_integer_macros.h
@@ -805,6 +805,17 @@
       return Option<T>::none();                                               \
   }                                                                           \
                                                                               \
+  /** Checked integer subtraction with an unsigned rhs. Computes self - rhs,  \
+   * returning None if overflow occurred.                                     \
+   */                                                                         \
+  constexpr Option<T> checked_sub_unsigned(const UnsignedT& rhs) const& {     \
+    auto out = __private::sub_with_overflow_unsigned(primitive_value, rhs);   \
+    if (!out.overflow) [[likely]]                                             \
+      return Option<T>::some(out.value);                                      \
+    else                                                                      \
+      return Option<T>::none();                                               \
+  }                                                                           \
+                                                                              \
   /** Calculates self - rhs                                                   \
    *                                                                          \
    * Returns a tuple of the subtraction along with a boolean indicating       \
@@ -817,7 +828,7 @@
     return Tuple<T, bool>::with(r.value, r.overflow);                         \
   }                                                                           \
                                                                               \
-  /** Calculates self - rhs                                                   \
+  /** Calculates self - rhs with an unsigned rhs.                             \
    *                                                                          \
    * Returns a tuple of the subtraction along with a boolean indicating       \
    * whether an arithmetic overflow would occur. If an overflow would have    \
@@ -836,6 +847,17 @@
     return __private::saturating_sub(primitive_value, rhs.primitive_value);   \
   }                                                                           \
                                                                               \
+  /** Saturating integer subtraction with an unsigned rhs. Computes self -    \
+   * rhs, saturating at the numeric bounds instead of overflowing.            \
+   */                                                                         \
+  constexpr T saturating_sub_unsigned(const UnsignedT& rhs) const& {          \
+    auto r = __private::sub_with_overflow_unsigned(primitive_value, rhs);     \
+    if (!r.overflow) [[likely]]                                               \
+      return r.value;                                                         \
+    else                                                                      \
+      return MIN();                                                           \
+  }                                                                           \
+                                                                              \
   /** Unchecked integer subtraction. Computes self - rhs, assuming overflow   \
    * cannot occur.                                                            \
    */                                                                         \
@@ -849,6 +871,13 @@
    */                                                                         \
   constexpr T wrapping_sub(const T& rhs) const& {                             \
     return __private::wrapping_sub(primitive_value, rhs.primitive_value);     \
+  }                                                                           \
+                                                                              \
+  /** Wrapping (modular) subtraction with an unsigned rhs. Computes self -    \
+   * rhs, wrapping around at the boundary of the type.                        \
+   */                                                                         \
+  constexpr T wrapping_sub_unsigned(const UnsignedT& rhs) const& {            \
+    return __private::sub_with_overflow_unsigned(primitive_value, rhs).value; \
   }                                                                           \
   static_assert(true)
 

--- a/num/__private/signed_integer_macros.h
+++ b/num/__private/signed_integer_macros.h
@@ -390,6 +390,19 @@
       return Option<T>::none();                                                \
   }                                                                            \
                                                                                \
+  /** Checked integer addition with an unsigned rhs. Computes self + rhs,      \
+   * returning None if overflow occurred.                                      \
+   */                                                                          \
+  constexpr Option<T> checked_add_unsigned(const UnsignedT& rhs)               \
+      const& noexcept {                                                        \
+    const auto out =                                                           \
+        __private::add_with_overflow_unsigned(primitive_value, rhs);           \
+    if (!out.overflow) [[likely]]                                              \
+      return Option<T>::some(out.value);                                       \
+    else                                                                       \
+      return Option<T>::none();                                                \
+  }                                                                            \
+                                                                               \
   /** Calculates self + rhs                                                    \
    *                                                                           \
    * Returns a tuple of the addition along with a boolean indicating whether   \
@@ -422,6 +435,18 @@
     return __private::saturating_add(primitive_value, rhs.primitive_value);    \
   }                                                                            \
                                                                                \
+  /** Saturating integer addition with an unsigned rhs. Computes self + rhs,   \
+   * saturating at the numeric bounds instead of overflowing.                  \
+   */                                                                          \
+  constexpr T saturating_add_unsigned(const UnsignedT& rhs) const& noexcept {  \
+    const auto r =                                                             \
+        __private::add_with_overflow_unsigned(primitive_value, rhs);           \
+    if (!r.overflow) [[likely]]                                                \
+      return r.value;                                                          \
+    else                                                                       \
+      return MAX();                                                            \
+  }                                                                            \
+                                                                               \
   /** Unchecked integer addition. Computes self + rhs, assuming overflow       \
    * cannot occur.                                                             \
    *                                                                           \
@@ -439,6 +464,13 @@
    */                                                                          \
   constexpr T wrapping_add(const T& rhs) const& noexcept {                     \
     return __private::wrapping_add(primitive_value, rhs.primitive_value);      \
+  }                                                                            \
+                                                                               \
+  /** Wrapping (modular) addition with an unsigned rhs. Computes self + rhs,   \
+   * wrapping around at the boundary of the type.                              \
+   */                                                                          \
+  constexpr T wrapping_add_unsigned(const UnsignedT& rhs) const& noexcept {    \
+    return __private::add_with_overflow_unsigned(primitive_value, rhs).value;  \
   }                                                                            \
   static_assert(true)
 

--- a/num/i32_unittest.cc
+++ b/num/i32_unittest.cc
@@ -1216,25 +1216,6 @@ TEST(i32, OverflowingSub) {
             (Tuple<i32, bool>::with(i32::MIN(), true)));
 }
 
-// ** Signed only.
-TEST(i32, OverflowingSubUnsigned) {
-  [[maybe_unused]] constexpr auto a = (-1_i32).overflowing_sub_unsigned(3u);
-
-  EXPECT_EQ((1_i32).overflowing_sub_unsigned(2u),
-            (Tuple<i32, bool>::with(-1_i32, false)));
-  EXPECT_EQ(
-      (i32::MAX()).overflowing_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
-      (Tuple<i32, bool>::with(i32::MIN(), false)));
-  EXPECT_EQ((i32::MAX() - 1_i32)
-                .overflowing_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
-            (Tuple<i32, bool>::with(i32::MAX(), true)));
-  EXPECT_EQ((i32::MAX() - 1_i32)
-                .overflowing_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
-            (Tuple<i32, bool>::with(i32::MIN(), false)));
-  EXPECT_EQ((i32::MIN() + 2_i32).overflowing_sub_unsigned(3u),
-            (Tuple<i32, bool>::with(i32::MAX(), true)));
-}
-
 TEST(i32, SaturatingSub) {
   constexpr auto a = (5_i32).saturating_sub(3_i32);
   EXPECT_EQ(a, 2_i32);
@@ -1949,6 +1930,78 @@ TEST(i32, WrappingAddUnsigned) {
                 .wrapping_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
             i32::MAX());
   EXPECT_EQ((i32::MAX() - 2_i32).wrapping_add_unsigned(3u), i32::MIN());
+}
+
+// ** Signed only.
+TEST(i32, CheckedSubUnsigned) {
+  constexpr auto a = (1_i32).checked_sub_unsigned(3u);
+  EXPECT_EQ(a, Option<i32>::some(-2_i32));
+
+  EXPECT_EQ((-1_i32).checked_sub_unsigned(2u), Option<i32>::some(-3_i32));
+  EXPECT_EQ((i32::MAX()).checked_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            Option<i32>::some(i32::MIN()));
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .checked_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            None);
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .checked_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            Option<i32>::some(i32::MIN()));
+  EXPECT_EQ((i32::MIN() + 2_i32).checked_sub_unsigned(3u), None);
+}
+
+// ** Signed only.
+TEST(i32, OverflowingSubUnsigned) {
+  constexpr auto a = (1_i32).overflowing_sub_unsigned(3u);
+  EXPECT_EQ(a, (Tuple<i32, bool>::with(-2_i32, false)));
+
+  EXPECT_EQ((-1_i32).overflowing_sub_unsigned(2u),
+            (Tuple<i32, bool>::with(-3_i32, false)));
+  EXPECT_EQ(
+      (i32::MAX()).overflowing_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+      (Tuple<i32, bool>::with(i32::MIN(), false)));
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .overflowing_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            (Tuple<i32, bool>::with(i32::MAX(), true)));
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .overflowing_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            (Tuple<i32, bool>::with(i32::MIN(), false)));
+  EXPECT_EQ((i32::MIN() + 2_i32).overflowing_sub_unsigned(3u),
+            (Tuple<i32, bool>::with(i32::MAX(), true)));
+}
+
+// ** Signed only.
+TEST(i32, SaturatingSubUnsigned) {
+  constexpr auto a = (1_i32).saturating_sub_unsigned(3u);
+  EXPECT_EQ(a, -2_i32);
+
+  EXPECT_EQ((-1_i32).saturating_sub_unsigned(2u), -3_i32);
+  EXPECT_EQ(
+      (i32::MAX()).saturating_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+      i32::MIN());
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .saturating_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            i32::MIN());
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .saturating_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            i32::MIN());
+  EXPECT_EQ((i32::MIN() + 2_i32).saturating_sub_unsigned(3u), i32::MIN());
+}
+
+// ** Signed only.
+TEST(i32, WrappingSubUnsigned) {
+  constexpr auto a = (1_i32).wrapping_sub_unsigned(3u);
+  EXPECT_EQ(a, -2_i32);
+
+  EXPECT_EQ((-1_i32).wrapping_sub_unsigned(2u), -3_i32);
+  EXPECT_EQ((i32::MAX()).wrapping_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            i32::MIN());
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .wrapping_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            i32::MAX());
+  EXPECT_EQ((i32::MAX() - 1_i32)
+                .wrapping_sub_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            i32::MIN());
+  EXPECT_EQ((i32::MIN() + 2_i32).wrapping_sub_unsigned(3u), i32::MAX());
 }
 
 TEST(i32, From) {

--- a/num/i32_unittest.cc
+++ b/num/i32_unittest.cc
@@ -413,26 +413,6 @@ TEST(i32, OverflowingAdd) {
             (Tuple<i32, bool>::with(0_i32, true)));
 }
 
-// ** Signed only.
-TEST(i32, OverflowingAddUnsigned) {
-  constexpr auto a = (1_i32).overflowing_add_unsigned(3u);
-  EXPECT_EQ(a, (Tuple<i32, bool>::with(4_i32, false)));
-
-  EXPECT_EQ((-1_i32).overflowing_add_unsigned(2u),
-            (Tuple<i32, bool>::with(1_i32, false)));
-  EXPECT_EQ(
-      (i32::MIN()).overflowing_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
-      (Tuple<i32, bool>::with(i32::MAX(), false)));
-  EXPECT_EQ((i32::MIN() + 1_i32)
-                .overflowing_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
-            (Tuple<i32, bool>::with(i32::MIN(), true)));
-  EXPECT_EQ((i32::MIN() + 1_i32)
-                .overflowing_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
-            (Tuple<i32, bool>::with(i32::MAX(), false)));
-  EXPECT_EQ((i32::MAX() - 2_i32).overflowing_add_unsigned(3u),
-            (Tuple<i32, bool>::with(i32::MIN(), true)));
-}
-
 TEST(i32, SaturatingAdd) {
   constexpr auto a = (1_i32).saturating_add(3_i32);
   EXPECT_EQ(a, 4_i32);
@@ -1897,6 +1877,78 @@ TEST(i32, ToNeBytes) {
       EXPECT_EQ(a.get(3), 0x12);
     }
   }
+}
+
+// ** Signed only.
+TEST(i32, CheckedAddUnsigned) {
+  constexpr auto a = (1_i32).checked_add_unsigned(3u);
+  EXPECT_EQ(a, Option<i32>::some(4_i32));
+
+  EXPECT_EQ((-1_i32).checked_add_unsigned(2u), Option<i32>::some(1_i32));
+  EXPECT_EQ((i32::MIN()).checked_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            Option<i32>::some(i32::MAX()));
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .checked_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            None);
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .checked_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            Option<i32>::some(i32::MAX()));
+  EXPECT_EQ((i32::MAX() - 2_i32).checked_add_unsigned(3u), None);
+}
+
+// ** Signed only.
+TEST(i32, OverflowingAddUnsigned) {
+  constexpr auto a = (1_i32).overflowing_add_unsigned(3u);
+  EXPECT_EQ(a, (Tuple<i32, bool>::with(4_i32, false)));
+
+  EXPECT_EQ((-1_i32).overflowing_add_unsigned(2u),
+            (Tuple<i32, bool>::with(1_i32, false)));
+  EXPECT_EQ(
+      (i32::MIN()).overflowing_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+      (Tuple<i32, bool>::with(i32::MAX(), false)));
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .overflowing_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            (Tuple<i32, bool>::with(i32::MIN(), true)));
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .overflowing_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            (Tuple<i32, bool>::with(i32::MAX(), false)));
+  EXPECT_EQ((i32::MAX() - 2_i32).overflowing_add_unsigned(3u),
+            (Tuple<i32, bool>::with(i32::MIN(), true)));
+}
+
+// ** Signed only.
+TEST(i32, SaturatingAddUnsigned) {
+  constexpr auto a = (1_i32).saturating_add_unsigned(3u);
+  EXPECT_EQ(a, 4_i32);
+
+  EXPECT_EQ((-1_i32).saturating_add_unsigned(2u), 1_i32);
+  EXPECT_EQ(
+      (i32::MIN()).saturating_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+      i32::MAX());
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .saturating_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            i32::MAX());
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .saturating_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            i32::MAX());
+  EXPECT_EQ((i32::MAX() - 2_i32).saturating_add_unsigned(3u), i32::MAX());
+}
+
+// ** Signed only.
+TEST(i32, WrappingAddUnsigned) {
+  constexpr auto a = (1_i32).wrapping_add_unsigned(3u);
+  EXPECT_EQ(a, 4_i32);
+
+  EXPECT_EQ((-1_i32).wrapping_add_unsigned(2u), 1_i32);
+  EXPECT_EQ((i32::MIN()).wrapping_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            i32::MAX());
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .wrapping_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX),
+            i32::MIN());
+  EXPECT_EQ((i32::MIN() + 1_i32)
+                .wrapping_add_unsigned(/* TODO: u32::MAX() */ UINT_MAX - 1),
+            i32::MAX());
+  EXPECT_EQ((i32::MAX() - 2_i32).wrapping_add_unsigned(3u), i32::MIN());
 }
 
 TEST(i32, From) {

--- a/num/u32.h
+++ b/num/u32.h
@@ -77,7 +77,6 @@ struct u32 {
   // TODO: checked_next_multiple_of().
   // TODO: from_str_radix(). Need Result type and Errors.
   // TODO: next_power_of_two().
-  // TODO: checked_add_signed() and friends?
 
   /// The inner primitive value, in case it needs to be unwrapped from the
   /// type. Avoid using this member except to convert when a consumer

--- a/num/u32.h
+++ b/num/u32.h
@@ -63,7 +63,8 @@ struct u32 {
   // u32_defn.h and u32_impl.h, allowing most of the library to just use
   // u32_defn.h which will keep headers smaller.
   _sus__unsigned_constants(u32, 0xFFFFFFFF);
-  _sus__unsigned_impl(u32, sizeof(primitive_type), /*LargerT=*/uint64_t);
+  _sus__unsigned_impl(u32, sizeof(primitive_type), /*SignedT=*/i32,
+                      /*LargerT=*/uint64_t);
 
   // TODO: overflowing_div_euclid().
   // TODO: overflowing_rem_euclid().

--- a/num/u32_unittest.cc
+++ b/num/u32_unittest.cc
@@ -18,8 +18,8 @@
 
 #include "concepts/into.h"
 #include "concepts/make_default.h"
-#include "num/i32.h"
 #include "mem/__private/relocate.h"
+#include "num/i32.h"
 #include "num/num_concepts.h"
 #include "option/option.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
@@ -1217,6 +1217,57 @@ TEST(u32, ToNeBytes) {
       EXPECT_EQ(a.get(3), 0x12);
     }
   }
+}
+
+// ** Unsigned only.
+TEST(u32, CheckedAddSigned) {
+  constexpr auto a = (1_u32).checked_add_signed(3_i32);
+  EXPECT_EQ(a, Option<u32>::some(4_u32));
+
+  EXPECT_EQ((1_u32).checked_add_signed(2_i32), Option<u32>::some(3_u32));
+  EXPECT_EQ((u32::MIN() + 1_u32).checked_add_signed(-1_i32),
+            Option<u32>::some(u32::MIN()));
+  EXPECT_EQ((u32::MIN()).checked_add_signed(-1_i32), None);
+  EXPECT_EQ((u32::MAX() - 2_u32).checked_add_signed(3_i32), None);
+}
+
+// ** Unsigned only.
+TEST(u32, OverflowingAddSigned) {
+  constexpr auto a = (1_u32).overflowing_add_signed(3_i32);
+  EXPECT_EQ(a, (Tuple<u32, bool>::with(4_u32, false)));
+
+  EXPECT_EQ((1_u32).overflowing_add_signed(2_i32),
+            (Tuple<u32, bool>::with(3_u32, false)));
+  EXPECT_EQ((u32::MIN() + 1_u32).overflowing_add_signed(-1_i32),
+            (Tuple<u32, bool>::with(u32::MIN(), false)));
+  EXPECT_EQ((u32::MIN()).overflowing_add_signed(-1_i32),
+            (Tuple<u32, bool>::with(u32::MAX(), true)));
+  EXPECT_EQ((u32::MAX() - 2_u32).overflowing_add_signed(3_i32),
+            (Tuple<u32, bool>::with(u32::MIN(), true)));
+}
+
+// ** Unsigned only.
+TEST(u32, SaturatingAddSigned) {
+  constexpr auto a = (1_u32).saturating_add_signed(3_i32);
+  EXPECT_EQ(a, 4_u32);
+
+  EXPECT_EQ((1_u32).saturating_add_signed(2_i32), 3_u32);
+  EXPECT_EQ((u32::MIN() + 1_u32).saturating_add_signed(-1_i32),
+            u32::MIN());
+  EXPECT_EQ((u32::MIN()).saturating_add_signed(-1_i32), u32::MIN());
+  EXPECT_EQ((u32::MAX() - 2_u32).saturating_add_signed(3_i32), u32::MAX());
+}
+
+// ** Unsigned only.
+TEST(u32, WrappingAddSigned) {
+  constexpr auto a = (1_u32).wrapping_add_signed(3_i32);
+  EXPECT_EQ(a, 4_u32);
+
+  EXPECT_EQ((1_u32).wrapping_add_signed(2_i32), 3_u32);
+  EXPECT_EQ((u32::MIN() + 1_u32).wrapping_add_signed(-1_i32),
+            u32::MIN());
+  EXPECT_EQ((u32::MIN()).wrapping_add_signed(-1_i32), u32::MAX());
+  EXPECT_EQ((u32::MAX() - 2_u32).wrapping_add_signed(3_i32), u32::MIN());
 }
 
 TEST(u32, From) {


### PR DESCRIPTION
Based on Rust feature mixed_integer_ops: https://github.com/rust-lang/rust/issues/87840

Allows:
- adding a signed value to an unsigned one
- adding an unsigned value to a signed one
- subtracting an unsigned value from a signed one