### PR TITLE
Use move() instead of static_cast, add a Moveable concept

### DIFF
--- a/containers/array.h
+++ b/containers/array.h
@@ -22,6 +22,7 @@
 #include "assertions/check.h"
 #include "construct/make_default.h"
 #include "marker/unsafe.h"
+#include "mem/move.h"
 #include "mem/relocate.h"
 
 namespace sus::containers {
@@ -68,7 +69,7 @@ class Array final {
 
   template <class InitializerFn>
   constexpr static Array with_initializer(InitializerFn f) noexcept {
-    return Array(kWithInitializer, static_cast<decltype(f)&&>(f),
+    return Array(kWithInitializer, ::sus::move(f),
                  std::make_index_sequence<N>());
   }
 

--- a/fn/callable.h
+++ b/fn/callable.h
@@ -39,12 +39,12 @@ concept FunctionPointerReturns = (
 namespace __private {
 
 template <class T, class R, class... Args>
-inline constexpr bool lambda_callable_const(R (T::*)(Args...) const) {
+inline constexpr bool callable_const(R (T::*)(Args...) const) {
   return true;
 };
 
 template <class T, class R, class... Args>
-inline constexpr bool lambda_callable_mut(R (T::*)(Args...)) {
+inline constexpr bool callable_mut(R (T::*)(Args...)) {
   return true;
 };
 
@@ -52,7 +52,7 @@ inline constexpr bool lambda_callable_mut(R (T::*)(Args...)) {
 
 // clang-format off
 template <class T, class R, class... Args>
-concept LambdaReturnsConst = (
+concept CallableObjectReturnsConst = (
     !FunctionPointerReturns<T, R, Args...> &&
     requires (const T& t, Args&&... args) {
         { t(forward<Args>(args)...) } -> std::convertible_to<R>;
@@ -60,7 +60,7 @@ concept LambdaReturnsConst = (
 );
 
 template <class T, class R, class... Args>
-concept LambdaReturnsMut = (
+concept CallableObjectReturnsMut = (
     !FunctionPointer<T> &&
     requires (T& t, Args&&... args) {
         { t(forward<Args>(args)...) } -> std::convertible_to<R>;
@@ -69,14 +69,14 @@ concept LambdaReturnsMut = (
 // clang-format on
 
 template <class T, class R, class... Args>
-concept LambdaReturns =
-    LambdaReturnsConst<T, R, Args...> || LambdaReturnsMut<T, R, Args...>;
+concept CallableObjectReturns = CallableObjectReturnsConst<T, R, Args...> ||
+                                CallableObjectReturnsMut<T, R, Args...>;
 
 template <class T>
-concept LambdaConst = __private::lambda_callable_const(&T::operator());
+concept CallableObjectConst = __private::callable_const(&T::operator());
 
 template <class T>
-concept LambdaMut = LambdaConst<T> ||
-                    __private::lambda_callable_mut(&T::operator());
+concept CallableObjectMut = CallableObjectConst<T> ||
+                            __private::callable_mut(&T::operator());
 
 }  // namespace sus::fn::callable

--- a/fn/fn_bind.h
+++ b/fn/fn_bind.h
@@ -64,9 +64,9 @@
                       _sus__unpack names)]<class... Args>(Args&&... args) {   \
           const auto x = lambda __VA_OPT__(, ) __VA_ARGS__;                   \
           const bool is_const =                                               \
-              ::sus::fn::callable::LambdaConst<decltype(x)>;            \
+              ::sus::fn::callable::CallableObjectConst<decltype(x)>;            \
           if constexpr (!is_const) {                                          \
-            return ::sus::fn::__private::CheckLambdaConst<                    \
+            return ::sus::fn::__private::CheckCallableObjectConst<                    \
                 is_const>::template error<void>();                            \
           } else {                                                            \
             return x(::sus::forward<Args>(args)...);                          \
@@ -228,13 +228,13 @@ std::false_type is_lvalue(...);
 /// represents the constness of the lambda. When false, the error() function
 /// generates a compiler error.
 template <bool = true>
-struct CheckLambdaConst final {
+struct CheckCallableObjectConst final {
   template <class U>
   static constexpr inline auto error() {}
 };
 
 template <>
-struct CheckLambdaConst<false> final {
+struct CheckCallableObjectConst<false> final {
   template <class U>
   static consteval inline auto error() {
     throw "Use sus_bind_mut() to bind a mutable lambda";

--- a/fn/fn_bind.h
+++ b/fn/fn_bind.h
@@ -22,6 +22,7 @@
 #include "macros/remove_parens.h"
 #include "marker/unsafe.h"
 #include "mem/forward.h"
+#include "mem/move.h"
 
 /// Bind a const lambda to storage for its bound arguments. The output can be
 /// used to construct a FnOnce, FnMut, or Fn.
@@ -259,7 +260,7 @@ struct CheckLambdaConst<false> final {
                 "sus_bind() can only bind to variable names (lvalues).");
 
 #define _sus__bind_noop(x) x
-#define _sus__bind_move(x) static_cast<decltype(x)&&>(x)
+#define _sus__bind_move(x) ::sus::move(x)
 #define _sus__bind_pointer(x) \
   ::sus::fn::__private::UnsafePointer(::sus::marker::unsafe_fn, x)
 #define _sus__macro(x, ...) x(__VA_ARGS__)

--- a/fn/fn_defn.h
+++ b/fn/fn_defn.h
@@ -135,7 +135,7 @@ class [[sus_trivial_abi]] FnOnce<R(CallArgs...)> {
   FnOnce(F ptr) noexcept;
 
   /// Construction from the output of `sus_bind()`.
-  template <::sus::fn::callable::LambdaReturns<R, CallArgs...> F>
+  template <::sus::fn::callable::CallableObjectReturns<R, CallArgs...> F>
   FnOnce(__private::SusBind<F>&& holder) noexcept
       : FnOnce(__private::StorageConstructionFnOnce,
                static_cast<F&&>(holder.lambda)) {}
@@ -163,14 +163,14 @@ class [[sus_trivial_abi]] FnOnce<R(CallArgs...)> {
   }
   /// `sus::construct::From` trait implementation for the output of
   /// `sus_bind()`.
-  template <::sus::fn::callable::LambdaReturns<R, CallArgs...> F>
+  template <::sus::fn::callable::CallableObjectReturns<R, CallArgs...> F>
   constexpr static auto from(__private::SusBind<F>&& holder) noexcept {
     return FnOnce(static_cast<__private::SusBind<F>&&>(holder));
   }
 
  protected:
   template <class ConstructionType,
-            ::sus::fn::callable::LambdaReturns<R, CallArgs...> F>
+            ::sus::fn::callable::CallableObjectReturns<R, CallArgs...> F>
   FnOnce(ConstructionType, F&& lambda) noexcept;
 
   // Functions to construct and return a pointer to a static vtable object for
@@ -279,7 +279,7 @@ class [[sus_trivial_abi]] FnMut<R(CallArgs...)>
   FnMut(F ptr) noexcept : FnOnce<R(CallArgs...)>(static_cast<F&&>(ptr)) {}
 
   /// Construction from the output of `sus_bind()`.
-  template <::sus::fn::callable::LambdaReturns<R, CallArgs...> F>
+  template <::sus::fn::callable::CallableObjectReturns<R, CallArgs...> F>
   FnMut(__private::SusBind<F>&& holder) noexcept
       : FnOnce<R(CallArgs...)>(__private::StorageConstructionFnMut,
                                static_cast<F&&>(holder.lambda)) {}
@@ -317,7 +317,7 @@ class [[sus_trivial_abi]] FnMut<R(CallArgs...)>
   }
   /// `sus::construct::From` trait implementation for the output of
   /// `sus_bind()`.
-  template <::sus::fn::callable::LambdaReturns<R, CallArgs...> F>
+  template <::sus::fn::callable::CallableObjectReturns<R, CallArgs...> F>
   constexpr static auto from(__private::SusBind<F>&& holder) noexcept {
     return FnMut(static_cast<__private::SusBind<F>&&>(holder));
   }
@@ -328,7 +328,7 @@ class [[sus_trivial_abi]] FnMut<R(CallArgs...)>
   // would slice that off.
 
   template <class ConstructionType,
-            ::sus::fn::callable::LambdaReturns<R, CallArgs...> F>
+            ::sus::fn::callable::CallableObjectReturns<R, CallArgs...> F>
   FnMut(ConstructionType c, F&& lambda) noexcept
       : FnOnce<R(CallArgs...)>(c, static_cast<F&&>(lambda)) {}
 
@@ -405,7 +405,7 @@ class [[sus_trivial_abi]] Fn<R(CallArgs...)> final
   Fn(F ptr) noexcept : FnMut<R(CallArgs...)>(static_cast<F&&>(ptr)) {}
 
   /// Construction from the output of `sus_bind()`.
-  template <::sus::fn::callable::LambdaReturnsConst<R, CallArgs...> F>
+  template <::sus::fn::callable::CallableObjectReturnsConst<R, CallArgs...> F>
   Fn(__private::SusBind<F>&& holder) noexcept
       : FnMut<R(CallArgs...)>(__private::StorageConstructionFn,
                               static_cast<F&&>(holder.lambda)) {}
@@ -443,7 +443,7 @@ class [[sus_trivial_abi]] Fn<R(CallArgs...)> final
   }
   /// `sus::construct::From` trait implementation for the output of
   /// `sus_bind()`.
-  template <::sus::fn::callable::LambdaReturnsConst<R, CallArgs...> F>
+  template <::sus::fn::callable::CallableObjectReturnsConst<R, CallArgs...> F>
   constexpr static auto from(__private::SusBind<F>&& holder) noexcept {
     return Fn(static_cast<__private::SusBind<F>&&>(holder));
   }
@@ -453,7 +453,7 @@ class [[sus_trivial_abi]] Fn<R(CallArgs...)> final
   // do anything in its destructor, as `FnOnce` moves from itself, and it
   // would slice that off.
 
-  template <::sus::fn::callable::LambdaReturnsConst<R, CallArgs...> F>
+  template <::sus::fn::callable::CallableObjectReturnsConst<R, CallArgs...> F>
   Fn(__private::StorageConstructionFnType, F&& fn) noexcept;
 
  private:

--- a/fn/fn_impl.h
+++ b/fn/fn_impl.h
@@ -31,7 +31,7 @@ FnOnce<R(CallArgs...)>::FnOnce(F ptr) noexcept
 
 template <class R, class... CallArgs>
 template <class ConstructionType,
-          ::sus::fn::callable::LambdaReturns<R, CallArgs...> F>
+          ::sus::fn::callable::CallableObjectReturns<R, CallArgs...> F>
 FnOnce<R(CallArgs...)>::FnOnce(ConstructionType construction,
                                F&& lambda) noexcept
     : type_(__private::Storage) {

--- a/iter/filter.h
+++ b/iter/filter.h
@@ -18,13 +18,14 @@
 #include "iter/iterator_defn.h"
 #include "iter/sized_iterator.h"
 #include "mem/__private/relocatable_storage.h"
+#include "mem/move.h"
 #include "mem/relocate.h"
 
 namespace sus::iter {
 
 using ::sus::iter::IteratorBase;
-using ::sus::mem::__private::RelocatableStorage;
 using ::sus::mem::relocate_one_by_memcpy;
+using ::sus::mem::__private::RelocatableStorage;
 
 template <class Item, size_t InnerIterSize, size_t InnerIterAlign>
 class Filter : public IteratorBase<Item> {
@@ -57,9 +58,8 @@ class Filter : public IteratorBase<Item> {
 
  protected:
   Filter(Pred&& pred, InnerSizedIter&& next_iter)
-      : data_(Option<Data>::some(Data{
-            .pred_ = static_cast<decltype(pred)&&>(pred),
-            .next_iter_ = static_cast<decltype(next_iter)&&>(next_iter)})) {}
+      : data_(Option<Data>::some(Data{.pred_ = ::sus::move(pred),
+                                      .next_iter_ = ::sus::move(next_iter)})) {}
 
  private:
   RelocatableStorage<Data> data_;

--- a/iter/once.h
+++ b/iter/once.h
@@ -14,14 +14,15 @@
 
 #pragma once
 
-#include "mem/__private/relocatable_storage.h"
 #include "iter/iterator_defn.h"
+#include "mem/__private/relocatable_storage.h"
+#include "mem/move.h"
 
 namespace sus::iter {
 
+using ::sus::iter::IteratorBase;
 using ::sus::mem::__private::RelocatableStorage;
 using ::sus::option::Option;
-using ::sus::iter::IteratorBase;
 
 /// An IteratorBase implementation that walks over at most a single Item.
 template <class Item>
@@ -30,8 +31,7 @@ class [[sus_trivial_abi]] Once : public IteratorBase<Item> {
   Option<Item> next() noexcept final { return single_.take(); }
 
  protected:
-  Once(Option<Item>&& single)
-      : single_(static_cast<decltype(single)&&>(single)) {}
+  Once(Option<Item>&& single) : single_(::sus::move(single)) {}
 
  private:
   RelocatableStorage<Item> single_;
@@ -43,7 +43,7 @@ template <class Item>
 inline Once<Item> once(Option<Item>&& single)
   requires(std::is_move_constructible_v<Item>)
 {
-  return Once(static_cast<decltype(single)&&>(single));
+  return Once(::sus::move(single));
 }
 
 }  // namespace sus::iter

--- a/iter/sized_iterator.h
+++ b/iter/sized_iterator.h
@@ -41,7 +41,7 @@ struct SizedIterator final {
   void (*destroy)(char& sized);
 };
 
-template <class IteratorSubclass, int&...,
+template <::sus::mem::Moveable IteratorSubclass, int&...,
           class SubclassItem = typename IteratorSubclass::Item,
           class SizedIteratorType =
               SizedIterator<SubclassItem, sizeof(IteratorSubclass),
@@ -51,12 +51,11 @@ inline SizedIteratorType make_sized_iterator(IteratorSubclass&& subclass)
   requires(
       std::is_convertible_v<IteratorSubclass&, IteratorBase<SubclassItem>&>)
 {
-  static_assert(
-      ::sus::mem::relocate_one_by_memcpy<IteratorSubclass>);
+  static_assert(::sus::mem::relocate_one_by_memcpy<IteratorSubclass>);
   auto it = SizedIteratorType([](char& sized) {
     reinterpret_cast<IteratorSubclass&>(sized).~IteratorSubclass();
   });
-  new (it.sized) IteratorSubclass(static_cast<decltype(subclass)&&>(subclass));
+  new (it.sized) IteratorSubclass(::sus::move(subclass));
   return it;
 }
 

--- a/mem/__private/relocatable_storage.h
+++ b/mem/__private/relocatable_storage.h
@@ -14,8 +14,9 @@
 
 #pragma once
 
-#include "mem/relocate.h"
+#include "mem/move.h"
 #include "mem/mref.h"
+#include "mem/relocate.h"
 #include "option/option.h"
 
 namespace sus::mem::__private {
@@ -27,7 +28,7 @@ template <class T>
   requires(!::sus::mem::relocate_one_by_memcpy<T>)
 struct [[sus_trivial_abi]] RelocatableStorage<T> final {
   RelocatableStorage(Option<T>&& t)
-      : heap_(static_cast<decltype(t)&&>(t).and_then([](T&& t) {
+      : heap_(::sus::move(t).and_then([](T&& t) {
           return Option<T&>::some(mref(*new T(static_cast<T&&>(t))));
         })) {}
 
@@ -69,7 +70,7 @@ struct [[sus_trivial_abi]] RelocatableStorage<T> final {
 template <class T>
   requires(::sus::mem::relocate_one_by_memcpy<T>)
 struct [[sus_trivial_abi]] RelocatableStorage<T> final {
-  RelocatableStorage(Option<T>&& t) : stack_(static_cast<decltype(t)&&>(t)) {}
+  RelocatableStorage(Option<T>&& t) : stack_(::sus::move(t)) {}
 
   // TODO: Do memcpy instead of take() when not in a constexpr context.
   RelocatableStorage(RelocatableStorage&& o) : stack_(o.stack_.take()) {}

--- a/mem/move.h
+++ b/mem/move.h
@@ -21,6 +21,14 @@
 namespace sus::mem {
 
 template <class T>
+concept Moveable = (!std::is_const_v<std::remove_reference_t<T>> &&
+                    std::is_move_constructible_v<T>);
+
+template <class T>
+concept MoveableForAssign = (!std::is_const_v<std::remove_reference_t<T>> &&
+                             std::is_move_assignable_v<T>);
+
+template <class T>
   requires(!std::is_const_v<std::remove_reference_t<T>>)
 sus_always_inline constexpr std::remove_reference_t<T>&& move(T&& t) noexcept {
   return static_cast<typename std::remove_reference_t<T>&&>(t);

--- a/mem/move.h
+++ b/mem/move.h
@@ -49,6 +49,8 @@ concept MoveableForAssign = (NonConstObject<T> && std::is_move_assignable_v<T>);
 ///
 /// The `move()` call itself does nothing to `t`, as it is just a cast, similar
 /// to `std::move()`. It enables an lvalue object to be used as an rvalue.
+//
+// TODO: Should this be `as_rvalue()`? Kinda technical. `as_...something...()`?
 template <NonConstObject T>
 sus_always_inline constexpr std::remove_reference_t<T>&& move(T&& t) noexcept {
   return static_cast<typename std::remove_reference_t<T>&&>(t);

--- a/mem/move_unittest.cc
+++ b/mem/move_unittest.cc
@@ -19,6 +19,8 @@
 namespace {
 
 using sus::move;
+using sus::mem::Moveable;
+using sus::mem::MoveableForAssign;
 
 template <class T>
 concept can_move = requires(T &&t) {
@@ -31,7 +33,19 @@ static_assert(can_move<int &&>);
 static_assert(!can_move<const int &>);
 static_assert(!can_move<const int &&>);
 
-void bind_rvalue(int&&) {}
+static_assert(Moveable<int>);
+static_assert(Moveable<int &>);
+static_assert(Moveable<int &&>);
+static_assert(!Moveable<const int &>);
+static_assert(!Moveable<const int &&>);
+
+static_assert(MoveableForAssign<int>);
+static_assert(MoveableForAssign<int &>);
+static_assert(MoveableForAssign<int &&>);
+static_assert(!MoveableForAssign<const int &>);
+static_assert(!MoveableForAssign<const int &&>);
+
+void bind_rvalue(int &&) {}
 void bind_value(int) {}
 
 TEST(Move, Binds) {
@@ -44,12 +58,15 @@ TEST(Move, Binds) {
 
 struct MoveOnly {
   MoveOnly() = default;
-  MoveOnly(MoveOnly&&) = default;
+  MoveOnly(MoveOnly &&) = default;
 };
 
-void bind_rvalue(MoveOnly&&) {}
+static_assert(Moveable<MoveOnly>);
+static_assert(!MoveableForAssign<MoveOnly>);
+
+void bind_rvalue(MoveOnly &&) {}
 void bind_value(MoveOnly) {}
-void bind_const(const MoveOnly&) {}
+void bind_const(const MoveOnly &) {}
 
 TEST(Move, MoveOnly) {
   MoveOnly m;
@@ -58,5 +75,14 @@ TEST(Move, MoveOnly) {
   bind_value(move(m));
   bind_value(move(MoveOnly()));
 }
+
+struct MoveOnlyWithAssign {
+  MoveOnlyWithAssign() = default;
+  MoveOnlyWithAssign(MoveOnlyWithAssign &&) = default;
+  MoveOnlyWithAssign& operator=(MoveOnlyWithAssign &&) = default;
+};
+
+static_assert(Moveable<MoveOnlyWithAssign>);
+static_assert(MoveableForAssign<MoveOnlyWithAssign>);
 
 }  // namespace

--- a/option/option.h
+++ b/option/option.h
@@ -297,7 +297,7 @@ class Option final {
   /// auto x = Option<int>::some(2);
   /// switch (x) {
   ///  case Some:
-  ///   return static_cast<decltype(x)&&>(x).unwrap_unchecked(unsafe_fn);
+  ///   return sus::move(x).unwrap_unchecked(unsafe_fn);
   ///  case None:
   ///   return -1;
   /// }
@@ -768,7 +768,7 @@ class Option<T&> final {
   /// auto x = Option<int>::some(2);
   /// switch (x) {
   ///  case Some:
-  ///   return static_cast<decltype(x)&&>(x).unwrap_unchecked(unsafe_fn);
+  ///   return sus::move(x).unwrap_unchecked(unsafe_fn);
   ///  case None:
   ///   return -1;
   /// }

--- a/tuple/__private/storage.h
+++ b/tuple/__private/storage.h
@@ -18,6 +18,7 @@
 #include <utility>  // TODO: Replace std::index_sequence to remove this header.
 
 #include "mem/forward.h"
+#include "mem/move.h"
 
 namespace sus::tuple::__private {
 
@@ -74,7 +75,7 @@ struct TupleAccess<TupleStorage, 0> final {
   }
 
   static inline constexpr auto&& unwrap(TupleStorage&& tuple) noexcept {
-    return static_cast<decltype(tuple.t)&&>(tuple.t);
+    return sus::move(tuple.t);
   }
 };
 

--- a/tuple/tuple_unittest.cc
+++ b/tuple/tuple_unittest.cc
@@ -18,6 +18,7 @@
 
 #include <concepts>
 
+#include "mem/move.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
 namespace {
@@ -133,16 +134,16 @@ TEST(Tuple, Unwrap) {
 TEST(TupleDeathTest, Moved) {
 #if GTEST_HAS_DEATH_TEST
   auto m1 = Tuple<int>::with(1);
-  static_cast<decltype(m1)&&>(m1).unwrap<0>();
+  sus::move(m1).unwrap<0>();
   EXPECT_DEATH(m1.get<0>(), "");
 
   auto m2 = Tuple<int>::with(1);
-  static_cast<decltype(m2)&&>(m2).unwrap<0>();
+  sus::move(m2).unwrap<0>();
   EXPECT_DEATH(m2.get_mut<0>(), "");
 
   auto m3 = Tuple<int>::with(1);
-  static_cast<decltype(m3)&&>(m3).unwrap<0>();
-  EXPECT_DEATH(static_cast<decltype(m3)&&>(m3).unwrap<0>(), "");
+  sus::move(m3).unwrap<0>();
+  EXPECT_DEATH(sus::move(m3).unwrap<0>(), "");
 #endif
 }
 


### PR DESCRIPTION
The MoveableConcept is different from std::is_move_constructible, it
verifies you can sus::move() it which requires it to be non-const.