### PR TITLE
Flesh out the NonNull type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ add_executable(subspace_unittests
     "mem/move_unittest.cc"
     "mem/mref_unittest.cc"
     "mem/nonnull_unittest.cc"
+    "mem/nonnull_types_unittest.cc"
     "mem/relocate_unittest.cc"
     "mem/replace_unittest.cc"
     "mem/swap_unittest.cc"

--- a/construct/from.h
+++ b/construct/from.h
@@ -21,6 +21,12 @@ namespace sus::construct {
 /// A concept that indicates ToType can be constructed from a FromType, via
 /// `ToType::from(FromType)`.
 ///
+/// This concept is rarely used directly, instead prefer to use the
+/// `sus::construct::Into` concept.
+///
+/// When a type is `From<T, O>`, it is also `Into<O, T>`. Then a variable `o` of
+/// type `O` can be explicitly converted to `T`, with type deduction, via
+/// `sus::into(o)`.
 template <class ToType, class FromType>
 // clang-format off
 concept From = requires (FromType&& from) {

--- a/construct/from_unittest.cc
+++ b/construct/from_unittest.cc
@@ -25,13 +25,12 @@ struct S {};
 struct WithFromInt {
   static auto from(int) { return WithFromInt(); }
 };
-struct NotFromInt {
-};
+struct NotFromInt {};
 struct WithFromS {
   static auto from(S) { return WithFromS(); }
 };
 struct FromReturnsVoid {
-  static auto from(int) {  }
+  static auto from(int) {}
 };
 struct FromReturnsElse {
   static auto from(int i) { return i; }

--- a/mem/nonnull.h
+++ b/mem/nonnull.h
@@ -19,37 +19,132 @@
 #include "marker/unsafe.h"
 #include "mem/addressof.h"
 #include "mem/never_value.h"
+#include "mem/relocate.h"
 
 namespace sus::mem {
 
 /// A pointer wrapper which holds a never-null pointer.
+///
+/// A NonNull can not be implicitly created from an array, as that would throw
+/// away the length information. Explicitly cast to a pointer to use NonNull
+/// with an array.
+///
+/// The NonNull type is trivially copyable and moveable.
+///
+/// TODO: Make a NonNullArray type? https://godbolt.org/z/3vW3xsz5h
 template <class T>
-struct NonNull {
+  requires(!std::is_reference_v<T>)
+struct [[sus_trivial_abi]] NonNull {
+  /// Constructs a `NonNull<T>` from a reference to `T`.
   static constexpr inline NonNull with(T& t) { return NonNull(addressof(t)); }
-  static constexpr inline NonNull with_ptr(T* t) {
+
+  /// Constructs a `NonNull<T>` from a pointer to `T`.
+  ///
+  /// Does not implicitly convert from an array. Explicitly convert it to a
+  /// pointer to throw away the length of the array.
+  ///
+  /// # Panics
+  /// The method will panic if the pointer `t` is null.
+  template <class U>
+    requires(std::is_pointer_v<U> && std::is_convertible_v<U, T*>)
+  static constexpr inline NonNull with_ptr(U t) {
     check(t);
     return NonNull(t);
   }
-  static constexpr inline NonNull with_ptr_unchecked(
-      ::sus::marker::UnsafeFnMarker, T* t) {
-    check(t);
-    return NonNull(*t);
+
+  template <class U, size_t N>
+  static constexpr inline NonNull with_ptr(U (&t)[N]) = delete;
+
+  /// Constructs a `NonNull<T>` from a pointer to `T`.
+  ///
+  /// Does not implicitly convert from an array. Explicitly convert it to a
+  /// pointer to throw away the length of the array.
+  ///
+  /// # Safety
+  /// This method must not be called with a null pointer, or Undefined Behaviour
+  /// results.
+  template <class U>
+    requires(std::is_pointer_v<U> && std::is_convertible_v<U, T*>)
+  static constexpr inline NonNull
+      with_ptr_unchecked(::sus::marker::UnsafeFnMarker,
+                         sus_assertions_nonnull_arg U t)
+          sus_assertions_nonnull_fn {
+    return NonNull(t);
   }
 
-  static constexpr inline NonNull from(T* t) { return with_ptr(t); }
+  template <class U, size_t N>
+  static constexpr inline NonNull with_ptr_unchecked(U (&t)[N]) = delete;
 
+  /// sus::construct::From<NonNull<T>, T&> and
+  /// sus::construct::From<NonNull<const T>, T&> traits.
+  static constexpr inline NonNull from(T& t) { return with(t); }
+
+  /// sus::construct::From<NonNull<T>, T*> and
+  /// sus::construct::From<NonNull<const T>, T*> traits.
+  ///
+  /// Does not implicitly convert from an array. Explicitly convert it to a
+  /// pointer to throw away the length of the array.
+  ///
+  /// # Panics
+  /// The method will panic if the pointer `t` is null.
+  template <class U>
+    requires(std::is_pointer_v<U> && std::is_convertible_v<U, T*>)
+  static constexpr inline NonNull from(U t) {
+    check(t);
+    return NonNull(t);
+  }
+
+  template <class U, size_t N>
+  static constexpr inline NonNull from(U (&t)[N]) = delete;
+
+  /// NonNull<T> is copyable, so this is the copy constructor.
+  NonNull(const NonNull&) = default;
+  /// NonNull<T> is copyable, so this is the copy assignment operator.
+  NonNull& operator=(const NonNull&) = default;
+
+  /// Returns a const reference to the pointee.
   constexpr inline const T& as_ref() const { return *ptr_; }
-  constexpr inline T& as_ref_mut()
+
+  /// Returns a mutable reference to the pointee.
+  ///
+  /// This method is only callable when the pointer is not const.
+  constexpr inline T& as_mut()
     requires(!std::is_const_v<T>)
   {
     return *ptr_;
   }
 
+  /// Returns a const pointer to the pointee.
   constexpr inline const T* as_ptr() const { return ptr_; }
+
+  /// Returns a mutable pointer to the pointee.
+  ///
+  /// This method is only callable when the pointer is not const.
   constexpr inline T* as_ptr_mut()
     requires(!std::is_const_v<T>)
   {
     return ptr_;
+  }
+
+  /// Cast the pointer of type `T` in NonNull<T> to a pointer of type `U` and
+  /// return a `NonNull<U>`.
+  ///
+  /// This requires that `T*` is implicitly convertible to `U*`. To perform a
+  /// static_cast<U*>, use `downcast()`.
+  template <class U>
+    requires(std::is_convertible_v<T*, U*>)
+  NonNull<U> cast() const {
+    return NonNull<U>::with_ptr_unchecked(unsafe_fn, static_cast<U*>(ptr_));
+  }
+
+  /// Cast the pointer of type `T` in NonNull<T> to a pointer of type `U` and
+  /// return a `NonNull<U>`.
+  ///
+  /// # Safety
+  /// The pointee must be a `U*` or this results in Undefined Behaviour.
+  template <class U>
+  NonNull<U> downcast(::sus::marker::UnsafeFnMarker) const {
+    return NonNull<U>::with_ptr_unchecked(unsafe_fn, static_cast<U*>(ptr_));
   }
 
  private:
@@ -58,6 +153,11 @@ struct NonNull {
 
   T* ptr_;
 
+  // Declare that this type can always be trivially relocated for library
+  // optimizations.
+  sus_class_trivial_relocatable(unsafe_fn);
+  // Declare that the `ptr_` field is never set to `nullptr` for library
+  // optimizations.
   sus_class_never_value_field(unsafe_fn, NonNull, ptr_, nullptr);
 };
 

--- a/mem/nonnull.h
+++ b/mem/nonnull.h
@@ -69,10 +69,9 @@ struct [[sus_trivial_abi]] NonNull {
   /// results.
   template <class U>
     requires(std::is_pointer_v<U> && std::is_convertible_v<U, T*>)
-  static constexpr inline NonNull
+  static constexpr inline sus_assertions_nonnull_fn NonNull
       with_ptr_unchecked(::sus::marker::UnsafeFnMarker,
-                         sus_assertions_nonnull_arg U t)
-          sus_assertions_nonnull_fn {
+                         sus_assertions_nonnull_arg U t) {
     return NonNull(t);
   }
 

--- a/mem/nonnull.h
+++ b/mem/nonnull.h
@@ -20,6 +20,7 @@
 #include "mem/addressof.h"
 #include "mem/never_value.h"
 #include "mem/relocate.h"
+#include "option/option.h"
 
 namespace sus::mem {
 
@@ -47,13 +48,16 @@ struct [[sus_trivial_abi]] NonNull {
   /// The method will panic if the pointer `t` is null.
   template <class U>
     requires(std::is_pointer_v<U> && std::is_convertible_v<U, T*>)
-  static constexpr inline NonNull with_ptr(U t) {
-    check(t);
-    return NonNull(t);
+  static constexpr inline ::sus::option::Option<NonNull> with_ptr(U t) {
+    if (t) [[likely]]
+      return ::sus::option::Option<NonNull<T>>::some(NonNull(t));
+    else
+      return ::sus::option::Option<NonNull<T>>::none();
   }
 
   template <class U, size_t N>
-  static constexpr inline NonNull with_ptr(U (&t)[N]) = delete;
+  static constexpr inline ::sus::option::Option<NonNull> with_ptr(U (&t)[N]) =
+      delete;
 
   /// Constructs a `NonNull<T>` from a pointer to `T`.
   ///

--- a/mem/nonnull_types_unittest.cc
+++ b/mem/nonnull_types_unittest.cc
@@ -1,0 +1,301 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "construct/make_default.h"
+#include "mem/nonnull.h"
+#include "mem/relocate.h"
+#include "test/behaviour_types.h"
+
+using sus::construct::MakeDefault;
+using sus::mem::NonNull;
+using sus::mem::relocate_array_by_memcpy;
+using sus::mem::relocate_one_by_memcpy;
+
+namespace default_constructible {
+using T = NonNull < sus::test::DefaultConstructible>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace default_constructible
+
+namespace not_default_constructible {
+using T = NonNull < sus::test::NotDefaultConstructible>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace not_default_constructible
+
+namespace with_default_constructible {
+using T = NonNull < sus::test::WithDefaultConstructible>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace with_default_constructible
+
+namespace trivially_copyable {
+using T = NonNull < sus::test::TriviallyCopyable>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace trivially_copyable
+
+namespace trivially_moveable_and_relocatable {
+using T = NonNull < sus::test::TriviallyMoveableAndRelocatable>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace trivially_moveable_and_relocatable
+
+namespace trivially_copyable_not_destructible {
+using T = NonNull < sus::test::TriviallyCopyableNotDestructible>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace trivially_copyable_not_destructible
+
+namespace trivially_moveable_not_destructible {
+using T = NonNull < sus::test::TriviallyMoveableNotDestructible>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace trivially_moveable_not_destructible
+
+namespace not_trivially_relocatable_copyable_or_moveable {
+using T = NonNull < sus::test::NotTriviallyRelocatableCopyableOrMoveable>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace not_trivially_relocatable_copyable_or_moveable
+
+namespace trivial_abi_relocatable {
+using T = NonNull < sus::test::TrivialAbiRelocatable>;
+using From = T;
+static_assert(!std::is_trivial_v<T>);
+static_assert(!std::is_aggregate_v<T>);
+static_assert(std::is_standard_layout_v<T>);
+static_assert(!std::is_trivially_default_constructible_v<T>);
+static_assert(!std::is_default_constructible_v<T>);
+static_assert(std::is_trivially_copy_constructible_v<T>);
+static_assert(std::is_trivially_copy_assignable_v<T>);
+static_assert(std::is_trivially_move_constructible_v<T>);
+static_assert(std::is_trivially_move_assignable_v<T>);
+static_assert(std::is_trivially_destructible_v<T>);
+static_assert(std::is_copy_constructible_v<T>);
+static_assert(std::is_copy_assignable_v<T>);
+static_assert(std::is_move_constructible_v<T>);
+static_assert(std::is_move_assignable_v<T>);
+static_assert(std::is_nothrow_swappable_v<T>);
+static_assert(std::is_constructible_v<T, From&&>);
+static_assert(std::is_assignable_v<T, From&&>);
+static_assert(std::is_constructible_v<T, const From&>);
+static_assert(std::is_assignable_v<T, const From&>);
+static_assert(std::is_constructible_v<T, From>);
+static_assert(std::is_trivially_constructible_v<T, From>);
+static_assert(std::is_assignable_v<T, From>);
+static_assert(std::is_nothrow_destructible_v<T>);
+static_assert(!MakeDefault<T>);
+static_assert(relocate_one_by_memcpy<T>);
+static_assert(relocate_array_by_memcpy<T>);
+}  // namespace trivial_abi_relocatable

--- a/mem/nonnull_unittest.cc
+++ b/mem/nonnull_unittest.cc
@@ -97,9 +97,9 @@ TEST(NonNull, AddressOf) {
 TEST(NonNull, ConstructPtr) {
   int i = 1;
   const int c = 2;
-  auto n1 = NonNull<int>::with_ptr(&i);
-  auto n2 = NonNull<const int>::with_ptr(&i);
-  auto c1 = NonNull<const int>::with_ptr(&c);
+  auto n1 = NonNull<int>::with_ptr(&i).unwrap();
+  auto n2 = NonNull<const int>::with_ptr(&i).unwrap();
+  auto c1 = NonNull<const int>::with_ptr(&c).unwrap();
 
   EXPECT_EQ(&i, &n1.as_ref());
   EXPECT_EQ(&i, &n2.as_ref());
@@ -227,7 +227,7 @@ TEST(NonNull, Cast) {
   struct Sub : public Base {};
   Sub s;
   s.i = 3_i32;
-  auto sn = NonNull<Sub>::with_ptr(&s);
+  auto sn = NonNull<Sub>::with(s);
   auto bn = sn.cast<Base>();
   EXPECT_EQ(bn.as_ref().i, 3_i32);
 }
@@ -239,7 +239,7 @@ TEST(NonNull, Downcast) {
   struct Sub : public Base {};
   Sub s;
   s.i = 3_i32;
-  auto bn = NonNull<Base>::with_ptr(&s);
+  auto bn = NonNull<Base>::with(s);
   auto sn = bn.downcast<Sub>(unsafe_fn);
   EXPECT_EQ(sn.as_ref().i, 3_i32);
 }

--- a/option/__private/storage.h
+++ b/option/__private/storage.h
@@ -171,8 +171,8 @@ struct Storage<T, true> final {
 
 template <class T>
 struct [[sus_trivial_abi]] StoragePointer {
-  explicit constexpr sus_always_inline StoragePointer(
-      sus_assertions_nonnull_arg T& ref) sus_assertions_nonnull_fn noexcept
+  explicit constexpr sus_always_inline sus_assertions_nonnull_fn
+  StoragePointer(sus_assertions_nonnull_arg T& ref) noexcept
       : ptr_(::sus::mem::addressof(ref)) {}
 
   constexpr sus_always_inline const T& as_ref() const { return *ptr_; }

--- a/option/option.h
+++ b/option/option.h
@@ -821,7 +821,7 @@ class Option<T&> final {
     requires(!std::is_const_v<T>)
   sus_assertions_nonnull_fn {
     ::sus::check_with_message(is_some(), *msg);
-    return t_.val_.as_ref_mut();
+    return t_.val_.as_mut();
   }
 
   /// Returns the contained value inside the Option.
@@ -868,7 +868,7 @@ class Option<T&> final {
     requires(!std::is_const_v<T>)
   {
     ::sus::check(is_some());
-    return t_.val_.as_ref_mut();
+    return t_.val_.as_mut();
   }
 
   /// Returns the contained value inside the Option, if there is one. Otherwise,
@@ -899,7 +899,7 @@ class Option<T&> final {
   /// returns a mutable reference to the new value.
   T& insert(T& t) & noexcept {
     t_.set_some(::sus::mem::NonNull<T>::with(t));
-    return t_.val_.as_ref_mut();
+    return t_.val_.as_mut();
   }
 
   /// If the Option holds a value, returns a mutable reference to it. Otherwise,
@@ -908,7 +908,7 @@ class Option<T&> final {
   T& get_or_insert(T& t) & noexcept {
     if (t_.state() == None)
       t_.construct_from_none(::sus::mem::NonNull<T>::with(t));
-    return t_.val_.as_ref_mut();
+    return t_.val_.as_mut();
   }
 
   /// If the Option holds a value, returns a mutable reference to it. Otherwise,
@@ -922,7 +922,7 @@ class Option<T&> final {
   T& get_or_insert_with(WithFn f) & noexcept {
     if (t_.state() == None)
       t_.construct_from_none(::sus::mem::NonNull<T>::with(f()));
-    return t_.val_.as_ref_mut();
+    return t_.val_.as_mut();
   }
 
   /// Returns a new Option containing whatever was inside the current Option.
@@ -1068,7 +1068,7 @@ class Option<T&> final {
       // we return what this was holding, otherwise we return None.
       auto nonnull = t_.take_and_set_none();
       if (opt.t_.state() == None)
-        return Option(nonnull.as_ref_mut());
+        return Option(nonnull.as_mut());
       else
         return Option::none();
     } else {
@@ -1130,7 +1130,7 @@ class Option<T&> final {
     } else {
       return Option(
           ::sus::mem::replace(mref(t_.val_), ::sus::mem::NonNull<T>::with(t))
-              .as_ref_mut());
+              .as_mut());
     }
   }
 
@@ -1170,7 +1170,7 @@ class Option<T&> final {
     if (t_.state() == None)
       return Option<T&>::none();
     else
-      return Option<T&>(t_.val_.as_ref_mut());
+      return Option<T&>(t_.val_.as_mut());
   }
 
   Iterator<Once<const T&>> iter() const& noexcept {
@@ -1203,7 +1203,7 @@ class Option<T&> final {
     if constexpr (std::is_const_v<T>)
       return nonnull.as_ref();
     else
-      return nonnull.as_ref_mut();
+      return nonnull.as_mut();
   }
 
   ::sus::option::__private::Storage<::sus::mem::NonNull<T>> t_;

--- a/option/option.h
+++ b/option/option.h
@@ -256,9 +256,9 @@ class Option final {
   ///
   /// The function will panic with the given message if the Option's state is
   /// currently `None`.
-  constexpr T expect(
+  constexpr sus_assertions_nonnull_fn T expect(
       /* TODO: string view type */ sus_assertions_nonnull_arg const char*
-          msg) && noexcept sus_assertions_nonnull_fn {
+          msg) && noexcept {
     ::sus::check_with_message(is_some(), *msg);
     return static_cast<Option&&>(*this).unwrap_unchecked(unsafe_fn);
   }
@@ -269,9 +269,9 @@ class Option final {
   ///
   /// The function will panic with the given message if the Option's state is
   /// currently `None`.
-  constexpr const T& expect_ref(
+  constexpr sus_assertions_nonnull_fn const T& expect_ref(
       /* TODO: string view type */ sus_assertions_nonnull_arg const char* msg)
-      const& noexcept sus_assertions_nonnull_fn {
+      const& noexcept {
     ::sus::check_with_message(is_some(), *msg);
     return t_.val_;
   }
@@ -283,9 +283,9 @@ class Option final {
   ///
   /// The function will panic with the given message if the Option's state is
   /// currently `None`.
-  constexpr T& expect_mut(
+  constexpr sus_assertions_nonnull_fn T& expect_mut(
       /* TODO: string view type */ sus_assertions_nonnull_arg const char*
-          msg) & noexcept sus_assertions_nonnull_fn {
+          msg) & noexcept {
     ::sus::check_with_message(is_some(), *msg);
     return t_.val_;
   }
@@ -789,9 +789,9 @@ class Option<T&> final {
   ///
   /// The function will panic with the given message if the Option's state is
   /// currently `None`.
-  constexpr T& expect(
+  constexpr sus_assertions_nonnull_fn T& expect(
       /* TODO: string view type */ sus_assertions_nonnull_arg const char*
-          msg) && noexcept sus_assertions_nonnull_fn {
+          msg) && noexcept {
     ::sus::check_with_message(is_some(), *msg);
     return static_cast<Option&&>(*this).unwrap_unchecked(unsafe_fn);
   }
@@ -802,9 +802,9 @@ class Option<T&> final {
   ///
   /// The function will panic with the given message if the Option's state is
   /// currently `None`.
-  constexpr const T& expect_ref(
+  constexpr sus_assertions_nonnull_fn const T& expect_ref(
       /* TODO: string view type */ sus_assertions_nonnull_arg const char* msg)
-      const& noexcept sus_assertions_nonnull_fn {
+      const& noexcept {
     ::sus::check_with_message(is_some(), *msg);
     return t_.val_.as_ref();
   }
@@ -816,11 +816,11 @@ class Option<T&> final {
   ///
   /// The function will panic with the given message if the Option's state is
   /// currently `None`.
-  constexpr T& expect_mut(
+  constexpr sus_assertions_nonnull_fn T& expect_mut(
       /* TODO: string view type */ sus_assertions_nonnull_arg const char*
           msg) & noexcept
     requires(!std::is_const_v<T>)
-  sus_assertions_nonnull_fn {
+  {
     ::sus::check_with_message(is_some(), *msg);
     return t_.val_.as_mut();
   }
@@ -907,8 +907,7 @@ class Option<T&> final {
   /// stores `t` inside the Option and returns a mutable reference to the new
   /// value.
   T& get_or_insert(T& t) & noexcept {
-    if (t_.state() == None)
-      t_.construct_from_none(StoragePointer(t));
+    if (t_.state() == None) t_.construct_from_none(StoragePointer(t));
     return t_.val_.as_mut();
   }
 
@@ -921,8 +920,7 @@ class Option<T&> final {
   template <class WithFn>
     requires(std::is_same_v<std::invoke_result_t<WithFn>, T&>)
   T& get_or_insert_with(WithFn f) & noexcept {
-    if (t_.state() == None)
-      t_.construct_from_none(StoragePointer(f()));
+    if (t_.state() == None) t_.construct_from_none(StoragePointer(f()));
     return t_.val_.as_mut();
   }
 
@@ -1130,8 +1128,7 @@ class Option<T&> final {
       return Option::none();
     } else {
       return Option(
-          ::sus::mem::replace(mref(t_.val_), StoragePointer(t))
-              .as_mut());
+          ::sus::mem::replace(mref(t_.val_), StoragePointer(t)).as_mut());
     }
   }
 

--- a/option/option_unittest.cc
+++ b/option/option_unittest.cc
@@ -16,12 +16,12 @@
 
 #include <math.h>  // TODO: Replace with f32::NAN()
 
-#include "macros/builtin.h"
 #include "iter/iterator.h"
+#include "macros/builtin.h"
+#include "mem/nonnull.h"
 #include "mem/relocate.h"
 #include "num/types.h"
 #include "result/result.h"
-#include "tuple/tuple.h"
 #include "test/behaviour_types.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 #include "tuple/tuple.h"
@@ -1693,7 +1693,9 @@ TEST(Option, NonZeroField) {
   EXPECT_EQ(o, None);
 
   o = Option<T>::some(T::with(i));
-  EXPECT_EQ(sus::move(o).zip(Option<T>::some(T::with(i))), (Option<sus::Tuple<T, T>>::some(sus::Tuple<T, T>::with(T::with(i), T::with(i)))));
+  EXPECT_EQ(sus::move(o).zip(Option<T>::some(T::with(i))),
+            (Option<sus::Tuple<T, T>>::some(
+                sus::Tuple<T, T>::with(T::with(i), T::with(i)))));
   EXPECT_EQ(o, None);
 
   o = Option<T>::some(T::with(i));


### PR DESCRIPTION
We want to be able to construct a NonNull from an lvalue pointer, and just copy the pointer. So we rework/entend Into and into() to support lvalues for trivially copyable (const/non-const) types and trivially movable (non-const) types.