### PR TITLE
Make the panic functions possible to override at compile time

### DIFF
--- a/assertions/check_unittest.cc
+++ b/assertions/check_unittest.cc
@@ -30,7 +30,7 @@ TEST(Check, CheckFails) {
 #endif
 }
 
-TEST(Panic, WithMessage) {
+TEST(Check, WithMessage) {
 #if GTEST_HAS_DEATH_TEST
   EXPECT_DEATH(check_with_message(false, *"hello world"), "hello world");
 #endif

--- a/assertions/panic.cc
+++ b/assertions/panic.cc
@@ -16,15 +16,11 @@
 
 #include <stdio.h>
 
-namespace sus {
+namespace sus::__private {
 
-// Defined outside the header to avoid inlining, to optimize for code size.
-[[noreturn]] void panic_with_message(
-    /* TODO: string view type, or format + args */ const char& msg) {
-  // TODO: allow configuring messages away at build time.
+// Defined outside the header to avoid fprintf in the header.
+void print_panic_message(const char& msg) {
   fprintf(stderr, "PANIC! %s\n", &msg);
-  // TODO: allow configuring this to some other method of aborting.
-  ::abort();
 }
 
-}  // namespace sus
+}  // namespace sus::__private

--- a/assertions/panic.h
+++ b/assertions/panic.h
@@ -17,12 +17,49 @@
 #include <stdlib.h>
 
 #include "macros/always_inline.h"
+#include "macros/builtin.h"
+#include "macros/compiler.h"
 
 namespace sus {
 
-[[noreturn]] sus_always_inline void panic() { ::abort(); }
+namespace __private {
+void print_panic_message(const char& msg);
+}
 
-[[noreturn]] void panic_with_message(
-    /* TODO: string view type, or format + args */ const char& msg);
+/// Terminate the program.
+///
+/// The default behaviour of this function is to abort(). The behaviour of this
+/// function can be overridden by defining a `SUS_PROVIDE_PANIC_HANDLER()` macro
+/// when compiling the library.
+///
+/// # Safety
+/// If `SUS_PROVIDE_PANIC_HANDLER()` is defined, the macro _must_ not return of
+/// Undefined Behaviour will result.
+[[noreturn]] sus_always_inline void panic() {
+#if defined(SUS_PROVIDE_PANIC_HANDLER)
+  SUS_PROVIDE_PANIC_HANDLER();
+#elif __has_builtin(__builtin_trap)
+  __builtin_trap();
+#else
+  abort();
+#endif
+}
+
+/// Terminate the program, after printing a message.
+///
+/// The default behaviour of this function is to print the message to stderr.
+/// The behaviour of this function can be overridden by defining a
+/// SUS_PROVIDE_PRINT_PANIC_MESSAGE_HANDLER() macro when compiling the library.
+///
+/// After printing the message, the function will `panic()`.
+[[noreturn]] sus_always_inline void panic_with_message(
+    /* TODO: string view type, or format + args */ const char& msg) {
+#if defined(SUS_PROVIDE_PRINT_PANIC_MESSAGE_HANDLER)
+  SUS_PROVIDE_PRINT_PANIC_MESSAGE_HANDLER(msg);
+#else
+  __private::print_panic_message(msg);
+#endif
+  panic();
+}
 
 }  // namespace sus


### PR DESCRIPTION
This allows the user of subspace to provide their own implementation of these methods.
