### PR TITLE
Implement Ord methods and simplify Eq and Ord concepts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ add_executable(subspace_unittests
     "option/option_unittest.cc"
     "option/option_types_unittest.cc"
     "ops/eq_unittest.cc"
+    "ops/ord_unittest.cc"
     "result/result_unittest.cc"
     "result/result_types_unittest.cc"
     "tuple/tuple_unittest.cc"

--- a/containers/array.h
+++ b/containers/array.h
@@ -284,9 +284,12 @@ class Array final {
     });
   }
 
-  /// sus::ops::Eq<Array<U, N>> trait.
-  template <::sus::ops::Eq<T> U>
-  constexpr bool operator==(const Array<U, N>& r) const& noexcept {
+  /// sus::ops::Eq<Array<T, N>, Array<U, N>> trait.
+  template <class U>
+    requires(::sus::ops::Eq<T, U>)
+  constexpr bool operator==(const Array<U, N>& r) const& noexcept
+    requires(::sus::ops::Eq<T>)
+  {
     return eq_impl(r, std::make_index_sequence<N>());
   }
 
@@ -356,7 +359,7 @@ constexpr inline auto array_cmp(auto equal, const Array<T, N>& l,
 
 }  // namespace __private
 
-/// sus::ops::Ord<Option<U>> trait.
+/// sus::ops::Ord<Array<T, N>, Array<U, N>> trait.
 template <class T, class U, size_t N>
   requires(::sus::ops::ExclusiveOrd<T, U>)
 constexpr inline auto operator<=>(const Array<T, N>& l,
@@ -365,7 +368,7 @@ constexpr inline auto operator<=>(const Array<T, N>& l,
                               std::make_index_sequence<N>());
 }
 
-/// sus::ops::Ord<Option<U>> trait.
+/// sus::ops::WeakOrd<Array<T>> trait.
 template <class T, class U, size_t N>
   requires(::sus::ops::ExclusiveWeakOrd<T, U>)
 constexpr inline auto operator<=>(const Array<T, N>& l,
@@ -374,7 +377,7 @@ constexpr inline auto operator<=>(const Array<T, N>& l,
                               std::make_index_sequence<N>());
 }
 
-/// sus::ops::Ord<Option<U>> trait.
+/// sus::ops::PartialOrd<Array<T>> trait.
 template <class T, class U, size_t N>
   requires(::sus::ops::ExclusivePartialOrd<T, U>)
 constexpr inline auto operator<=>(const Array<T, N>& l,

--- a/mem/nonnull.h
+++ b/mem/nonnull.h
@@ -21,6 +21,7 @@
 #include "mem/never_value.h"
 #include "mem/relocate.h"
 #include "ops/eq.h"
+#include "ops/ord.h"
 #include "option/option.h"
 
 namespace sus::mem {
@@ -165,7 +166,7 @@ struct [[sus_trivial_abi]] NonNull {
   sus_class_never_value_field(unsafe_fn, NonNull, ptr_, nullptr);
 };
 
-/// sus::ops::Eq<Option<U>> trait.
+/// sus::ops::Eq<NonNull<T>> trait.
 template <class T, class U>
   requires(::sus::ops::Eq<const T*, const U*>)
 constexpr inline bool operator==(const NonNull<T>& l,
@@ -173,7 +174,7 @@ constexpr inline bool operator==(const NonNull<T>& l,
   return l.as_ptr() == r.as_ptr();
 }
 
-/// sus::ops::Ord<Option<U>> trait.
+/// sus::ops::Ord<NonNull<T>> trait.
 template <class T, class U>
   requires(::sus::ops::Ord<const T*, const U*>)
 constexpr inline auto operator<=>(const NonNull<T>& l,

--- a/mem/nonnull_unittest.cc
+++ b/mem/nonnull_unittest.cc
@@ -238,8 +238,7 @@ TEST(NonNull, Downcast) {
 }
 
 TEST(NonNull, Eq) {
-  static_assert(sus::ops::Eq<NonNull<int>, NonNull<int>>);
-  static_assert(!sus::ops::Eq<NonNull<int>, NonNull<char>>);
+  static_assert(sus::ops::Eq<NonNull<int>>);
 
   auto a = int();
   auto b = int();
@@ -255,12 +254,7 @@ TEST(NonNull, Eq) {
 }
 
 TEST(NonNull, Ord) {
-  static_assert(sus::ops::Ord<NonNull<int>, NonNull<int>>);
-  // TODO: GCC internal compiler error when Ord fails:
-  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107542
-#if !(defined(__GNUC__) && !defined(__clang__))
-  static_assert(!sus::ops::Ord<NonNull<int>, NonNull<char>>);
-#endif
+  static_assert(sus::ops::Ord<NonNull<int>>);
 
   int a[] = {1, 2};
   EXPECT_LE(NonNull<int>::with(a[0]), NonNull<int>::with(a[0]));

--- a/num/f32_unittest.cc
+++ b/num/f32_unittest.cc
@@ -56,14 +56,14 @@ TEST(f32, Traits) {
   static_assert(!sus::num::Shr<f32>);
   static_assert(!sus::num::ShrAssign<f32>);
 
-  static_assert(!sus::ops::Ord<f32, f32>);
-  static_assert(!sus::ops::WeakOrd<f32, f32>);
-  static_assert(sus::ops::PartialOrd<f32, f32>);
+  static_assert(!sus::ops::Ord<f32>);
+  static_assert(!sus::ops::WeakOrd<f32>);
+  static_assert(sus::ops::PartialOrd<f32>);
   static_assert(1_f32 >= 1_f32);
   static_assert(2_f32 > 1_f32);
   static_assert(1_f32 <= 1_f32);
   static_assert(1_f32 < 2_f32);
-  static_assert(sus::ops::Eq<f32, f32>);
+  static_assert(sus::ops::Eq<f32>);
   static_assert(1_f32 == 1_f32);
   static_assert(!(1_f32 == 2_f32));
   static_assert(1_f32 != 2_f32);

--- a/num/f64_unittest.cc
+++ b/num/f64_unittest.cc
@@ -51,14 +51,14 @@ TEST(f64, Traits) {
   static_assert(!sus::num::Shr<f64>);
   static_assert(!sus::num::ShrAssign<f64>);
 
-  static_assert(!sus::ops::Ord<f64, f64>);
-  static_assert(!sus::ops::WeakOrd<f64, f64>);
-  static_assert(sus::ops::PartialOrd<f64, f64>);
+  static_assert(!sus::ops::Ord<f64>);
+  static_assert(!sus::ops::WeakOrd<f64>);
+  static_assert(sus::ops::PartialOrd<f64>);
   static_assert(1_f64 >= 1_f64);
   static_assert(2_f64 > 1_f64);
   static_assert(1_f64 <= 1_f64);
   static_assert(1_f64 < 2_f64);
-  static_assert(sus::ops::Eq<f64, f64>);
+  static_assert(sus::ops::Eq<f64>);
   static_assert(1_f64 == 1_f64);
   static_assert(!(1_f64 == 2_f64));
   static_assert(1_f64 != 2_f64);

--- a/num/i16_unittest.cc
+++ b/num/i16_unittest.cc
@@ -100,12 +100,12 @@ TEST(i16, Traits) {
   static_assert(sus::num::Shr<i16>);
   static_assert(sus::num::ShrAssign<i16>);
 
-  static_assert(sus::ops::Ord<i16, i16>);
+  static_assert(sus::ops::Ord<i16>);
   static_assert(1_i16 >= 1_i16);
   static_assert(2_i16 > 1_i16);
   static_assert(1_i16 <= 1_i16);
   static_assert(1_i16 < 2_i16);
-  static_assert(sus::ops::Eq<i16, i16>);
+  static_assert(sus::ops::Eq<i16>);
   static_assert(1_i16 == 1_i16);
   static_assert(!(1_i16 == 2_i16));
   static_assert(1_i16 != 2_i16);

--- a/num/i32_unittest.cc
+++ b/num/i32_unittest.cc
@@ -103,12 +103,12 @@ TEST(i32, Traits) {
   static_assert(sus::num::Shr<i32>);
   static_assert(sus::num::ShrAssign<i32>);
 
-  static_assert(sus::ops::Ord<i32, i32>);
+  static_assert(sus::ops::Ord<i32>);
   static_assert(1_i32 >= 1_i32);
   static_assert(2_i32 > 1_i32);
   static_assert(1_i32 <= 1_i32);
   static_assert(1_i32 < 2_i32);
-  static_assert(sus::ops::Eq<i32, i32>);
+  static_assert(sus::ops::Eq<i32>);
   static_assert(1_i32 == 1_i32);
   static_assert(!(1_i32 == 2_i32));
   static_assert(1_i32 != 2_i32);

--- a/num/i64_unittest.cc
+++ b/num/i64_unittest.cc
@@ -100,12 +100,12 @@ TEST(i64, Traits) {
   static_assert(sus::num::Shr<i64>);
   static_assert(sus::num::ShrAssign<i64>);
 
-  static_assert(sus::ops::Ord<i64, i64>);
+  static_assert(sus::ops::Ord<i64>);
   static_assert(1_i64 >= 1_i64);
   static_assert(2_i64 > 1_i64);
   static_assert(1_i64 <= 1_i64);
   static_assert(1_i64 < 2_i64);
-  static_assert(sus::ops::Eq<i64, i64>);
+  static_assert(sus::ops::Eq<i64>);
   static_assert(1_i64 == 1_i64);
   static_assert(!(1_i64 == 2_i64));
   static_assert(1_i64 != 2_i64);

--- a/num/i8_unittest.cc
+++ b/num/i8_unittest.cc
@@ -100,12 +100,12 @@ TEST(i8, Traits) {
   static_assert(sus::num::Shr<i8>);
   static_assert(sus::num::ShrAssign<i8>);
 
-  static_assert(sus::ops::Ord<i8, i8>);
+  static_assert(sus::ops::Ord<i8>);
   static_assert(1_i8 >= 1_i8);
   static_assert(2_i8 > 1_i8);
   static_assert(1_i8 <= 1_i8);
   static_assert(1_i8 < 2_i8);
-  static_assert(sus::ops::Eq<i8, i8>);
+  static_assert(sus::ops::Eq<i8>);
   static_assert(1_i8 == 1_i8);
   static_assert(!(1_i8 == 2_i8));
   static_assert(1_i8 != 2_i8);

--- a/num/isize_unittest.cc
+++ b/num/isize_unittest.cc
@@ -113,12 +113,12 @@ TEST(isize, Traits) {
   static_assert(sus::num::Shr<isize>);
   static_assert(sus::num::ShrAssign<isize>);
 
-  static_assert(sus::ops::Ord<isize, isize>);
+  static_assert(sus::ops::Ord<isize>);
   static_assert(1_isize >= 1_isize);
   static_assert(2_isize > 1_isize);
   static_assert(1_isize <= 1_isize);
   static_assert(1_isize < 2_isize);
-  static_assert(sus::ops::Eq<isize, isize>);
+  static_assert(sus::ops::Eq<isize>);
   static_assert(1_isize == 1_isize);
   static_assert(!(1_isize == 2_isize));
   static_assert(1_isize != 2_isize);

--- a/num/u16_unittest.cc
+++ b/num/u16_unittest.cc
@@ -100,12 +100,12 @@ TEST(u16, Traits) {
   static_assert(sus::num::Shr<u16>);
   static_assert(sus::num::ShrAssign<u16>);
 
-  static_assert(sus::ops::Ord<u16, u16>);
+  static_assert(sus::ops::Ord<u16>);
   static_assert(1_u16 >= 1_u16);
   static_assert(2_u16 > 1_u16);
   static_assert(1_u16 <= 1_u16);
   static_assert(1_u16 < 2_u16);
-  static_assert(sus::ops::Eq<u16, u16>);
+  static_assert(sus::ops::Eq<u16>);
   static_assert(1_u16 == 1_u16);
   static_assert(!(1_u16 == 2_u16));
   static_assert(1_u16 != 2_u16);

--- a/num/u32_unittest.cc
+++ b/num/u32_unittest.cc
@@ -103,12 +103,12 @@ TEST(u32, Traits) {
   static_assert(sus::num::Shr<u32>);
   static_assert(sus::num::ShrAssign<u32>);
 
-  static_assert(sus::ops::Ord<u32, u32>);
+  static_assert(sus::ops::Ord<u32>);
   static_assert(1_u32 >= 1_u32);
   static_assert(2_u32 > 1_u32);
   static_assert(1_u32 <= 1_u32);
   static_assert(1_u32 < 2_u32);
-  static_assert(sus::ops::Eq<u32, u32>);
+  static_assert(sus::ops::Eq<u32>);
   static_assert(1_u32 == 1_u32);
   static_assert(!(1_u32 == 2_u32));
   static_assert(1_u32 != 2_u32);

--- a/num/u64_unittest.cc
+++ b/num/u64_unittest.cc
@@ -100,12 +100,12 @@ TEST(u64, Traits) {
   static_assert(sus::num::Shr<u64>);
   static_assert(sus::num::ShrAssign<u64>);
 
-  static_assert(sus::ops::Ord<u64, u64>);
+  static_assert(sus::ops::Ord<u64>);
   static_assert(1_u64 >= 1_u64);
   static_assert(2_u64 > 1_u64);
   static_assert(1_u64 <= 1_u64);
   static_assert(1_u64 < 2_u64);
-  static_assert(sus::ops::Eq<u64, u64>);
+  static_assert(sus::ops::Eq<u64>);
   static_assert(1_u64 == 1_u64);
   static_assert(!(1_u64 == 2_u64));
   static_assert(1_u64 != 2_u64);

--- a/num/u8_unittest.cc
+++ b/num/u8_unittest.cc
@@ -100,12 +100,12 @@ TEST(u8, Traits) {
   static_assert(sus::num::Shr<u8>);
   static_assert(sus::num::ShrAssign<u8>);
 
-  static_assert(sus::ops::Ord<u8, u8>);
+  static_assert(sus::ops::Ord<u8>);
   static_assert(1_u8 >= 1_u8);
   static_assert(2_u8 > 1_u8);
   static_assert(1_u8 <= 1_u8);
   static_assert(1_u8 < 2_u8);
-  static_assert(sus::ops::Eq<u8, u8>);
+  static_assert(sus::ops::Eq<u8>);
   static_assert(1_u8 == 1_u8);
   static_assert(!(1_u8 == 2_u8));
   static_assert(1_u8 != 2_u8);

--- a/num/usize_unittest.cc
+++ b/num/usize_unittest.cc
@@ -142,12 +142,12 @@ TEST(usize, Traits) {
   static_assert(sus::num::Shr<usize>);
   static_assert(sus::num::ShrAssign<usize>);
 
-  static_assert(sus::ops::Ord<usize, usize>);
+  static_assert(sus::ops::Ord<usize>);
   static_assert(1_usize >= 1_usize);
   static_assert(2_usize > 1_usize);
   static_assert(1_usize <= 1_usize);
   static_assert(1_usize < 2_usize);
-  static_assert(sus::ops::Eq<usize, usize>);
+  static_assert(sus::ops::Eq<usize>);
   static_assert(1_usize == 1_usize);
   static_assert(!(1_usize == 2_usize));
   static_assert(1_usize != 2_usize);

--- a/ops/eq.h
+++ b/ops/eq.h
@@ -18,14 +18,27 @@
 
 namespace sus::ops {
 
-// Type `A` and `B` are `Eq<A, B>` if an object of each type can be compared for
-// equality with the `==` operator.
-//
-// TODO: How do we do PartialEq? Can we even? Can we require Ord to be Eq? But
-// then it depends on ::num?
-template <class Lhs, class Rhs>
-concept Eq = requires(const Lhs& lhs, const Rhs& rhs) {
+/// Concept for types that can be compared for equality with the `==` and `!=`
+/// operators.
+///
+/// Implementations must ensure that eq and ne are consistent with each other:
+///
+/// * a != b if and only if !(a == b).
+///
+/// The default implementation of the `!=` operator provides this consistency
+/// and is almost always sufficient. It should not be overridden without very
+/// good reason.
+///
+/// This concept allows for partial equality, for types that do not have a full
+/// equivalence relation. For example, in floating point numbers NaN != NaN, but
+/// they can still be compared with `==` and `!=`. Unlike Rust, C++ does not
+/// understand partial equivalence so we are unable to differentiate.
+///
+/// TODO: How do we do PartialEq? Can we even? Should we require Ord to be Eq?
+template <class T, class U = T>
+concept Eq = requires(const T& lhs, const U& rhs) {
                { lhs == rhs } -> std::same_as<bool>;
+               { lhs != rhs } -> std::same_as<bool>;
              };
 
 }  // namespace sus::ops

--- a/ops/eq_unittest.cc
+++ b/ops/eq_unittest.cc
@@ -14,20 +14,28 @@
 
 #include "ops/eq.h"
 
-#include <type_traits>
-
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
 namespace {
 
 using sus::ops::Eq;
 
+struct CComp {};
+struct C {
+  friend bool operator==(const C&, const C&) { return true; }
+  friend bool operator==(const C&, const CComp&) { return true; }
+};
+
 // These types are comparable.
-static_assert(Eq<int, int>);
-static_assert(Eq<int, char>);
-static_assert(Eq<char, int>);
+static_assert(Eq<int>);
+static_assert(Eq<char>);
+static_assert(Eq<C>);
+static_assert(Eq<C, C>);
+static_assert(Eq<C, CComp>);
+
+struct S {};  // No operator==.
 
 // These types are not comparable.
-static_assert(!Eq<int, char*>);
+static_assert(!Eq<S>);
 
-}
+}  // namespace

--- a/ops/ord.h
+++ b/ops/ord.h
@@ -18,6 +18,7 @@
 #include <concepts>
 
 #include "assertions/check.h"
+#include "fn/callable.h"
 
 // TODO: PartialOrd comes with: lt, le, ge, gt.
 // TODO: Eq comes with eq, ne.
@@ -25,73 +26,166 @@
 
 namespace sus::ops {
 
-/// Determines if the types `Lhs` and `Rhs` have a total ordering (aka
-/// `std::strong_ordering`).
-template <class Lhs, class Rhs>
-concept Ord = requires(const Lhs& lhs, const Rhs& rhs) {
+using ::sus::fn::callable::CallableReturns;
+using ::sus::fn::callable::CallableWith;
+
+/// Concept for types that form a total order (aka `std::strong_ordering`).
+template <class T, class U = T>
+concept Ord = requires(const T& lhs, const U& rhs) {
                 { lhs <=> rhs } -> std::same_as<std::strong_ordering>;
               };
 
-/// Determines if the types `Lhs` and `Rhs` have a weak ordering (aka
-/// `std::weak_ordering`).
+/// Concept for types that form a weak ordering (aka `std::weak_ordering`).
 ///
 /// This will be true if the types have a total ordering as well, which is
 /// stronger than a weak ordering. To determine if a weak ordering is the
 /// strongest type of ordering between the types, use `ExclusiveWeakOrd`.
-template <class Lhs, class Rhs>
-concept WeakOrd = Ord<Lhs, Rhs> || requires(const Lhs& lhs, const Rhs& rhs) {
-                                     {
-                                       lhs <=> rhs
-                                       } -> std::same_as<std::weak_ordering>;
-                                   };
+template <class T, class U = T>
+concept WeakOrd = Ord<T, U> || requires(const T& lhs, const U& rhs) {
+                                 {
+                                   lhs <=> rhs
+                                   } -> std::same_as<std::weak_ordering>;
+                               };
 
-/// Determines if the types `Lhs` and `Rhs` have a partial ordering (aka
+/// Concept for types that form a partial ordering (aka
 /// `std::partial_ordering`).
 ///
 /// This will be true if the types have a weak r total ordering as well, which
 /// is stronger than a partial ordering. To determine if a partial ordering is
 /// the strongest type of ordering between the types, use `ExclusivePartialOrd`.
-template <class Lhs, class Rhs>
-concept PartialOrd = WeakOrd<Lhs, Rhs> || Ord<Lhs, Rhs> ||
-                     requires(const Lhs& lhs, const Rhs& rhs) {
-                       { lhs <=> rhs } -> std::same_as<std::partial_ordering>;
-                     };
+template <class T, class U = T>
+concept PartialOrd =
+    WeakOrd<T, U> || Ord<T, U> || requires(const T& lhs, const U& rhs) {
+                                    {
+                                      lhs <=> rhs
+                                      } -> std::same_as<std::partial_ordering>;
+                                  };
 
-/// Determines if the types `Lhs` and `Rhs` have a total ordering (aka
-/// `std::strong_ordering`).
-template <class Lhs, class Rhs>
-concept ExclusiveOrd = Ord<Lhs, Rhs>;
+/// Concept for types that have a total ordering (aka `std::strong_ordering`).
+///
+/// This is an alias for Ord, but exists as a set with `ExclusiveWeakOrd` and
+/// `ExclusivePartialOrd`.
+template <class T, class U = T>
+concept ExclusiveOrd = Ord<T, U>;
 
 /// Determines if the types `Lhs` and `Rhs` have a weak ordering (aka
 /// `std::weak_ordering`), and that this is the strongest ordering that exists
 /// between the types.
-template <class Lhs, class Rhs>
-concept ExclusiveWeakOrd = (!Ord<Lhs, Rhs> && WeakOrd<Lhs, Rhs>);
+template <class T, class U = T>
+concept ExclusiveWeakOrd = (!Ord<T, U> && WeakOrd<T, U>);
 
 /// Determines if the types `Lhs` and `Rhs` have a partial ordering (aka
 /// `std::partial_ordering`), and that this is the strongest ordering that
 /// exists between the types.
-template <class Lhs, class Rhs>
-concept ExclusivePartialOrd = (!Ord<Lhs, Rhs> && !WeakOrd<Lhs, Rhs> &&
-                               PartialOrd<Lhs, Rhs>);
+template <class T, class U>
+concept ExclusivePartialOrd = (!Ord<T, U> && !WeakOrd<T, U> &&
+                               PartialOrd<T, U>);
 
+/// Compares and returns the minimum of two values.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+///
+/// By default this receives and returns objects by value. To receive and return
+/// references, specify the type parameter, such as:
+/// `sus::ops::min<i32&>(a, b)`. Note that if either input is a temporary object
+/// this can return a reference to an object past its lifetime.
 template <class T>
-  requires(Ord<T, T>)
-constexpr const T& min(const T& a, const T& b) noexcept {
-  return a < b ? a : b;
+  requires(Ord<T>)
+constexpr T min(T a, T b) noexcept {
+  return a > b ? b : a;
 }
 
+/// Compares and returns the minimum of two values with respect to the specified
+/// comparison function.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+///
+/// By default this receives and returns objects by value. To receive and return
+/// references, specify the type parameter, such as:
+/// `sus::ops::min_by<i32&>(a, b, c)`. Note that if either input is a temporary
+/// object this can return a reference to an object past its lifetime.
+template <class T, CallableReturns<std::strong_ordering, const T&, const T&> F>
+constexpr T min_by(T a, T b, F compare) noexcept {
+  return compare(a, b) == std::strong_ordering::greater ? b : a;
+}
+
+/// Returns the element that gives the minimum value from the specified
+/// function.
+///
+/// Returns the first argument if the comparison determines them to be equal.
+///
+/// By default this receives and returns objects by value. To receive and return
+/// references, specify the type parameter, such as:
+/// `sus::ops::min_by_key<i32&>(a, b, k)`. Note that if either input is a
+/// temporary object this can return a reference to an object past its lifetime.
+template <class T, CallableWith<const T&> F, int&...,
+          class K = std::invoke_result_t<F, const T&>>
+  requires(Ord<K>)
+constexpr T min_by_key(T a, T b, F f) noexcept {
+  return f(a) > f(b) ? b : a;
+}
+
+/// Compares and returns the maximum of two values.
+///
+/// Returns the second argument if the comparison determines them to be equal.
+///
+/// By default this receives and returns objects by value. To receive and return
+/// references, specify the type parameter, such as:
+/// `sus::ops::max<i32&>(a, b)`. Note that if either input is a temporary object
+/// this can return a reference to an object past its lifetime.
 template <class T>
-  requires(Ord<T, T>)
-constexpr const T& max(const T& a, const T& b) noexcept {
+  requires(Ord<T>)
+constexpr T max(T a, T b) noexcept {
   return a > b ? a : b;
 }
 
+/// Compares and returns the maximum of two values with respect to the specified
+/// comparison function.
+///
+/// Returns the second argument if the comparison determines them to be equal.
+///
+/// By default this receives and returns objects by value. To receive and return
+/// references, specify the type parameter, such as:
+/// `sus::ops::max_by<i32&>(a, b, c)`. Note that if either input is a temporary
+/// object this can return a reference to an object past its lifetime.
+template <class T, CallableReturns<std::strong_ordering, const T&, const T&> F>
+constexpr T max_by(T a, T b, F compare) noexcept {
+  return compare(a, b) == std::strong_ordering::greater ? a : b;
+}
+
+/// Returns the element that gives the maximum value from the specified
+/// function.
+///
+/// Returns the second argument if the comparison determines them to be equal.
+///
+/// By default this receives and returns objects by value. To receive and return
+/// references, specify the type parameter, such as:
+/// `sus::ops::max_by_key<i32&>(a, b, k)`. Note that if either input is a
+/// temporary object this can return a reference to an object past its lifetime.
+template <class T, CallableWith<const T&> F, int&...,
+          class K = std::invoke_result_t<F, const T&>>
+  requires(Ord<K>)
+constexpr T max_by_key(T a, T b, F f) noexcept {
+  return f(a) > f(b) ? a : b;
+}
+
+/// Restrict a value to a certain interval.
+///
+/// Returns `max` if `v` is greater than `max`, and `min` if `v` is less than
+/// `min`. Otherwise this returns `v`.
+///
+/// By default this receives and returns objects by value. To receive and return
+/// references, specify the type parameter, such as:
+/// `sus::ops::clamp<i32&>(a, min, max)`. Note that if any input is a temporary
+/// object this can return a reference to an object past its lifetime.
+///
+/// # Panics
+/// Panics if `min > max`.
 template <class T>
-  requires(Ord<T, T>)
-constexpr const T& clamp(const T& a, const T& min, const T& max) noexcept {
+  requires(Ord<T>)
+constexpr T clamp(T v, T min, T max) noexcept {
   ::sus::check(min <= max);
-  return a < min ? min : (a > max ? max : a);
+  return v < min ? min : (v > max ? max : v);
 }
 
 }  // namespace sus::ops

--- a/ops/ord_unittest.cc
+++ b/ops/ord_unittest.cc
@@ -1,0 +1,143 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "ops/ord.h"
+
+#include "macros/__private/compiler_bugs.h"
+#include "num/types.h"
+#include "third_party/googletest/googletest/include/gtest/gtest.h"
+
+namespace {
+
+using sus::ops::clamp;
+using sus::ops::max;
+using sus::ops::max_by;
+using sus::ops::max_by_key;
+using sus::ops::min;
+using sus::ops::min_by;
+using sus::ops::min_by_key;
+
+struct Strong {
+  sus_clang_bug_54040(Strong(i32 i, i32 id) : i(i), id(id){});
+
+  i32 i;
+  i32 id;
+
+  friend std::strong_ordering operator<=>(const Strong& a, const Strong& b) {
+    return a.i <=> b.i;
+  }
+};
+static_assert(sus::ops::Ord<Strong>);
+
+struct NoCmp {
+  sus_clang_bug_54040(NoCmp(i32 i, i32 id) : i(i), id(id){});
+
+  i32 i;
+  i32 id;
+};
+static_assert(!sus::ops::Ord<NoCmp>);
+
+TEST(Ord, Min) {
+  auto low1 = Strong(1, 1);
+  auto low2 = Strong(1, 2);
+  auto high = Strong(3, 3);
+
+  EXPECT_EQ(min(low1, high).id, 1_i32);
+  EXPECT_EQ(min(high, low1).id, 1_i32);
+
+  // On equal, the first is returned.
+  EXPECT_EQ(min(low1, low2).id, 1_i32);
+  EXPECT_EQ(min(low2, low1).id, 2_i32);
+}
+
+TEST(Ord, MinBy) {
+  auto cmp = [](const NoCmp& a, const NoCmp& b) { return a.i <=> b.i; };
+
+  auto low1 = NoCmp(1, 1);
+  auto low2 = NoCmp(1, 2);
+  auto high = NoCmp(3, 3);
+
+  // NoCmp is not Ord, but the comparator returns a strong_ordering, so they can
+  // be compared through it.
+  EXPECT_EQ(min_by(low1, high, cmp).id, 1_i32);
+  EXPECT_EQ(min_by(high, low1, cmp).id, 1_i32);
+
+  // On equal, the first is returned.
+  EXPECT_EQ(min_by(low1, low2, cmp).id, 1_i32);
+  EXPECT_EQ(min_by(low2, low1, cmp).id, 2_i32);
+}
+
+TEST(Ord, MinByKey) {
+  auto get_i = [](const NoCmp& a) { return a.i; };
+
+  auto low1 = NoCmp(1, 1);
+  auto low2 = NoCmp(1, 2);
+  auto high = NoCmp(3, 3);
+
+  // NoCmp is not Ord, but the key function returns a type that is Ord.
+  EXPECT_EQ(min_by_key(low1, high, get_i).id, 1_i32);
+  EXPECT_EQ(min_by_key(high, low1, get_i).id, 1_i32);
+
+  // On equal, the first is returned.
+  EXPECT_EQ(min_by_key(low1, low2, get_i).id, 1_i32);
+  EXPECT_EQ(min_by_key(low2, low1, get_i).id, 2_i32);
+}
+
+TEST(Ord, Max) {
+  auto low1 = Strong(1, 1);
+  auto low2 = Strong(1, 2);
+  auto high = Strong(3, 3);
+
+  EXPECT_EQ(max(low1, high).id, 3_i32);
+  EXPECT_EQ(max(high, low1).id, 3_i32);
+
+  // On equal, the second is returned.
+  EXPECT_EQ(max(low1, low2).id, 2_i32);
+  EXPECT_EQ(max(low2, low1).id, 1_i32);
+}
+
+TEST(Ord, MaxBy) {
+  auto cmp = [](const NoCmp& a, const NoCmp& b) { return a.i <=> b.i; };
+
+  auto low1 = NoCmp(1, 1);
+  auto low2 = NoCmp(1, 2);
+  auto high = NoCmp(3, 3);
+
+  // NoCmp is not Ord, but the comparator returns a strong_ordering, so they can
+  // be compared through it.
+  EXPECT_EQ(max_by(low1, high, cmp).id, 3_i32);
+  EXPECT_EQ(max_by(high, low1, cmp).id, 3_i32);
+
+  // On equal, the second is returned.
+  EXPECT_EQ(max_by(low1, low2, cmp).id, 2_i32);
+  EXPECT_EQ(max_by(low2, low1, cmp).id, 1_i32);
+}
+
+TEST(Ord, MaxByKey) {
+  auto get_i = [](const NoCmp& a) { return a.i; };
+
+  auto low1 = NoCmp(1, 1);
+  auto low2 = NoCmp(1, 2);
+  auto high = NoCmp(3, 3);
+
+  // NoCmp is not Ord, but the key function returns a type that is Ord.
+  EXPECT_EQ(max_by_key(low1, high, get_i).id, 3_i32);
+  EXPECT_EQ(max_by_key(high, low1, get_i).id, 3_i32);
+
+  // On equal, the second is returned.
+  EXPECT_EQ(max_by_key(low1, low2, get_i).id, 2_i32);
+  EXPECT_EQ(max_by_key(low2, low1, get_i).id, 1_i32);
+}
+
+}  // namespace


### PR DESCRIPTION
Give a default value to the second type variable for the Eq and Ord concepts so that Eq<int> is true and you don't have to write Eq<int, int>. However we still do need the second type in the concept in order to allow comparison between things like int and const int or int and int& due to a lack of blanket trait impls (like https://doc.rust-lang.org/stable/std/cmp/trait.Eq.html#impl-Eq-for-%26A) and the fact that references and qualifiers produce different types in C++.

Template types like Option or Tuple use a template argument to allow compare between Option<T> and Option<const T&>, etc.

Implement and test min/max min_by/max_by and min_by_key/max_by_key functions in the sus::ops namespace. They require the type that ends up being compared to satisfy Ord. We receive and return T instead of const T& to avoid introducing references and lifetimes when the input was not a reference. This allows moving 2 objects through min(a, b) and keeping only one of them.