### PR TITLE
Use msvc::no_unique_address

### DIFF
--- a/mem/__private/data_size_finder.h
+++ b/mem/__private/data_size_finder.h
@@ -25,7 +25,7 @@ constexpr inline size_t min(size_t a, size_t b) { return a < b ? a : b; }
 
 template <class T, size_t bytes>
 struct NoUnique {
-  [[no_unique_address]] T x;
+  [[sus_if_msvc(msvc::)no_unique_address]] T x;
   char c[bytes];
 };
 

--- a/mem/size_of_unittest.cc
+++ b/mem/size_of_unittest.cc
@@ -57,12 +57,12 @@ struct SubNonTrivial : public NonTrivial {
 };
 
 struct HoldNonStandard {
-  [[no_unique_address]] NonStandard x;
+  [[sus_if_msvc(msvc::)no_unique_address]] NonStandard x;
   i32 c;
 };
 
 struct HoldNonTrivial {
-  [[no_unique_address]] NonTrivial x;
+  [[sus_if_msvc(msvc::)no_unique_address]] NonTrivial x;
   i32 c;
 };
 


### PR DESCRIPTION
The attribute still seems to do nothing, but we should at least try to use it to look for MSVC code potentially creating overlapping types.

No idea why it's doing nothing still..