### PR TITLE
Prevent `{}` or `{stuff...}` construction of the UnsafeFnMarker

### DIFF
--- a/assertions/unreachable_unittest.cc
+++ b/assertions/unreachable_unittest.cc
@@ -14,6 +14,7 @@
 
 #include "assertions/unreachable.h"
 
+#include "prelude.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
 namespace sus {
@@ -27,14 +28,13 @@ TEST(Unreachable, Unreachable) {
 
 TEST(Unreachable, Unchecked) {
   switch (0) {
-  case 0:
-    break;
-  case 1:
-    // We can't actually land here or we'd introduce UB, but the confirms we can
-    // write it and it compiles.
-    unreachable_unchecked(unsafe_fn);
+    case 0: break;
+    case 1:
+      // We can't actually land here or we'd introduce UB, but the confirms we
+      // can write it and it compiles.
+      unreachable_unchecked(unsafe_fn);
   }
 }
 
-} // namespace
-} // namespace sus
+}  // namespace
+}  // namespace sus

--- a/containers/__private/array_iter.h
+++ b/containers/__private/array_iter.h
@@ -19,6 +19,7 @@
 #include <type_traits>
 
 #include "iter/iterator_defn.h"
+#include "marker/unsafe.h"
 #include "mem/move.h"
 #include "mem/mref.h"
 #include "num/unsigned_integer.h"
@@ -47,7 +48,7 @@ struct ArrayIntoIter : public ::sus::iter::IteratorBase<Item> {
     // observations we have here, as next_index_ is a field and changes across
     // multiple method calls.
     Item& item = array_.get_unchecked_mut(
-        unsafe_fn,
+        ::sus::marker::unsafe_fn,
         ::sus::mem::replace(mref(next_index_), next_index_ + 1_usize));
     return Option<Item>::some(move(item));
   }
@@ -59,7 +60,8 @@ struct ArrayIntoIter : public ::sus::iter::IteratorBase<Item> {
   usize next_index_ = 0_usize;
   Array<Item, N> array_;
 
-  sus_class_maybe_trivial_relocatable_types(unsafe_fn, decltype(next_index_),
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                            decltype(next_index_),
                                             decltype(array_));
 };
 

--- a/containers/__private/slice_iter.h
+++ b/containers/__private/slice_iter.h
@@ -58,7 +58,7 @@ struct [[sus_trivial_abi]] SliceIter
   const Item* ptr_;
   const Item* end_;
 
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(ptr_),
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(ptr_),
                                              decltype(end_));
 };
 
@@ -89,7 +89,7 @@ struct [[sus_trivial_abi]] SliceIterMut
   Item* ptr_;
   Item* end_;
 
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(ptr_),
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(ptr_),
                                              decltype(end_));
 };
 

--- a/containers/__private/vec_iter.h
+++ b/containers/__private/vec_iter.h
@@ -19,6 +19,7 @@
 #include <type_traits>
 
 #include "iter/iterator_defn.h"
+#include "marker/unsafe.h"
 #include "mem/move.h"
 #include "mem/mref.h"
 #include "num/unsigned_integer.h"
@@ -46,7 +47,7 @@ struct VecIntoIter : public ::sus::iter::IteratorBase<Item> {
     // observations we have here, as next_index_ is a field and changes across
     // multiple method calls.
     Item& item = vec_.get_unchecked_mut(
-        unsafe_fn,
+        ::sus::marker::unsafe_fn,
         ::sus::mem::replace(mref(next_index_), next_index_ + 1_usize));
     return Option<Item>::some(move(item));
   }
@@ -58,7 +59,8 @@ struct VecIntoIter : public ::sus::iter::IteratorBase<Item> {
   usize next_index_ = 0_usize;
   Vec<Item> vec_;
 
-  sus_class_maybe_trivial_relocatable_types(unsafe_fn, decltype(next_index_),
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                            decltype(next_index_),
                                             decltype(vec_));
 };
 

--- a/containers/array.h
+++ b/containers/array.h
@@ -111,7 +111,7 @@ class Array final {
   Array(Array&& o)
       // TODO: Make a NonTrivialMove<T>.
     requires(::sus::mem::Move<T> && !std::is_trivially_move_constructible_v<T>)
-  : Array(kWithUninitialized) {
+      : Array(kWithUninitialized) {
     for (auto i = size_t{0}; i < N; ++i)
       new (as_mut_ptr() + i) T(::sus::move(o.storage_.data_[i]));
   }
@@ -136,7 +136,7 @@ class Array final {
   constexpr Array clone() const& noexcept
     requires(::sus::mem::Clone<T>)
   {
-    auto ar = Array::with_uninitialized(unsafe_fn);
+    auto ar = Array::with_uninitialized(::sus::marker::unsafe_fn);
     for (auto i = size_t{0}; i < N; ++i) {
       new (ar.as_mut_ptr() + i) T(::sus::clone(storage_.data_[i]));
     }
@@ -147,8 +147,8 @@ class Array final {
     requires(::sus::mem::Clone<T>)
   {
     for (auto i = size_t{0}; i < N; ++i) {
-      ::sus::clone_into(mref(get_unchecked_mut(unsafe_fn, i)),
-                        other.get_unchecked(unsafe_fn, i));
+      ::sus::clone_into(mref(get_unchecked_mut(::sus::marker::unsafe_fn, i)),
+                        other.get_unchecked(::sus::marker::unsafe_fn, i));
     }
   }
 
@@ -333,9 +333,9 @@ class Array final {
   };
 
   sus_class_trivial_relocatable_value(
-      unsafe_fn, (N >= 2 && ::sus::mem::relocate_array_by_memcpy<T>) ||
-                     (N == 1 && ::sus::mem::relocate_one_by_memcpy<T>) ||
-                     N == 0);
+      ::sus::marker::unsafe_fn,
+      (N >= 2 && ::sus::mem::relocate_array_by_memcpy<T>) ||
+          (N == 1 && ::sus::mem::relocate_one_by_memcpy<T>) || N == 0);
 };
 
 namespace __private {
@@ -395,15 +395,15 @@ using ::sus::iter::__private::end;
 // Support for structured binding.
 template <size_t I, class T, size_t N>
 const auto& get(const Array<T, N>& a) noexcept {
-  return a.get_unchecked(unsafe_fn, I);
+  return a.get_unchecked(::sus::marker::unsafe_fn, I);
 }
 template <size_t I, class T, size_t N>
 auto& get(Array<T, N>& a) noexcept {
-  return a.get_unchecked_mut(unsafe_fn, I);
+  return a.get_unchecked_mut(::sus::marker::unsafe_fn, I);
 }
 template <size_t I, class T, size_t N>
 auto get(Array<T, N>&& a) noexcept {
-  return ::sus::move(a.get_unchecked_mut(unsafe_fn, I));
+  return ::sus::move(a.get_unchecked_mut(::sus::marker::unsafe_fn, I));
 }
 
 }  // namespace sus::containers

--- a/containers/slice.h
+++ b/containers/slice.h
@@ -164,7 +164,7 @@ class Slice {
   T* data_;
   ::sus::usize len_;
 
-  sus_class_never_value_field(unsafe_fn, Slice, data_, nullptr);
+  sus_class_never_value_field(::sus::marker::unsafe_fn, Slice, data_, nullptr);
 };
 
 // Implicit for-ranged loop iteration via `Slice::iter()`.

--- a/containers/vec.h
+++ b/containers/vec.h
@@ -86,7 +86,7 @@ class Vec {
   {
     auto v = Vec::with_capacity(capacity_);
     for (auto i = size_t{0}; i < len_; ++i) {
-      new (v.as_mut_ptr() + i) T(::sus::clone(get_unchecked(unsafe_fn, i)));
+      new (v.as_mut_ptr() + i) T(::sus::clone(get_unchecked(::sus::marker::unsafe_fn, i)));
     }
     v.len_ = len_;
     return v;
@@ -106,15 +106,15 @@ class Vec {
       const size_t in_place_count =
           sus::ops::min(len_, source.len_).primitive_value;
       for (auto i = size_t{0}; i < in_place_count; ++i) {
-        ::sus::clone_into(mref(get_unchecked_mut(unsafe_fn, i)),
-                          source.get_unchecked(unsafe_fn, i));
+        ::sus::clone_into(mref(get_unchecked_mut(::sus::marker::unsafe_fn, i)),
+                          source.get_unchecked(::sus::marker::unsafe_fn, i));
       }
       for (auto i = in_place_count; i < len_; ++i) {
-        get_unchecked_mut(unsafe_fn, i).~T();
+        get_unchecked_mut(::sus::marker::unsafe_fn, i).~T();
       }
       for (auto i = in_place_count; i < source.len_; ++i) {
         new (as_mut_ptr() + i)
-            T(::sus::clone(source.get_unchecked(unsafe_fn, i)));
+            T(::sus::clone(source.get_unchecked(::sus::marker::unsafe_fn, i)));
       }
       len_ = source.len_;
     }
@@ -227,7 +227,7 @@ class Vec {
   constexpr Option<const T&> get_ref(usize i) const& noexcept {
     if (i >= len_) [[unlikely]]
       return Option<const T&>::none();
-    return Option<const T&>::some(get_unchecked(unsafe_fn, i));
+    return Option<const T&>::some(get_unchecked(::sus::marker::unsafe_fn, i));
   }
   constexpr Option<const T&> get(usize i) && = delete;
 
@@ -235,7 +235,7 @@ class Vec {
   constexpr Option<T&> get_mut(usize i) & noexcept {
     if (i >= len_) [[unlikely]]
       return Option<T&>::none();
-    return Option<T&>::some(mref(get_unchecked_mut(unsafe_fn, i)));
+    return Option<T&>::some(mref(get_unchecked_mut(::sus::marker::unsafe_fn, i)));
   }
 
   /// Returns a const reference to the element at index `i`.
@@ -262,13 +262,13 @@ class Vec {
 
   constexpr inline const T& operator[](usize i) const& noexcept {
     check(i < len_);
-    return get_unchecked(unsafe_fn, i);
+    return get_unchecked(::sus::marker::unsafe_fn, i);
   }
   constexpr inline const T& operator[](usize i) && = delete;
 
   constexpr inline T& operator[](usize i) & noexcept {
     check(i < len_);
-    return get_unchecked_mut(unsafe_fn, i);
+    return get_unchecked_mut(::sus::marker::unsafe_fn, i);
   }
 
   /// Returns a const pointer to the first element in the vector.
@@ -380,8 +380,8 @@ class Vec {
   usize len_;
   usize capacity_;
 
-  sus_class_never_value_field(unsafe_fn, Vec, storage_, nullptr);
-  sus_class_trivial_relocatable_value(unsafe_fn,
+  sus_class_never_value_field(::sus::marker::unsafe_fn, Vec, storage_, nullptr);
+  sus_class_trivial_relocatable_value(::sus::marker::unsafe_fn,
                                       sus::mem::relocate_array_by_memcpy<T>);
 };
 

--- a/fn/fn_defn.h
+++ b/fn/fn_defn.h
@@ -241,10 +241,10 @@ class [[sus_trivial_abi]] FnOnce<R(CallArgs...)> {
   __private::FnType type_;
 
  private:
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(fn_ptr_),
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(fn_ptr_),
                                              decltype(storage_),
                                              decltype(type_));
-  sus_class_never_value_field(unsafe_fn, FnOnce, type_,
+  sus_class_never_value_field(::sus::marker::unsafe_fn, FnOnce, type_,
                               static_cast<__private::FnType>(0));
 };
 
@@ -371,7 +371,7 @@ class [[sus_trivial_abi]] FnMut<R(CallArgs...)>
       : FnOnce<R(CallArgs...)>(c, ::sus::move(lambda)) {}
 
  private:
-  sus_class_trivial_relocatable(unsafe_fn);
+  sus_class_trivial_relocatable(::sus::marker::unsafe_fn);
 };
 
 /// A closure that erases the type of the internal callable object (lambda). A
@@ -495,7 +495,7 @@ class [[sus_trivial_abi]] Fn<R(CallArgs...)> final
   Fn(__private::StorageConstructionFnType, F&& fn) noexcept;
 
  private:
-  sus_class_trivial_relocatable(unsafe_fn);
+  sus_class_trivial_relocatable(::sus::marker::unsafe_fn);
 };
 
 }  // namespace sus::fn

--- a/fn/fn_impl.h
+++ b/fn/fn_impl.h
@@ -154,7 +154,7 @@ R FnOnce<R(CallArgs...)>::operator()(CallArgs&&... args) && noexcept {
                               forward<CallArgs>(args)...);
     }
   }
-  ::sus::unreachable_unchecked(unsafe_fn);
+  ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
 }
 
 template <class R, class... CallArgs>
@@ -173,7 +173,7 @@ R FnMut<R(CallArgs...)>::operator()(CallArgs&&... args) & noexcept {
           forward<CallArgs>(args)...);
     }
   }
-  ::sus::unreachable_unchecked(unsafe_fn);
+  ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
 }
 
 template <class R, class... CallArgs>
@@ -192,7 +192,7 @@ R Fn<R(CallArgs...)>::operator()(CallArgs&&... args) const& noexcept {
           forward<CallArgs>(args)...);
     }
   }
-  ::sus::unreachable_unchecked(unsafe_fn);
+  ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
 }
 
 }  // namespace sus::fn

--- a/iter/__private/adaptors.h
+++ b/iter/__private/adaptors.h
@@ -23,10 +23,10 @@ struct Unwrapper : public ::sus::iter::IteratorBase<U> {
     Option<Item> try_item = iter.next();
     if (try_item.is_none()) return Option<U>::none();
     Result<U, E> result =
-        make_result(::sus::move(try_item).unwrap_unchecked(unsafe_fn));
+        make_result(::sus::move(try_item).unwrap_unchecked(::sus::marker::unsafe_fn));
     if (result.is_ok())
-      return Option<U>::some(::sus::move(result).unwrap_unchecked(unsafe_fn));
-    err.insert(::sus::move(result).unwrap_err_unchecked(unsafe_fn));
+      return Option<U>::some(::sus::move(result).unwrap_unchecked(::sus::marker::unsafe_fn));
+    err.insert(::sus::move(result).unwrap_err_unchecked(::sus::marker::unsafe_fn));
     return Option<U>::none();
   }
 

--- a/iter/filter.h
+++ b/iter/filter.h
@@ -42,7 +42,7 @@ class Filter : public IteratorBase<Item> {
     // TODO: Just call find(pred) on itself?
     while (true) {
       Option<Item> item = next_iter.next();
-      if (item.is_none() || pred(item.as_ref().unwrap_unchecked(unsafe_fn)))
+      if (item.is_none() || pred(item.as_ref().unwrap_unchecked(::sus::marker::unsafe_fn)))
         return item;
     }
   }
@@ -59,7 +59,7 @@ class Filter : public IteratorBase<Item> {
   // pushing the inner Iterator onto the heap if needed. Likewise, the
   // predicate is known to be trivially relocatable because the FnMut will
   // either be a function pointer or a heap allocation itself.
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(pred_),
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(pred_),
                                              decltype(next_iter_));
 };
 

--- a/iter/iterator_impl.h
+++ b/iter/iterator_impl.h
@@ -44,7 +44,7 @@ bool IteratorBase<Item>::all(::sus::fn::FnMut<bool(Item)> f) noexcept {
     Option<Item> item = next();
     if (item.is_none()) return true;
     // Safety: `item` was checked to hold Some already.
-    if (!f(item.take().unwrap_unchecked(unsafe_fn))) return false;
+    if (!f(item.take().unwrap_unchecked(::sus::marker::unsafe_fn))) return false;
   }
 }
 
@@ -54,7 +54,7 @@ bool IteratorBase<Item>::any(::sus::fn::FnMut<bool(Item)> f) noexcept {
     Option<Item> item = next();
     if (item.is_none()) return false;
     // Safety: `item` was checked to hold Some already.
-    if (f(item.take().unwrap_unchecked(unsafe_fn))) return true;
+    if (f(item.take().unwrap_unchecked(::sus::marker::unsafe_fn))) return true;
   }
 }
 

--- a/iter/iterator_unittest.cc
+++ b/iter/iterator_unittest.cc
@@ -19,6 +19,7 @@
 #include "containers/array.h"
 #include "iter/filter.h"
 #include "macros/__private/compiler_bugs.h"
+#include "prelude.h"
 #include "third_party/googletest/googletest/include/gtest/gtest.h"
 
 using ::sus::containers::Array;

--- a/iter/once.h
+++ b/iter/once.h
@@ -63,7 +63,7 @@ class [[sus_trivial_abi]] Once : public IteratorBase<Item> {
 
   RelocatableStorage<Item> single_;
 
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(single_));
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(single_));
 };
 
 template <class Item>

--- a/iter/sized_iterator.h
+++ b/iter/sized_iterator.h
@@ -44,7 +44,7 @@ struct [[sus_trivial_abi]] SizedIterator final {
   void (*destroy)(char& sized);
 
  private:
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(sized[0]),
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(sized[0]),
                                              decltype(destroy));
 };
 
@@ -71,7 +71,7 @@ struct [[sus_trivial_abi]] SizedIterator<Item, SubclassSize, SubclassAlign,
   void (*destroy)(IteratorBase<Item>& sized);
 
  private:
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(iter),
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(iter),
                                              decltype(destroy));
 };
 

--- a/marker/unsafe.h
+++ b/marker/unsafe.h
@@ -16,11 +16,17 @@
 
 namespace sus::marker {
 
-class UnsafeFnMarker {};
+namespace __private {
+enum class UnsafeFnMarkerConstructor { F };
+}
 
-constexpr inline UnsafeFnMarker unsafe_fn;
+struct UnsafeFnMarker {
+  // Prevent `{}` or `{any values...}` from being used to construct an
+  // `UnsafeFnMarker`, the marker should only be used as `unsafe_fn`.
+  consteval UnsafeFnMarker(__private::UnsafeFnMarkerConstructor) {}
+};
+
+constexpr inline auto unsafe_fn =
+    UnsafeFnMarker(::sus::marker::__private::UnsafeFnMarkerConstructor::F);
 
 }  // namespace sus::marker
-
-// TODO: Provide a way to opt in/out of these in the toplevel namespace.
-using sus::marker::unsafe_fn;

--- a/mem/__private/relocatable_storage.h
+++ b/mem/__private/relocatable_storage.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "marker/unsafe.h"
 #include "mem/move.h"
 #include "mem/mref.h"
 #include "mem/relocate.h"
@@ -64,7 +65,8 @@ struct [[sus_trivial_abi]] RelocatableStorage<T> final {
 
   Option<T&> heap_;
 
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(heap_));
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                             decltype(heap_));
 };
 
 template <class T>
@@ -87,7 +89,8 @@ struct [[sus_trivial_abi]] RelocatableStorage<T> final {
   // needed.
   Option<T> stack_;
 
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(stack_));
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                             decltype(stack_));
 };
 
 }  // namespace sus::mem::__private

--- a/mem/mref.h
+++ b/mem/mref.h
@@ -103,7 +103,7 @@ struct [[sus_trivial_abi]] Mref final {
 
   T& t_;
 
-  sus_class_assert_trivial_relocatable_types(unsafe_fn, decltype(t_));
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn, decltype(t_));
 };
 
 }  // namespace sus::mem

--- a/mem/nonnull.h
+++ b/mem/nonnull.h
@@ -139,7 +139,7 @@ struct [[sus_trivial_abi]] NonNull {
   template <class U>
     requires(std::is_convertible_v<T*, U*>)
   NonNull<U> cast() const {
-    return NonNull<U>::with_ptr_unchecked(unsafe_fn, static_cast<U*>(ptr_));
+    return NonNull<U>::with_ptr_unchecked(::sus::marker::unsafe_fn, static_cast<U*>(ptr_));
   }
 
   /// Cast the pointer of type `T` in NonNull<T> to a pointer of type `U` and
@@ -149,7 +149,7 @@ struct [[sus_trivial_abi]] NonNull {
   /// The pointee must be a `U*` or this results in Undefined Behaviour.
   template <class U>
   NonNull<U> downcast(::sus::marker::UnsafeFnMarker) const {
-    return NonNull<U>::with_ptr_unchecked(unsafe_fn, static_cast<U*>(ptr_));
+    return NonNull<U>::with_ptr_unchecked(::sus::marker::unsafe_fn, static_cast<U*>(ptr_));
   }
 
  private:
@@ -160,10 +160,10 @@ struct [[sus_trivial_abi]] NonNull {
 
   // Declare that this type can always be trivially relocated for library
   // optimizations.
-  sus_class_trivial_relocatable(unsafe_fn);
+  sus_class_trivial_relocatable(::sus::marker::unsafe_fn);
   // Declare that the `ptr_` field is never set to `nullptr` for library
   // optimizations.
-  sus_class_never_value_field(unsafe_fn, NonNull, ptr_, nullptr);
+  sus_class_never_value_field(::sus::marker::unsafe_fn, NonNull, ptr_, nullptr);
 };
 
 /// sus::ops::Eq<NonNull<T>> trait.

--- a/mem/relocate.h
+++ b/mem/relocate.h
@@ -31,9 +31,8 @@ struct relocatable_tag final {
 
   static constexpr bool value(int)
     requires requires {
-               requires(std::same_as<decltype(T::SusUnsafeTrivialRelocate),
-                                     const bool>);
-             }
+      requires(std::same_as<decltype(T::SusUnsafeTrivialRelocate), const bool>);
+    }
   {
     return T::SusUnsafeTrivialRelocate;
   };
@@ -141,16 +140,17 @@ concept relocate_one_by_memcpy =
 ///
 /// To additionally allow the class to be passed in registers, the class can be
 /// marked with the `sus_trivial_abi` attribute.
-#define sus_class_trivial_relocatable(unsafe_fn)                      \
-  static_assert(std::is_same_v<decltype(unsafe_fn),                   \
+#define sus_class_trivial_relocatable(unsafe_fn)       \
+  static_assert(std::is_same_v<decltype(unsafe_fn),    \
                                const ::sus::marker::UnsafeFnMarker>); \
   template <class SusOuterClassTypeForTriviallyReloc>                 \
   friend struct ::sus::mem::__private::relocatable_tag;               \
   static constexpr bool SusUnsafeTrivialRelocate = true
 
 /// Mark a class as trivially relocatable based on a compile-time condition.
-#define sus_class_trivial_relocatable_value(unsafe_fn, is_trivially_reloc)   \
-  static_assert(std::is_same_v<decltype(unsafe_fn),                          \
+#define sus_class_trivial_relocatable_value(unsafe_fn,        \
+                                            is_trivially_reloc)              \
+  static_assert(std::is_same_v<decltype(unsafe_fn),           \
                                const ::sus::marker::UnsafeFnMarker>);        \
   static_assert(                                                             \
       std::is_same_v<std::remove_cv_t<decltype(is_trivially_reloc)>, bool>); \
@@ -160,12 +160,13 @@ concept relocate_one_by_memcpy =
 
 /// Mark a class as trivially relocatable if all of the types passed as
 /// arguments are also marked as such.
-#define sus_class_maybe_trivial_relocatable_types(unsafe_fn, ...)     \
-  static_assert(std::is_same_v<decltype(unsafe_fn),                   \
-                               const ::sus::marker::UnsafeFnMarker>); \
-  template <class SusOuterClassTypeForTriviallyReloc>                 \
-  friend struct ::sus::mem::__private::relocatable_tag;               \
-  static constexpr bool SusUnsafeTrivialRelocate =                    \
+#define sus_class_maybe_trivial_relocatable_types(unsafe_fn, \
+                                                  ...)                      \
+  static_assert(std::is_same_v<decltype(unsafe_fn),          \
+                               const ::sus::marker::UnsafeFnMarker>);       \
+  template <class SusOuterClassTypeForTriviallyReloc>                       \
+  friend struct ::sus::mem::__private::relocatable_tag;                     \
+  static constexpr bool SusUnsafeTrivialRelocate =                          \
       ::sus::mem::relocate_one_by_memcpy<__VA_ARGS__>
 
 /// Mark a class as unconditionally trivially relocatable while also asserting
@@ -173,10 +174,12 @@ concept relocate_one_by_memcpy =
 ///
 /// To additionally allow the class to be passed in registers, the class can be
 /// marked with the `sus_trivial_abi` attribute.
-#define sus_class_assert_trivial_relocatable_types(unsafe_fn, ...)    \
-  static_assert(std::is_same_v<decltype(unsafe_fn),                   \
-                               const ::sus::marker::UnsafeFnMarker>); \
-  sus_class_maybe_trivial_relocatable_types(unsafe_fn, __VA_ARGS__);  \
-  static_assert(SusUnsafeTrivialRelocate,                             \
-                "Type is not trivially "                              \
+#define sus_class_assert_trivial_relocatable_types(unsafe_fn, \
+                                                   ...)                      \
+  static_assert(std::is_same_v<decltype(unsafe_fn),           \
+                               const ::sus::marker::UnsafeFnMarker>);        \
+  sus_class_maybe_trivial_relocatable_types(unsafe_fn,        \
+                                            __VA_ARGS__);                    \
+  static_assert(SusUnsafeTrivialRelocate,                                    \
+                "Type is not trivially "                                     \
                 "relocatable");

--- a/num/__private/float_macros.h
+++ b/num/__private/float_macros.h
@@ -673,7 +673,7 @@ class Array;
           min.primitive_value <= max.primitive_value);                         \
     /* SAFETY: We have verified that the min and max are not NaN and that      \
      * `min <= max`. */                                                        \
-    return __private::float_clamp(unsafe_fn, primitive_value,                  \
+    return __private::float_clamp(::sus::marker::unsafe_fn, primitive_value, \
                                   min.primitive_value, max.primitive_value);   \
   }
 

--- a/num/__private/intrinsics.h
+++ b/num/__private/intrinsics.h
@@ -328,7 +328,7 @@ template <class T>
   requires(std::is_integral_v<T> && std::is_unsigned_v<T> && sizeof(T) <= 8)
 constexpr sus_always_inline uint32_t leading_zeros(T value) noexcept {
   if (value == 0) return unchecked_mul(unchecked_sizeof<T>(), uint32_t{8});
-  return leading_zeros_nonzero(unsafe_fn, value);
+  return leading_zeros_nonzero(::sus::marker::unsafe_fn, value);
 }
 
 /** Counts the number of trailing zeros in a non-zero input.
@@ -387,7 +387,7 @@ template <class T>
   requires(std::is_integral_v<T> && std::is_unsigned_v<T> && sizeof(T) <= 8)
 constexpr sus_always_inline uint32_t trailing_zeros(T value) noexcept {
   if (value == 0) return static_cast<uint32_t>(sizeof(T) * 8u);
-  return trailing_zeros_nonzero(unsafe_fn, value);
+  return trailing_zeros_nonzero(::sus::marker::unsafe_fn, value);
 }
 
 template <class T>
@@ -973,7 +973,7 @@ sus_always_inline constexpr T one_less_than_next_power_of_two(T x) noexcept {
     // That means the shift is always in-bounds, and some processors (such as
     // intel pre-haswell) have more efficient ctlz intrinsics when the argument
     // is non-zero.
-    const auto z = leading_zeros_nonzero(unsafe_fn, p);
+    const auto z = leading_zeros_nonzero(::sus::marker::unsafe_fn, p);
     return unchecked_shr(max_value<T>(), z);
   }
 }
@@ -1058,7 +1058,7 @@ template <class T>
   requires(std::is_integral_v<T> && sizeof(T) <= 8)
 inline auto into_float(T x) noexcept {
   // SAFETY: Since this isn't a constexpr context, we're okay.
-  return into_float_constexpr(unsafe_fn, x);
+  return into_float_constexpr(::sus::marker::unsafe_fn, x);
 }
 
 template <class T>
@@ -1137,9 +1137,10 @@ sus_always_inline constexpr T nan() noexcept {
   // a constexpr and non-constexpr context. The quiet bit is always set in a
   // constexpr context, so we return a quiet bit here.
   if constexpr (sizeof(T) == sizeof(float))
-    return into_float_constexpr(unsafe_fn, uint32_t{0x7fc00000});
+    return into_float_constexpr(::sus::marker::unsafe_fn, uint32_t{0x7fc00000});
   else
-    return into_float_constexpr(unsafe_fn, uint64_t{0x7ff8000000000000});
+    return into_float_constexpr(::sus::marker::unsafe_fn,
+                                uint64_t{0x7ff8000000000000});
 }
 
 template <class T>
@@ -1148,9 +1149,10 @@ sus_always_inline constexpr T infinity() noexcept {
   // SAFETY: The value being constructed is non a NaN so we can do this in a
   // constexpr way.
   if constexpr (sizeof(T) == sizeof(float))
-    return into_float_constexpr(unsafe_fn, uint32_t{0x7f800000});
+    return into_float_constexpr(::sus::marker::unsafe_fn, uint32_t{0x7f800000});
   else
-    return into_float_constexpr(unsafe_fn, uint64_t{0x7ff0000000000000});
+    return into_float_constexpr(::sus::marker::unsafe_fn,
+                                uint64_t{0x7ff0000000000000});
 }
 
 template <class T>
@@ -1159,9 +1161,10 @@ sus_always_inline constexpr T negative_infinity() noexcept {
   // SAFETY: The value being constructed is non a NaN so we can do this in a
   // constexpr way.
   if constexpr (sizeof(T) == sizeof(float))
-    return into_float_constexpr(unsafe_fn, uint32_t{0xff800000});
+    return into_float_constexpr(::sus::marker::unsafe_fn, uint32_t{0xff800000});
   else
-    return into_float_constexpr(unsafe_fn, uint64_t{0xfff0000000000000});
+    return into_float_constexpr(::sus::marker::unsafe_fn,
+                                uint64_t{0xfff0000000000000});
 }
 
 constexpr inline int32_t exponent_bits(float x) noexcept {
@@ -1315,7 +1318,7 @@ constexpr T truncate_float(T x) noexcept {
   const auto shl = unchecked_shl(shr, trim_bits);
   // SAFETY: The value here is not a NaN, so will give the same value in
   // constexpr and non-constexpr contexts.
-  return into_float_constexpr(unsafe_fn, shl);
+  return into_float_constexpr(::sus::marker::unsafe_fn, shl);
 }
 
 template <class T>
@@ -1334,7 +1337,8 @@ constexpr T float_signum(T x) noexcept {
   const auto signbit = unchecked_and(into_unsigned_integer(x), high_bit<T>());
   // SAFETY: The value passed in is constructed here and is not a NaN.
   return into_float_constexpr(
-      unsafe_fn, unchecked_add(into_unsigned_integer(T{1}), signbit));
+      ::sus::marker::unsafe_fn,
+      unchecked_add(into_unsigned_integer(T{1}), signbit));
 }
 
 template <class T>
@@ -1363,7 +1367,7 @@ constexpr inline ::sus::num::FpCategory float_category(T x) noexcept {
     case norm: return ::sus::num::FpCategory::Normal;
     case subnorm: return ::sus::num::FpCategory::Subnormal;
     case zero: return ::sus::num::FpCategory::Zero;
-    default: ::sus::unreachable_unchecked(unsafe_fn);
+    default: ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
 }
 #else
@@ -1384,7 +1388,7 @@ constexpr inline ::sus::num::FpCategory float_category(T x) noexcept {
       case FP_NORMAL: return ::sus::num::FpCategory::Normal;
       case FP_SUBNORMAL: return ::sus::num::FpCategory::Subnormal;
       case FP_ZERO: return ::sus::num::FpCategory::Zero;
-      default: ::sus::unreachable_unchecked(unsafe_fn);
+      default: ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
     }
   }
 }

--- a/num/__private/signed_integer_macros.h
+++ b/num/__private/signed_integer_macros.h
@@ -617,7 +617,7 @@ class Tuple;
   constexpr Tuple overflowing_div(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       return Tuple::with(MIN(), true);                                         \
     } else {                                                                   \
@@ -636,7 +636,7 @@ class Tuple;
   constexpr T saturating_div(const T& rhs) const& noexcept {                   \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       /* Only overflows in the case of -MIN() / -1, which gives MAX() + 1,     \
        saturated to MAX(). */                                                  \
@@ -660,7 +660,7 @@ class Tuple;
   constexpr T wrapping_div(const T& rhs) const& noexcept {                     \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       /* Only overflows in the case of -MIN() / -1, which gives MAX() + 1,     \
        that wraps around to MIN(). */                                          \
@@ -802,7 +802,7 @@ class Tuple;
   constexpr Tuple overflowing_rem(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       return Tuple::with(PrimitiveT{0}, true);                                 \
     } else {                                                                   \
@@ -822,7 +822,7 @@ class Tuple;
   constexpr T wrapping_rem(const T& rhs) const& noexcept {                     \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[likely]] {    \
       return PrimitiveT{0};                                                    \
     } else {                                                                   \
@@ -849,7 +849,7 @@ class Tuple;
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(                                                              \
         !__private::div_overflows(primitive_value, rhs.primitive_value));      \
-    return __private::div_euclid(unsafe_fn, primitive_value,                   \
+    return __private::div_euclid(::sus::marker::unsafe_fn, primitive_value,                   \
                                  rhs.primitive_value);                         \
   }                                                                            \
                                                                                \
@@ -861,7 +861,7 @@ class Tuple;
         [[unlikely]] {                                                         \
       return Option<T>::none();                                                \
     } else {                                                                   \
-      return Option<T>::some(__private::div_euclid(unsafe_fn, primitive_value, \
+      return Option<T>::some(__private::div_euclid(::sus::marker::unsafe_fn, primitive_value, \
                                                    rhs.primitive_value));      \
     }                                                                          \
   }                                                                            \
@@ -879,11 +879,11 @@ class Tuple;
   constexpr Tuple overflowing_div_euclid(const T& rhs) const& noexcept {       \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       return Tuple::with(MIN(), true);                                         \
     } else {                                                                   \
-      return Tuple::with(__private::div_euclid(unsafe_fn, primitive_value,     \
+      return Tuple::with(__private::div_euclid(::sus::marker::unsafe_fn, primitive_value,     \
                                                rhs.primitive_value),           \
                          false);                                               \
     }                                                                          \
@@ -903,11 +903,11 @@ class Tuple;
   constexpr T wrapping_div_euclid(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       return MIN();                                                            \
     } else {                                                                   \
-      return __private::div_euclid(unsafe_fn, primitive_value,                 \
+      return __private::div_euclid(::sus::marker::unsafe_fn, primitive_value,                 \
                                    rhs.primitive_value);                       \
     }                                                                          \
   }                                                                            \
@@ -925,7 +925,7 @@ class Tuple;
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(                                                              \
         !__private::div_overflows(primitive_value, rhs.primitive_value));      \
-    return __private::rem_euclid(unsafe_fn, primitive_value,                   \
+    return __private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,                   \
                                  rhs.primitive_value);                         \
   }                                                                            \
                                                                                \
@@ -937,7 +937,7 @@ class Tuple;
         [[unlikely]] {                                                         \
       return Option<T>::none();                                                \
     } else {                                                                   \
-      return Option<T>::some(__private::rem_euclid(unsafe_fn, primitive_value, \
+      return Option<T>::some(__private::rem_euclid(::sus::marker::unsafe_fn, primitive_value, \
                                                    rhs.primitive_value));      \
     }                                                                          \
   }                                                                            \
@@ -955,11 +955,11 @@ class Tuple;
   constexpr Tuple overflowing_rem_euclid(const T& rhs) const& noexcept {       \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       return Tuple::with(PrimitiveT{0}, true);                                 \
     } else {                                                                   \
-      return Tuple::with(__private::rem_euclid(unsafe_fn, primitive_value,     \
+      return Tuple::with(__private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,     \
                                                rhs.primitive_value),           \
                          false);                                               \
     }                                                                          \
@@ -978,11 +978,11 @@ class Tuple;
   constexpr T wrapping_rem_euclid(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(unsafe_fn, primitive_value,           \
+    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
                                          rhs.primitive_value)) [[unlikely]] {  \
       return PrimitiveT{0};                                                    \
     } else {                                                                   \
-      return __private::rem_euclid(unsafe_fn, primitive_value,                 \
+      return __private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,                 \
                                    rhs.primitive_value);                       \
     }                                                                          \
   }                                                                            \
@@ -1305,7 +1305,7 @@ class Tuple;
       return Option<u32>::none();                                             \
     } else {                                                                  \
       uint32_t zeros = __private::leading_zeros_nonzero(                      \
-          unsafe_fn, __private::into_unsigned(primitive_value));              \
+          ::sus::marker::unsafe_fn, __private::into_unsigned(primitive_value));              \
       return Option<u32>::some(BITS() - 1_u32 - u32(zeros));                  \
     }                                                                         \
   }                                                                           \
@@ -1467,7 +1467,7 @@ class Tuple;
       }                                                                       \
       return bytes;                                                           \
     } else {                                                                  \
-      auto bytes = Array::with_uninitialized(unsafe_fn);                      \
+      auto bytes = Array::with_uninitialized(::sus::marker::unsafe_fn);       \
       memcpy(bytes.as_mut_ptr(), &primitive_value, Bytes);                    \
       return bytes;                                                           \
     }                                                                         \

--- a/num/__private/unsigned_integer_macros.h
+++ b/num/__private/unsigned_integer_macros.h
@@ -1061,8 +1061,8 @@ class Tuple;
     if (primitive_value == 0u) [[unlikely]] {                                 \
       return Option<u32>::none();                                             \
     } else {                                                                  \
-      uint32_t zeros =                                                        \
-          __private::leading_zeros_nonzero(unsafe_fn, primitive_value);       \
+      uint32_t zeros = __private::leading_zeros_nonzero(                      \
+          ::sus::marker::unsafe_fn, primitive_value);                         \
       return Option<u32>::some(BITS() - u32(1u) - u32(zeros));                \
     }                                                                         \
   }                                                                           \
@@ -1261,7 +1261,7 @@ class Tuple;
       }                                                                       \
       return bytes;                                                           \
     } else {                                                                  \
-      auto bytes = Array::with_uninitialized(unsafe_fn);                      \
+      auto bytes = Array::with_uninitialized(::sus::marker::unsafe_fn);       \
       memcpy(bytes.as_mut_ptr(), &primitive_value, Bytes);                    \
       return bytes;                                                           \
     }                                                                         \

--- a/option/__private/storage.h
+++ b/option/__private/storage.h
@@ -105,7 +105,7 @@ struct Storage<T, false> final {
 
   [[nodiscard]] constexpr inline T take_and_set_none() noexcept {
     state_ = None;
-    return ::sus::mem::take_and_destruct(unsafe_fn, mref(val_));
+    return ::sus::mem::take_and_destruct(::sus::marker::unsafe_fn, mref(val_));
   }
 
   constexpr inline void set_none() noexcept {
@@ -137,7 +137,7 @@ struct Storage<T, true> final {
   = default;
 
   constexpr Storage() : overlay_() {
-    ::sus::mem::never_value_field<T>::set_never_value(unsafe_fn, overlay_);
+    ::sus::mem::never_value_field<T>::set_never_value(::sus::marker::unsafe_fn, overlay_);
   }
   constexpr Storage(const T& t) : val_(t) {}
   constexpr Storage(T&& t) : val_(::sus::move(t)) {}
@@ -161,7 +161,7 @@ struct Storage<T, true> final {
   // the correct state and thus the correct union field to read, given the
   // current limitations of constexpr in C++20.
   [[nodiscard]] inline State state() const noexcept {
-    return ::sus::mem::never_value_field<T>::is_constructed(unsafe_fn, overlay_)
+    return ::sus::mem::never_value_field<T>::is_constructed(::sus::marker::unsafe_fn, overlay_)
                ? Some
                : None;
   }
@@ -183,10 +183,10 @@ struct Storage<T, true> final {
   }
 
   [[nodiscard]] constexpr inline T take_and_set_none() noexcept {
-    T t = take_and_destruct(unsafe_fn, mref(val_));
+    T t = take_and_destruct(::sus::marker::unsafe_fn, mref(val_));
     // Make the overlay_ field active.
     overlay_ = Overlay();
-    ::sus::mem::never_value_field<T>::set_never_value(unsafe_fn, overlay_);
+    ::sus::mem::never_value_field<T>::set_never_value(::sus::marker::unsafe_fn, overlay_);
     return t;
   }
 
@@ -194,7 +194,7 @@ struct Storage<T, true> final {
     val_.~T();
     // Make the overlay_ field active.
     overlay_ = Overlay();
-    ::sus::mem::never_value_field<T>::set_never_value(unsafe_fn, overlay_);
+    ::sus::mem::never_value_field<T>::set_never_value(::sus::marker::unsafe_fn, overlay_);
   }
 };
 
@@ -211,9 +211,9 @@ struct [[sus_trivial_abi]] StoragePointer {
   T* ptr_;
 
   // Pointers are trivially relocatable.
-  sus_class_trivial_relocatable(unsafe_fn);
+  sus_class_trivial_relocatable(::sus::marker::unsafe_fn);
   // The pointer is never set to null.
-  sus_class_never_value_field(unsafe_fn, StoragePointer, ptr_, nullptr);
+  sus_class_never_value_field(::sus::marker::unsafe_fn, StoragePointer, ptr_, nullptr);
 };
 
 // This must be true in order for StoragePointer to be useful with the

--- a/option/option.h
+++ b/option/option.h
@@ -304,7 +304,7 @@ class Option final {
   /// auto x = Option<int>::some(2);
   /// switch (x) {
   ///  case Some:
-  ///   return sus::move(x).unwrap_unchecked(unsafe_fn);
+  ///   return sus::move(x).unwrap_unchecked(::sus::marker::unsafe_fn);
   ///  case None:
   ///   return -1;
   /// }
@@ -320,7 +320,7 @@ class Option final {
           msg) && noexcept {
     if (!std::is_constant_evaluated())
       ::sus::check_with_message(t_.state() == Some, *msg);
-    return ::sus::move(*this).unwrap_unchecked(unsafe_fn);
+    return ::sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
   }
 
   /// Returns a const reference to the contained value inside the Option.
@@ -357,7 +357,7 @@ class Option final {
   /// currently `None`.
   constexpr T unwrap() && noexcept {
     if (!std::is_constant_evaluated()) ::sus::check(t_.state() == Some);
-    return ::sus::move(*this).unwrap_unchecked(unsafe_fn);
+    return ::sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
   }
 
   /// Returns the contained value inside the Option.
@@ -707,10 +707,10 @@ class Option final {
     } else {
       if (t_.val_.is_ok()) {
         return Result::with(Option<OkType>::some(
-            t_.take_and_set_none().unwrap_unchecked(unsafe_fn)));
+            t_.take_and_set_none().unwrap_unchecked(::sus::marker::unsafe_fn)));
       } else {
         return Result::with_err(
-            t_.take_and_set_none().unwrap_err_unchecked(unsafe_fn));
+            t_.take_and_set_none().unwrap_err_unchecked(::sus::marker::unsafe_fn));
       }
     }
   }
@@ -731,7 +731,7 @@ class Option final {
     requires(::sus::option::__private::IsOptionType<T>::value)
   {
     if (t_.state() == Some)
-      return ::sus::move(*this).unwrap_unchecked(unsafe_fn);
+      return ::sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
     else
       return T::none();
   }
@@ -782,7 +782,7 @@ class Option final {
 
   Storage<T> t_;
 
-  sus_class_maybe_trivial_relocatable_types(unsafe_fn, T);
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn, T);
 };
 
 /// Implementation of Option for a reference type.
@@ -840,7 +840,7 @@ class Option<T&> final {
   /// auto x = Option<int>::some(2);
   /// switch (x) {
   ///  case Some:
-  ///   return sus::move(x).unwrap_unchecked(unsafe_fn);
+  ///   return sus::move(x).unwrap_unchecked(::sus::marker::unsafe_fn);
   ///  case None:
   ///   return -1;
   /// }
@@ -856,7 +856,7 @@ class Option<T&> final {
           msg) && noexcept {
     if (!std::is_constant_evaluated())
       ::sus::check_with_message(t_.state() == Some, *msg);
-    return ::sus::move(*this).unwrap_unchecked(unsafe_fn);
+    return ::sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
   }
 
   /// Returns a const reference to the contained value inside the Option.
@@ -894,7 +894,7 @@ class Option<T&> final {
   /// currently `None`.
   constexpr T& unwrap() && noexcept {
     if (!std::is_constant_evaluated()) ::sus::check(t_.state() == Some);
-    return ::sus::move(*this).unwrap_unchecked(unsafe_fn);
+    return ::sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
   }
 
   /// Returns the contained value inside the Option.
@@ -1210,7 +1210,7 @@ class Option<T&> final {
     requires(::sus::option::__private::IsOptionType<T>::value)
   {
     if (t_.state() == Some)
-      return ::sus::move(*this).unwrap_unchecked(unsafe_fn);
+      return ::sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
     else
       return T::none();
   }
@@ -1268,7 +1268,7 @@ class Option<T&> final {
 
   Storage<StoragePointer<T>> t_;
 
-  sus_class_maybe_trivial_relocatable_types(unsafe_fn, T&);
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn, T&);
 };
 
 /// sus::ops::Eq<Option<U>> trait.
@@ -1280,7 +1280,7 @@ constexpr inline bool operator==(const Option<T>& l,
     case Some: return r.is_some() && l.unwrap_ref() == r.unwrap_ref();
     case None: return r.is_none();
   }
-  ::sus::unreachable_unchecked(unsafe_fn);
+  ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
 }
 
 /// sus::ops::Ord<Option<U>> trait.
@@ -1300,7 +1300,7 @@ constexpr inline auto operator<=>(const Option<T>& l,
       else
         return std::strong_ordering::equivalent;
   }
-  ::sus::unreachable_unchecked(unsafe_fn);
+  ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
 }
 
 /// sus::ops::WeakOrd<Option<U>> trait.
@@ -1320,7 +1320,7 @@ constexpr inline auto operator<=>(const Option<T>& l,
       else
         return std::weak_ordering::equivalent;
   }
-  ::sus::unreachable_unchecked(unsafe_fn);
+  ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
 }
 
 /// sus::ops::PartialOrd<Option<U>> trait.
@@ -1340,7 +1340,7 @@ constexpr inline auto operator<=>(const Option<T>& l,
       else
         return std::partial_ordering::equivalent;
   }
-  ::sus::unreachable_unchecked(unsafe_fn);
+  ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
 }
 
 // Implicit for-ranged loop iteration via `Array::iter()`.

--- a/prelude.h
+++ b/prelude.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "containers/vec.h"
+#include "marker/unsafe.h"
 #include "mem/mref.h"
 #include "num/types.h"
 
@@ -22,6 +23,7 @@
 // TODO: Make a compile-time option for this.
 
 using ::sus::containers::Vec;
+using sus::marker::unsafe_fn;
 using ::sus::mem::mref;
 using sus::num::f32;
 using sus::num::f64;

--- a/result/result.h
+++ b/result/result.h
@@ -156,7 +156,7 @@ class [[nodiscard]] Result final {
       case IsMoved:
         // SAFETY: The state_ is verified to be Ok or Err at the top of the
         // function.
-        ::sus::unreachable_unchecked(unsafe_fn);
+        ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
     }
   }
 
@@ -226,7 +226,7 @@ class [[nodiscard]] Result final {
     }
     // SAFETY: The state_ is verified to be Ok or Err at the top of the
     // function.
-    ::sus::unreachable_unchecked(unsafe_fn);
+    ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
 
   void clone_from(const Result& source) &
@@ -237,7 +237,7 @@ class [[nodiscard]] Result final {
       switch (state_) {
         case IsOk: ::sus::clone_into(mref(storage_.ok_), source.storage_.ok_); break;
         case IsErr: ::sus::clone_into(mref(storage_.err_), source.storage_.err_); break;
-        case IsMoved: ::sus::unreachable_unchecked(unsafe_fn);
+        case IsMoved: ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
       }
     } else {
       *this = source.clone();
@@ -267,7 +267,7 @@ class [[nodiscard]] Result final {
   /// auto x = Result<int, char>::with(2);
   /// switch (x) {
   ///  case Ok:
-  ///   return sus::move(x).unwrap_unchecked(unsafe_fn);
+  ///   return sus::move(x).unwrap_unchecked(::sus::marker::unsafe_fn);
   ///  case Err:
   ///   return -1;
   /// }
@@ -284,13 +284,13 @@ class [[nodiscard]] Result final {
   constexpr inline Option<T> ok() && noexcept {
     ::sus::check(state_ != IsMoved);
     switch (replace(mref(state_), IsMoved)) {
-      case IsOk: return Option<T>::some(take_and_destruct(unsafe_fn, mref(storage_.ok_)));
+      case IsOk: return Option<T>::some(take_and_destruct(::sus::marker::unsafe_fn, mref(storage_.ok_)));
       case IsErr: storage_.err_.~E(); return Option<T>::none();
       case IsMoved: break;
     }
     // SAFETY: The state_ is verified to be Ok or Err at the top of the
     // function.
-    ::sus::unreachable_unchecked(unsafe_fn);
+    ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
 
   /// Converts from `Result<T, E>` to `Option<E>`.
@@ -301,12 +301,12 @@ class [[nodiscard]] Result final {
     ::sus::check(state_ != IsMoved);
     switch (replace(mref(state_), IsMoved)) {
       case IsOk: storage_.ok_.~T(); return Option<E>::none();
-      case IsErr: return Option<E>::some(take_and_destruct(unsafe_fn, mref(storage_.err_)));
+      case IsErr: return Option<E>::some(take_and_destruct(::sus::marker::unsafe_fn, mref(storage_.err_)));
       case IsMoved: break;
     }
     // SAFETY: The state_ is verified to be Ok or Err at the top of the
     // function.
-    ::sus::unreachable_unchecked(unsafe_fn);
+    ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
 
   /// Returns the contained `Ok` value, consuming the self value.
@@ -321,7 +321,7 @@ class [[nodiscard]] Result final {
   constexpr inline T unwrap() && noexcept {
     check_with_message(replace(mref(state_), IsMoved) == IsOk,
                        *"called `Result::unwrap()` on an `Err` value");
-    return take_and_destruct(unsafe_fn, mref(storage_.ok_));
+    return take_and_destruct(::sus::marker::unsafe_fn, mref(storage_.ok_));
   }
 
   /// Returns the contained `Ok` value, consuming the self value, without
@@ -330,7 +330,7 @@ class [[nodiscard]] Result final {
   /// # Safety
   /// Calling this method on an `Err` is Undefined Behavior.
   constexpr inline T unwrap_unchecked(::sus::marker::UnsafeFnMarker) && noexcept {
-    return take_and_destruct(unsafe_fn, mref(storage_.ok_));
+    return take_and_destruct(::sus::marker::unsafe_fn, mref(storage_.ok_));
   }
 
   /// Returns the contained `Err` value, consuming the self value.
@@ -340,7 +340,7 @@ class [[nodiscard]] Result final {
   constexpr inline E unwrap_err() && noexcept {
     check_with_message(replace(mref(state_), IsMoved) == IsErr,
                        *"called `Result::unwrap_err()` on an `Ok` value");
-    return take_and_destruct(unsafe_fn, mref(storage_.err_));
+    return take_and_destruct(::sus::marker::unsafe_fn, mref(storage_.err_));
   }
 
   /// Returns the contained `Err` value, consuming the self value, without
@@ -349,7 +349,7 @@ class [[nodiscard]] Result final {
   /// # Safety
   /// Calling this method on an `Ok` is Undefined Behavior.
   constexpr inline E unwrap_err_unchecked(::sus::marker::UnsafeFnMarker) && noexcept {
-    return take_and_destruct(unsafe_fn, mref(storage_.err_));
+    return take_and_destruct(::sus::marker::unsafe_fn, mref(storage_.err_));
   }
 
   constexpr Iterator<Once<const T&>> iter() const& noexcept {
@@ -372,7 +372,7 @@ class [[nodiscard]] Result final {
   constexpr Iterator<Once<T>> into_iter() && noexcept {
     ::sus::check(state_ != IsMoved);
     if (replace(mref(state_), IsMoved) == IsOk) {
-      return sus::iter::once(Option<T>::some(take_and_destruct(unsafe_fn, mref(storage_.ok_))));
+      return sus::iter::once(Option<T>::some(take_and_destruct(::sus::marker::unsafe_fn, mref(storage_.ok_))));
     } else {
       storage_.err_.~E();
       return sus::iter::once(Option<T>::none());
@@ -396,7 +396,7 @@ class [[nodiscard]] Result final {
   [[sus_no_unique_address]] __private::Storage<T, E> storage_;
   enum FullState { IsErr = 0, IsOk = 1, IsMoved = 2 } state_;
 
-  sus_class_maybe_trivial_relocatable_types(unsafe_fn, T, E);
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn, T, E);
 };
 
 }  // namespace sus::result

--- a/test/behaviour_types.h
+++ b/test/behaviour_types.h
@@ -17,6 +17,7 @@
 #include <type_traits>
 
 #include "macros/__private/compiler_bugs.h"
+#include "marker/unsafe.h"
 #include "mem/relocate.h"
 
 namespace sus::test {
@@ -90,7 +91,7 @@ struct NotTriviallyRelocatableCopyableOrMoveable final {
 };
 
 struct [[sus_trivial_abi]] TrivialAbiRelocatable final {
-  sus_class_trivial_relocatable(unsafe_fn);
+  sus_class_trivial_relocatable(::sus::marker::unsafe_fn);
   TrivialAbiRelocatable(TrivialAbiRelocatable&&) noexcept = default;
   TrivialAbiRelocatable& operator=(TrivialAbiRelocatable&&) noexcept = default;
   ~TrivialAbiRelocatable() {}


### PR DESCRIPTION
It should only be used as `unsafe_fn` in code.

We move the `unsafe_fn` top level defn out to prelude.h, and in the library implementation we use the full namespace path to `::sus::marker::unsafe_fn`.