### PR TITLE
Remove workarounds for offsetof() on clang-cl from the code

### DIFF
--- a/cir/lib/run.cc
+++ b/cir/lib/run.cc
@@ -62,6 +62,12 @@ int run_files(const clang::tooling::CompilationDatabase& compdb,
     // Clang-cl doesn't understand this argument, but it may appear in the
     // command-line for MSVC in C++20 codebases (like subspace).
     std::erase(args, "/Zc:preprocessor");
+
+    // TODO: https://github.com/llvm/llvm-project/issues/59689 clang-cl requires
+    // this define in order to use offsetof() from constant expressions, which
+    // subspace uses for the never-value optimization.
+    args.push_back("/D_CRT_USE_BUILTIN_OFFSETOF");
+
     return std::move(args);
   };
   tool.appendArgumentsAdjuster(adj);

--- a/subspace/CMakeLists.txt
+++ b/subspace/CMakeLists.txt
@@ -150,6 +150,14 @@ add_executable(subspace_unittests
 target_include_directories(subspace PUBLIC .)
 set_target_properties(subspace PROPERTIES LINKER_LANGUAGE CXX)
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
+   CMAKE_CXX_SIMULATE_ID STREQUAL "MSVC")
+    # TODO: https://github.com/llvm/llvm-project/issues/59689
+    # clang-cl requires this define in order to use offsetof() from constant
+    # expressions, which is needed for the never-value optimization.
+    target_compile_options(subspace PUBLIC /D_CRT_USE_BUILTIN_OFFSETOF)
+endif()
+
 # Subspace test support
 target_include_directories(subspace_test_support PUBLIC .)
 set_target_properties(subspace_test_support PROPERTIES LINKER_LANGUAGE CXX)

--- a/subspace/macros/__private/compiler_bugs.h
+++ b/subspace/macros/__private/compiler_bugs.h
@@ -125,13 +125,3 @@
 #define sus_clang_bug_49358(...)
 #define sus_clang_bug_49358_else(...) __VA_ARGS__
 #endif
-
-// TODO: https://github.com/llvm/llvm-project/issues/59689
-// offsetof() is not constant evaluable in clang-cl.
-#if _MSC_VER && __clang_major__ > 0  // TODO: Update when the bug is fixed.
-#define sus_clang_bug_59689(...) __VA_ARGS__
-#define sus_clang_bug_59689_else(...)
-#else
-#define sus_clang_bug_59689(...)
-#define sus_clang_bug_59689_else(...) __VA_ARGS__
-#endif

--- a/subspace/mem/never_value.h
+++ b/subspace/mem/never_value.h
@@ -179,8 +179,7 @@ concept NeverValueField = never_value_access<T>::has_field;
                                                                                \
   template <class SusUnsafeNeverValueOuter,                                    \
             bool SusUnsafeNeverValueStandardLayout =                           \
-                sus_clang_bug_59689(false) sus_clang_bug_59689_else(           \
-                    std::is_standard_layout_v<SusUnsafeNeverValueOuter>)>      \
+                std::is_standard_layout_v<SusUnsafeNeverValueOuter>>           \
   struct SusUnsafeNeverValueOverlay;                                           \
                                                                                \
   template <class SusUnsafeNeverValueOuter>                                    \

--- a/subspace/option/__private/storage.h
+++ b/subspace/option/__private/storage.h
@@ -212,9 +212,7 @@ struct [[sus_trivial_abi]] StoragePointer<T&> {
 // This must be true in order for StoragePointer to be useful with the
 // never-value field optimization.
 // clang-format off
-sus_clang_bug_59689_else(
-  static_assert(::sus::mem::NeverValueField<StoragePointer<int&>>);
-)
+static_assert(::sus::mem::NeverValueField<StoragePointer<int&>>);
 // clang-format on
 
 }  // namespace sus::option::__private


### PR DESCRIPTION
We need to define `_CRT_USE_BUILTIN_OFFSETOF ` when compiling with clang-cl, both for subspace (and its dependents) and for the CIR tool.

The define works around the clang-cl issue
https://github.com/llvm/llvm-project/issues/59689 without requiring code changes.