### PR TITLE
Teach CIR what a function's return type is

### DIFF
--- a/cir/lib/output.h
+++ b/cir/lib/output.h
@@ -33,7 +33,7 @@ struct Output {
     for (const auto& f : functions.iter()) {
       if (saw_fn) s << "\n\n";
       saw_fn = true;
-      s << f.to_string();
+      s << cir::to_string(f);
     }
     return s.str();
   }

--- a/cir/lib/output.h
+++ b/cir/lib/output.h
@@ -23,14 +23,13 @@
 namespace cir {
 
 struct Output {
-  sus::Vec<syntax::Function> functions =
-      sus::Vec<syntax::Function>::with_default();
+  std::unordered_map<syntax::FunctionId, syntax::Function> functions;
 
   std::string to_string() const& noexcept {
     // TODO: Use fmt library (or add such to subspace).
     std::ostringstream s;
     bool saw_fn = false;
-    for (const auto& f : functions.iter()) {
+    for (const auto& [id, f] : functions) {
       if (saw_fn) s << "\n\n";
       saw_fn = true;
       s << cir::to_string(f);

--- a/cir/lib/run.cc
+++ b/cir/lib/run.cc
@@ -91,6 +91,7 @@ sus::Option<Output> run_file(
       cir::visit_decl(mref(ctx), **it, mref(output));
     }
   }
+
   return sus::Option<Output>::some(sus::move(output));
 }
 

--- a/cir/lib/syntax/function.h
+++ b/cir/lib/syntax/function.h
@@ -31,21 +31,25 @@ struct Function {
   Option<syntax::Let> return_var;
 
   const clang::FunctionDecl& decl;
-
-  std::string to_string() const& noexcept {
-    // TODO: Use fmt library (or add such to subspace).
-    std::ostringstream s;
-    s << "fn " << name << "@" << id.primitive_value << "(";
-    // TODO: args
-    s << ") ";
-    if (return_var.is_some()) {
-      s << "-> " << return_var.unwrap_ref().type.to_string() << " ";
-    }
-    s << "{\n";
-    // TODO: body
-    s << "}";
-    return s.str();
-  }
 };
 
 }  // namespace cir::syntax
+
+namespace cir {
+
+inline std::string to_string(const syntax::Function& fn) noexcept {
+  // TODO: Use fmt library (or add such to subspace).
+  std::ostringstream s;
+  s << "fn " << fn.name << "@" << fn.id.primitive_value << "(";
+  // TODO: args
+  s << ") ";
+  if (fn.return_var.is_some()) {
+    s << "-> " << cir::to_string(fn.return_var.unwrap_ref().type) << " ";
+  }
+  s << "{\n";
+  // TODO: body
+  s << "}";
+  return s.str();
+}
+
+}  // namespace cir

--- a/cir/lib/syntax/function.h
+++ b/cir/lib/syntax/function.h
@@ -24,8 +24,12 @@
 
 namespace cir::syntax {
 
+struct FunctionId {
+  u32 num;
+};
+
 struct Function {
-  u32 id;
+  FunctionId id;
   std::string name;
   SourceSpan span;
   Option<syntax::Let> return_var;
@@ -37,10 +41,16 @@ struct Function {
 
 namespace cir {
 
+inline std::string to_string(const syntax::FunctionId& id) noexcept {
+  std::ostringstream s;
+  s << id.num.primitive_value;
+  return s.str();
+}
+
 inline std::string to_string(const syntax::Function& fn) noexcept {
   // TODO: Use fmt library (or add such to subspace).
   std::ostringstream s;
-  s << "fn " << fn.name << "@" << fn.id.primitive_value << "(";
+  s << "fn " << fn.name << "@" << cir::to_string(fn.id) << "(";
   // TODO: args
   s << ") ";
   if (fn.return_var.is_some()) {
@@ -53,3 +63,20 @@ inline std::string to_string(const syntax::Function& fn) noexcept {
 }
 
 }  // namespace cir
+
+namespace std {
+template <>
+struct hash<cir::syntax::FunctionId> {
+  auto operator()(const cir::syntax::FunctionId& i) const {
+    return std::hash<decltype(i.num)>()(i.num);
+  }
+};
+template <>
+struct equal_to<cir::syntax::FunctionId> {
+  auto operator()(const cir::syntax::FunctionId& l,
+                  const cir::syntax::FunctionId& r) const {
+    return l.num == r.num;
+  }
+};
+
+}  // namespace std

--- a/cir/lib/syntax/function.h
+++ b/cir/lib/syntax/function.h
@@ -14,10 +14,11 @@
 
 #pragma once
 
-#include <string>
 #include <sstream>
+#include <string>
 
 #include "cir/lib/source_span.h"
+#include "cir/lib/syntax/statements/let.h"
 #include "cir/llvm.h"
 #include "subspace/prelude.h"
 
@@ -27,15 +28,20 @@ struct Function {
   u32 id;
   std::string name;
   SourceSpan span;
+  Option<syntax::Let> return_var;
 
   const clang::FunctionDecl& decl;
 
   std::string to_string() const& noexcept {
     // TODO: Use fmt library (or add such to subspace).
     std::ostringstream s;
-    s << "fn " << name << "@" << id.primitive_value << " (";
+    s << "fn " << name << "@" << id.primitive_value << "(";
     // TODO: args
-    s << ") {\n";
+    s << ") ";
+    if (return_var.is_some()) {
+      s << "-> " << return_var.unwrap_ref().type.to_string() << " ";
+    }
+    s << "{\n";
     // TODO: body
     s << "}";
     return s.str();

--- a/cir/lib/syntax/pointer_annotations.h
+++ b/cir/lib/syntax/pointer_annotations.h
@@ -23,3 +23,24 @@ struct PointerAnnotations {
 };
 
 }  // namespace cir::syntax
+
+namespace cir {
+
+inline std::string to_string(const syntax::PointerAnnotations& anno) noexcept {
+  // TODO: Use fmt library (or add such to subspace).
+  std::ostringstream s;
+  bool space = false;
+  if (anno.is_const) {
+    if (space) s << " ";
+    s << "const";
+    space = true;
+  }
+  if (anno.is_nullable) {
+    if (space) s << " ";
+    s << "nullable";
+    space = true;
+  }
+  return s.str();
+}
+
+}  // namespace cir

--- a/cir/lib/syntax/pointer_annotations.h
+++ b/cir/lib/syntax/pointer_annotations.h
@@ -16,9 +16,8 @@
 
 namespace cir::syntax {
 
-struct TypeReferenceAnnotations {
+struct PointerAnnotations {
   bool is_const;
-  bool is_volatile;
   bool is_nullable;
   // TODO: lifetimes.
 };

--- a/cir/lib/syntax/statements/let.h
+++ b/cir/lib/syntax/statements/let.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "cir/lib/source_span.h"
 #include "cir/lib/syntax/type_reference.h"
 #include "cir/llvm.h"
@@ -39,13 +41,17 @@ struct Let {
   SourceSpan span;
 
   LetClangType clang_type;
-
-  std::string to_string() const& noexcept {
-    // TODO: Use fmt library (or add such to subspace).
-    std::ostringstream s;
-    s << "let _" << id.primitive_value << ": " << type.to_string() << ";";
-    return s.str();
-  }
 };
 
 }  // namespace cir::syntax
+
+namespace cir {
+
+inline std::string to_string(const syntax::Let& let) noexcept {
+  // TODO: Use fmt library (or add such to subspace).
+  std::ostringstream s;
+  s << "let _" << let.id.primitive_value << ": " << cir::to_string(let.type) << ";";
+  return s.str();
+}
+
+}  // namespace cir

--- a/cir/lib/syntax/statements/let.h
+++ b/cir/lib/syntax/statements/let.h
@@ -14,24 +14,36 @@
 
 #pragma once
 
+#include "cir/lib/source_span.h"
 #include "cir/lib/syntax/type_reference.h"
 #include "cir/llvm.h"
 #include "subspace/prelude.h"
-#include "cir/lib/source_span.h"
+#include "subspace/union/union.h"
 
 namespace cir::syntax {
 
+enum LetClangTypeTag {
+  Return,
+  Variable,
+};
+using LetClangType =
+    sus::Union<sus_value_types((LetClangTypeTag::Return, clang::QualType),
+                               (LetClangTypeTag::Variable, clang::VarDecl&))>;
+
 struct Let {
-  u32 name;
+  Let(u32 id, TypeReference type, SourceSpan span, LetClangType clang_type)
+      : id(id), type(type), span(span), clang_type(clang_type) {}
+
+  u32 id;
   TypeReference type;
   SourceSpan span;
 
-  clang::VarDecl& decl;
+  LetClangType clang_type;
 
   std::string to_string() const& noexcept {
     // TODO: Use fmt library (or add such to subspace).
     std::ostringstream s;
-    s << "let _" << name.primitive_value << ": " << type.to_string() << ";";
+    s << "let _" << id.primitive_value << ": " << type.to_string() << ";";
     return s.str();
   }
 };

--- a/cir/lib/syntax/statements/let.h
+++ b/cir/lib/syntax/statements/let.h
@@ -33,9 +33,6 @@ using LetClangType =
                                (LetClangTypeTag::Variable, clang::VarDecl&))>;
 
 struct Let {
-  Let(u32 id, TypeReference type, SourceSpan span, LetClangType clang_type)
-      : id(id), type(type), span(span), clang_type(clang_type) {}
-
   u32 id;
   TypeReference type;
   SourceSpan span;

--- a/cir/lib/syntax/type_reference.h
+++ b/cir/lib/syntax/type_reference.h
@@ -14,34 +14,51 @@
 
 #pragma once
 
+#include <sstream>
+#include <string>
+
 #include "cir/lib/source_span.h"
 #include "cir/lib/syntax/declared_type.h"
-#include "cir/lib/syntax/type_reference_annotations.h"
+#include "cir/lib/syntax/pointer_annotations.h"
 #include "cir/llvm.h"
+#include "subspace/option/option.h"
 #include "subspace/prelude.h"
 #include "subspace/union/union.h"
 
+using sus::option::Option;
+using sus::union_type::Union;
+
 namespace cir::syntax {
 
-enum class BuiltInTypes {
+enum class BuiltinType {
   Nullptr,
   Bool,
-  Char,  // TODO: Figure out if char is signed and remove this option?
+  Char,
   UChar,
-  SChar,
+  WideChar,
+  UWideChar,
+  Char8,
   Char16,
   Char32,
   Short,
   UShort,
   Int,
-  Uint,
+  UInt,
   Long,
   ULong,
   LongLong,
   ULongLong,
+  Int128,
+  UInt128,
   Float,
   Double,
   LongDouble,
+  ObjCId,
+};
+
+enum class TypeRefKindTag {
+  Builtin,
+  Declared,
   Pointer,
   /// A pointer to a function or method.
   ///
@@ -49,25 +66,132 @@ enum class BuiltInTypes {
   FnPointer,
 };
 
-enum class TypeRefKindTag {
-  Builtin,
-  Declared,
-};
-
 // clang-format off
-using TypeRefKind = sus::Union<sus_value_types(
-    (TypeRefKindTag::Builtin, BuiltInTypes),
-    (TypeRefKindTag::Declared, DeclaredType&),
+using TypeRefKind = Union<sus_value_types(
+    (TypeRefKindTag::Builtin, BuiltinType),
+    (TypeRefKindTag::Declared, DeclaredType),
+    (TypeRefKindTag::Pointer, PointerAnnotations), // TODO: Store the pointee(s) types.
+    (TypeRefKindTag::FnPointer, /* function id */ u32),
 )>;
 // clang-format on
 
+inline Option<BuiltinType> builtin_type(const clang::QualType& q) noexcept {
+  auto* b = clang::dyn_cast<clang::BuiltinType>(&*q.getCanonicalType());
+  if (b == nullptr) return sus::none();
+  switch (b->getKind()) {
+    case clang::BuiltinType::NullPtr: return sus::some(BuiltinType::Nullptr);
+    case clang::BuiltinType::Bool: return sus::some(BuiltinType::Bool);
+    case clang::BuiltinType::Char_U: return sus::some(BuiltinType::UChar);
+    case clang::BuiltinType::UChar: return sus::some(BuiltinType::UChar);
+    case clang::BuiltinType::WChar_U: return sus::some(BuiltinType::UWideChar);
+    case clang::BuiltinType::Char8: return sus::some(BuiltinType::Char8);
+    case clang::BuiltinType::Char16: return sus::some(BuiltinType::Char16);
+    case clang::BuiltinType::Char32: return sus::some(BuiltinType::Char32);
+    case clang::BuiltinType::Char_S: return sus::some(BuiltinType::Char);
+    case clang::BuiltinType::SChar: return sus::some(BuiltinType::Char);
+    case clang::BuiltinType::WChar_S: return sus::some(BuiltinType::WideChar);
+    case clang::BuiltinType::Short: return sus::some(BuiltinType::Short);
+    case clang::BuiltinType::UShort: return sus::some(BuiltinType::UShort);
+    case clang::BuiltinType::Int: return sus::some(BuiltinType::Int);
+    case clang::BuiltinType::UInt: return sus::some(BuiltinType::UInt);
+    case clang::BuiltinType::Long: return sus::some(BuiltinType::Long);
+    case clang::BuiltinType::ULong: return sus::some(BuiltinType::ULong);
+    case clang::BuiltinType::LongLong: return sus::some(BuiltinType::LongLong);
+    case clang::BuiltinType::ULongLong:
+      return sus::some(BuiltinType::ULongLong);
+    case clang::BuiltinType::Int128: return sus::some(BuiltinType::Int128);
+    case clang::BuiltinType::UInt128: return sus::some(BuiltinType::UInt128);
+    case clang::BuiltinType::Float: return sus::some(BuiltinType::Float);
+    case clang::BuiltinType::Double: return sus::some(BuiltinType::Double);
+    case clang::BuiltinType::LongDouble:
+      return sus::some(BuiltinType::LongDouble);
+    case clang::BuiltinType::ObjCId: return sus::some(BuiltinType::ObjCId);
+  }
+  return sus::none();
+}
+
+inline std::string builtin_type_to_string(BuiltinType b) noexcept {
+  switch (b) {
+    case BuiltinType::Nullptr: return "nullptr_t";
+    case BuiltinType::Bool: return "bool";
+    case BuiltinType::Char: return "signed char";
+    case BuiltinType::UChar: return "unsigned char";
+    case BuiltinType::WideChar: return "signed wchar_t";
+    case BuiltinType::UWideChar: return "unsigned wchar_t";
+    case BuiltinType::Char8: return "char8_t";
+    case BuiltinType::Char16: return "char16_t";
+    case BuiltinType::Char32: return "char32_t";
+    case BuiltinType::Short: return "signed short";
+    case BuiltinType::UShort: return "unsigned short";
+    case BuiltinType::Int: return "signed int";
+    case BuiltinType::UInt: return "unsigned int";
+    case BuiltinType::Long: return "signed long";
+    case BuiltinType::ULong: return "unsigned long";
+    case BuiltinType::LongLong: return "signed long long";
+    case BuiltinType::ULongLong: return "unsigned long long";
+    case BuiltinType::Int128: return "int128_t";
+    case BuiltinType::UInt128: return "unsigned int128_t";
+    case BuiltinType::Float: return "float";
+    case BuiltinType::Double: return "double";
+    case BuiltinType::LongDouble: return "long double";
+    case BuiltinType::ObjCId: return "ObjcID";
+  }
+  sus::unreachable();
+}
+
 struct TypeReference {
+  static TypeReference with_return_type(clang::QualType q, bool nullable,
+                                        SourceSpan span) {
+    TypeRefKind kind = [&]() {
+      Option<BuiltinType> b = builtin_type(q);
+      if (b.is_some()) {
+        return TypeRefKind::with<TypeRefKind::Tag::Builtin>(
+            sus::move(b).unwrap());
+      }
+
+      if (q->isPointerType() || q->isReferenceType() ||
+          q->isMemberDataPointerType())
+        return TypeRefKind::with<TypeRefKind::Tag::Pointer>(PointerAnnotations{
+            .is_const = q->getPointeeType().isConstQualified(),
+            .is_nullable = nullable && !q->isReferenceType(),
+            // TODO: lifetimes
+        });
+
+      if (q->isFunctionPointerType() || q->isFunctionReferenceType() ||
+          q->isMemberFunctionPointerType() || q->isReferenceType())
+        return TypeRefKind::with<TypeRefKind::Tag::FnPointer>(
+            // TODO: get the ID from ctx_.
+            0_u32);
+
+      return TypeRefKind::with<TypeRefKind::Tag::Declared>(
+          syntax::DeclaredType::with_qual_type(q, span));
+    }();
+
+    return TypeReference{
+        .kind = sus::move(kind),
+        .span = sus::move(span),
+    };
+  }
+
   TypeRefKind kind;
-  TypeReferenceAnnotations annotations;
   SourceSpan span;
 
   std::string to_string() const& noexcept {
-    return "(TODO: TypeReference)";
+    switch (kind) {
+      case TypeRefKind::Tag::Builtin:
+        return builtin_type_to_string(
+            kind.get_ref<TypeRefKind::Tag::Builtin>());
+      case TypeRefKind::Tag::Declared: return "(TODO: declared type name)";
+      case TypeRefKind::Tag::Pointer: return "(pointer, TODO: pointee types)";
+      case TypeRefKind::Tag::FnPointer: {
+        std::ostringstream s;
+        s << "fn pointer(";
+        s << kind.get_ref<TypeRefKind::Tag::FnPointer>().primitive_value;
+        s << ")";
+        return s.str();
+      }
+    }
+    sus::unreachable();
   }
 };
 

--- a/cir/lib/visit.cc
+++ b/cir/lib/visit.cc
@@ -42,11 +42,14 @@ class Visitor : public clang::RecursiveASTVisitor<Visitor> {
           decl->getReturnType(), /*nullable=*/true,
           SourceSpan::from_decl(*decl));
 
-      return_var.insert(syntax::Let(
-          ctx_.make_local_var_id(), sus::move(type_ref),
-          SourceSpan::from_decl(*decl),
-          syntax::LetClangType::with<syntax::LetClangTypeTag::Return>(
-              decl->getReturnType())));
+      return_var.insert(syntax::Let{
+          .id = ctx_.make_local_var_id(),
+          .type = sus::move(type_ref),
+          .span = SourceSpan::from_decl(*decl),
+          .clang_type =
+              syntax::LetClangType::with<syntax::LetClangTypeTag::Return>(
+                  decl->getReturnType()),
+      });
     }
 
     auto this_param = Option<syntax::Let>::none();

--- a/cir/lib/visit.cc
+++ b/cir/lib/visit.cc
@@ -59,19 +59,22 @@ class Visitor : public clang::RecursiveASTVisitor<Visitor> {
 
     // TODO: The function's parameters and return type.
 
+    auto id = ctx_.make_function_id();
     auto f = syntax::Function{
-        .id = ctx_.make_function_id(),
+        .id = id,
         .name = decl->getNameAsString(),
         .span = SourceSpan::from_decl(*decl),
         .return_var = sus::move(return_var),
         .decl = *decl,
     };
 
+    output_.functions.emplace(id, sus::move(f));
+
     // Recurse so we can tell when we leave the function, and store the
     // syntax::Function in Output when we're done.
-    ctx_.in_functions.push(sus::move(f));
+    ctx_.in_functions.push(id);
     bool b = Visitor(ctx_, output_).TraverseStmt(decl->getBody());
-    output_.functions.push(ctx_.in_functions.pop().unwrap());
+    ctx_.in_functions.pop();
     return b;
   }
 

--- a/cir/lib/visit.h
+++ b/cir/lib/visit.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "cir/lib/output.h"
+#include "cir/lib/syntax/function.h"
 #include "cir/llvm.h"
 #include "subspace/prelude.h"
 
@@ -22,10 +23,12 @@ namespace cir {
 
 struct VisitCtx {
  public:
-  u32 make_function_id() noexcept {
+  syntax::FunctionId make_function_id() noexcept {
     u32 id = next_function_id;
     next_function_id += 1u;
-    return id;
+    return syntax::FunctionId{
+        .num = id,
+    };
   }
 
   u32 make_local_var_id() noexcept {
@@ -35,9 +38,10 @@ struct VisitCtx {
   }
 
   // The back of this Vec is the function whose body is being parsed.
-  Vec<syntax::Function> in_functions = Vec<syntax::Function>::with_default();
+  Vec<syntax::FunctionId> in_functions =
+      Vec<syntax::FunctionId>::with_default();
 
-private:
+ private:
   u32 next_function_id = 0u;
   u32 next_local_var_id = 0u;
 };

--- a/cir/lib/visit.h
+++ b/cir/lib/visit.h
@@ -28,9 +28,9 @@ struct VisitCtx {
     return id;
   }
 
-  u32 make_local_varname() noexcept {
-    u32 id = next_local_varname;
-    next_local_varname += 1u;
+  u32 make_local_var_id() noexcept {
+    u32 id = next_local_var_id;
+    next_local_var_id += 1u;
     return id;
   }
 
@@ -39,7 +39,7 @@ struct VisitCtx {
 
 private:
   u32 next_function_id = 0u;
-  u32 next_local_varname = 0u;
+  u32 next_local_var_id = 0u;
 };
 
 void visit_decl(VisitCtx& ctx, clang::Decl& decl, Output& output) noexcept;

--- a/subspace/CMakeLists.txt
+++ b/subspace/CMakeLists.txt
@@ -71,6 +71,7 @@ add_library(subspace STATIC
     "num/unsigned_integer.h"
     "option/__private/is_option_type.h"
     "option/__private/is_tuple_type.h"
+    "option/__private/marker.h"
     "option/__private/storage.h"
     "option/option.h"
     "option/state.h"

--- a/subspace/num/__private/float_macros.h
+++ b/subspace/num/__private/float_macros.h
@@ -790,3 +790,16 @@ class Array;
   _sus__float_euclid(T, PrimitiveT);                       \
   _sus__float_endian(T, sizeof(PrimitiveT), UnsignedIntT); \
   static_assert(true)
+
+#define _sus__float_hash_equal_to(Type)                                   \
+  template <>                                                              \
+  struct hash<Type> {                                                      \
+    auto operator()(const Type& u) const {                                 \
+      return std::hash<decltype(u.primitive_value)>()(u.primitive_value);  \
+    }                                                                      \
+  };                                                                       \
+  template <>                                                              \
+  struct equal_to<Type> {                                                  \
+    auto operator()(const Type& l, const Type& r) const { return l == r; } \
+  };                                                                       \
+  static_assert(true)

--- a/subspace/num/__private/signed_integer_macros.h
+++ b/subspace/num/__private/signed_integer_macros.h
@@ -1527,8 +1527,8 @@ class Tuple;
 #define _sus__signed_hash_equal_to(Type)                                   \
   template <>                                                              \
   struct hash<Type> {                                                      \
-    auto operator()(const Type& u) const {                                 \
-      return std::hash<decltype(u.primitive_value)>()(u.primitive_value);  \
+    size_t operator()(const Type& u) const {                                 \
+      return u.primitive_value;  \
     }                                                                      \
   };                                                                       \
   template <>                                                              \

--- a/subspace/num/__private/signed_integer_macros.h
+++ b/subspace/num/__private/signed_integer_macros.h
@@ -617,8 +617,9 @@ class Tuple;
   constexpr Tuple overflowing_div(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       return Tuple::with(MIN(), true);                                         \
     } else {                                                                   \
       return Tuple::with(                                                      \
@@ -636,8 +637,9 @@ class Tuple;
   constexpr T saturating_div(const T& rhs) const& noexcept {                   \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       /* Only overflows in the case of -MIN() / -1, which gives MAX() + 1,     \
        saturated to MAX(). */                                                  \
       return MAX();                                                            \
@@ -660,8 +662,9 @@ class Tuple;
   constexpr T wrapping_div(const T& rhs) const& noexcept {                     \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       /* Only overflows in the case of -MIN() / -1, which gives MAX() + 1,     \
        that wraps around to MIN(). */                                          \
       return MIN();                                                            \
@@ -802,8 +805,9 @@ class Tuple;
   constexpr Tuple overflowing_rem(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       return Tuple::with(PrimitiveT{0}, true);                                 \
     } else {                                                                   \
       return Tuple::with(                                                      \
@@ -822,8 +826,9 @@ class Tuple;
   constexpr T wrapping_rem(const T& rhs) const& noexcept {                     \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[likely]] {    \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[likely]] {                                                           \
       return PrimitiveT{0};                                                    \
     } else {                                                                   \
       return static_cast<PrimitiveT>(primitive_value % rhs.primitive_value);   \
@@ -849,7 +854,7 @@ class Tuple;
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(                                                              \
         !__private::div_overflows(primitive_value, rhs.primitive_value));      \
-    return __private::div_euclid(::sus::marker::unsafe_fn, primitive_value,                   \
+    return __private::div_euclid(::sus::marker::unsafe_fn, primitive_value,    \
                                  rhs.primitive_value);                         \
   }                                                                            \
                                                                                \
@@ -861,8 +866,8 @@ class Tuple;
         [[unlikely]] {                                                         \
       return Option<T>::none();                                                \
     } else {                                                                   \
-      return Option<T>::some(__private::div_euclid(::sus::marker::unsafe_fn, primitive_value, \
-                                                   rhs.primitive_value));      \
+      return Option<T>::some(__private::div_euclid(                            \
+          ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value));    \
     }                                                                          \
   }                                                                            \
                                                                                \
@@ -879,13 +884,15 @@ class Tuple;
   constexpr Tuple overflowing_div_euclid(const T& rhs) const& noexcept {       \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       return Tuple::with(MIN(), true);                                         \
     } else {                                                                   \
-      return Tuple::with(__private::div_euclid(::sus::marker::unsafe_fn, primitive_value,     \
-                                               rhs.primitive_value),           \
-                         false);                                               \
+      return Tuple::with(                                                      \
+          __private::div_euclid(::sus::marker::unsafe_fn, primitive_value,     \
+                                rhs.primitive_value),                          \
+          false);                                                              \
     }                                                                          \
   }                                                                            \
                                                                                \
@@ -903,11 +910,12 @@ class Tuple;
   constexpr T wrapping_div_euclid(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       return MIN();                                                            \
     } else {                                                                   \
-      return __private::div_euclid(::sus::marker::unsafe_fn, primitive_value,                 \
+      return __private::div_euclid(::sus::marker::unsafe_fn, primitive_value,  \
                                    rhs.primitive_value);                       \
     }                                                                          \
   }                                                                            \
@@ -925,7 +933,7 @@ class Tuple;
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(                                                              \
         !__private::div_overflows(primitive_value, rhs.primitive_value));      \
-    return __private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,                   \
+    return __private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,    \
                                  rhs.primitive_value);                         \
   }                                                                            \
                                                                                \
@@ -937,8 +945,8 @@ class Tuple;
         [[unlikely]] {                                                         \
       return Option<T>::none();                                                \
     } else {                                                                   \
-      return Option<T>::some(__private::rem_euclid(::sus::marker::unsafe_fn, primitive_value, \
-                                                   rhs.primitive_value));      \
+      return Option<T>::some(__private::rem_euclid(                            \
+          ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value));    \
     }                                                                          \
   }                                                                            \
                                                                                \
@@ -955,13 +963,15 @@ class Tuple;
   constexpr Tuple overflowing_rem_euclid(const T& rhs) const& noexcept {       \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       return Tuple::with(PrimitiveT{0}, true);                                 \
     } else {                                                                   \
-      return Tuple::with(__private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,     \
-                                               rhs.primitive_value),           \
-                         false);                                               \
+      return Tuple::with(                                                      \
+          __private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,     \
+                                rhs.primitive_value),                          \
+          false);                                                              \
     }                                                                          \
   }                                                                            \
                                                                                \
@@ -978,11 +988,12 @@ class Tuple;
   constexpr T wrapping_rem_euclid(const T& rhs) const& noexcept {              \
     /* TODO: Allow opting out of all overflow checks? */                       \
     ::sus::check(rhs.primitive_value != 0);                                    \
-    if (__private::div_overflows_nonzero(::sus::marker::unsafe_fn, primitive_value,           \
-                                         rhs.primitive_value)) [[unlikely]] {  \
+    if (__private::div_overflows_nonzero(                                      \
+            ::sus::marker::unsafe_fn, primitive_value, rhs.primitive_value))   \
+        [[unlikely]] {                                                         \
       return PrimitiveT{0};                                                    \
     } else {                                                                   \
-      return __private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,                 \
+      return __private::rem_euclid(::sus::marker::unsafe_fn, primitive_value,  \
                                    rhs.primitive_value);                       \
     }                                                                          \
   }                                                                            \
@@ -1305,7 +1316,8 @@ class Tuple;
       return Option<u32>::none();                                             \
     } else {                                                                  \
       uint32_t zeros = __private::leading_zeros_nonzero(                      \
-          ::sus::marker::unsafe_fn, __private::into_unsigned(primitive_value));              \
+          ::sus::marker::unsafe_fn,                                           \
+          __private::into_unsigned(primitive_value));                         \
       return Option<u32>::some(BITS() - 1_u32 - u32(zeros));                  \
     }                                                                         \
   }                                                                           \
@@ -1510,4 +1522,17 @@ class Tuple;
     }                                                                         \
     return __private::into_signed(val);                                       \
   }                                                                           \
+  static_assert(true)
+
+#define _sus__signed_hash_equal_to(Type)                                   \
+  template <>                                                              \
+  struct hash<Type> {                                                      \
+    auto operator()(const Type& u) const {                                 \
+      return std::hash<decltype(u.primitive_value)>()(u.primitive_value);  \
+    }                                                                      \
+  };                                                                       \
+  template <>                                                              \
+  struct equal_to<Type> {                                                  \
+    auto operator()(const Type& l, const Type& r) const { return l == r; } \
+  };                                                                       \
   static_assert(true)

--- a/subspace/num/__private/unsigned_integer_macros.h
+++ b/subspace/num/__private/unsigned_integer_macros.h
@@ -1304,3 +1304,16 @@ class Tuple;
     return val;                                                               \
   }                                                                           \
   static_assert(true)
+
+#define _sus__unsigned_hash_equal_to(Type)                                 \
+  template <>                                                              \
+  struct hash<Type> {                                                      \
+    auto operator()(const Type& u) const {                                 \
+      return std::hash<decltype(u.primitive_value)>()(u.primitive_value);  \
+    }                                                                      \
+  };                                                                       \
+  template <>                                                              \
+  struct equal_to<Type> {                                                  \
+    auto operator()(const Type& l, const Type& r) const { return l == r; } \
+  };                                                                       \
+  static_assert(true)

--- a/subspace/num/f32_unittest.cc
+++ b/subspace/num/f32_unittest.cc
@@ -29,6 +29,10 @@
 #define F32_NEAR(a, b, c) \
   EXPECT_NEAR((a).primitive_value, (b).primitive_value, (c).primitive_value);
 
+// std hashing
+static_assert(std::same_as<decltype(std::hash<f32>()(0_f32)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<f32>()(0_f32, 1_f32)), bool>);
+
 namespace {
 
 using sus::num::FpCategory;

--- a/subspace/num/float.h
+++ b/subspace/num/float.h
@@ -44,6 +44,11 @@ struct f64 final {
 
 }  // namespace sus::num
 
+namespace std {
+_sus__float_hash_equal_to(::sus::num::f32);
+_sus__float_hash_equal_to(::sus::num::f64);
+}  // namespace std
+
 _sus__float_literal(f32, ::sus::num::f32);
 _sus__float_literal(f64, ::sus::num::f64);
 

--- a/subspace/num/float.h
+++ b/subspace/num/float.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <functional>  // TODO: remove this but we need to hash things > size_t.
+
 #include "num/__private/float_consts.h"
 #include "num/__private/float_macros.h"
 #include "num/__private/literals.h"
@@ -56,4 +58,4 @@ _sus__float_literal(f64, ::sus::num::f64);
 namespace sus {
 using sus::num::f32;
 using sus::num::f64;
-}
+}  // namespace sus

--- a/subspace/num/i16_unittest.cc
+++ b/subspace/num/i16_unittest.cc
@@ -75,6 +75,10 @@ concept MaxInRange = requires {
 };
 static_assert(MaxInRange<i16>);
 
+// std hashing
+static_assert(std::same_as<decltype(std::hash<i16>()(0_i16)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<i16>()(0_i16, 1_i16)), bool>);
+
 TEST(i16, Traits) {
   // ** Signed only **
   static_assert(sus::num::Neg<i16>);

--- a/subspace/num/i32_unittest.cc
+++ b/subspace/num/i32_unittest.cc
@@ -78,6 +78,10 @@ concept MaxInRange = requires {
 };
 static_assert(MaxInRange<i32>);
 
+// std hashing
+static_assert(std::same_as<decltype(std::hash<i32>()(0_i32)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<i32>()(0_i32, 1_i32)), bool>);
+
 TEST(i32, Traits) {
   // ** Signed only **
   static_assert(sus::num::Neg<i32>);

--- a/subspace/num/i64_unittest.cc
+++ b/subspace/num/i64_unittest.cc
@@ -75,6 +75,10 @@ concept MaxInRange = requires {
 };
 static_assert(MaxInRange<i64>);
 
+// std hashing
+static_assert(std::same_as<decltype(std::hash<i64>()(0_i64)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<i64>()(0_i64, 1_i64)), bool>);
+
 TEST(i64, Traits) {
   // ** Signed only **
   static_assert(sus::num::Neg<i64>);

--- a/subspace/num/i8_unittest.cc
+++ b/subspace/num/i8_unittest.cc
@@ -75,6 +75,10 @@ concept MaxInRange = requires {
 };
 static_assert(MaxInRange<i8>);
 
+// std hashing
+static_assert(std::same_as<decltype(std::hash<i8>()(0_i8)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<i8>()(0_i8, 1_i8)), bool>);
+
 TEST(i8, Traits) {
   // ** Signed only **
   static_assert(sus::num::Neg<i8>);

--- a/subspace/num/isize_unittest.cc
+++ b/subspace/num/isize_unittest.cc
@@ -16,13 +16,13 @@
 
 #include "construct/into.h"
 #include "containers/array.h"
+#include "googletest/include/gtest/gtest.h"
 #include "num/num_concepts.h"
 #include "num/signed_integer.h"
 #include "num/unsigned_integer.h"
 #include "ops/eq.h"
 #include "ops/ord.h"
 #include "prelude.h"
-#include "googletest/include/gtest/gtest.h"
 #include "tuple/tuple.h"
 
 namespace {
@@ -88,6 +88,11 @@ concept MaxInRange = requires {
   } -> std::same_as<T>;
 };
 static_assert(MaxInRange<isize>);
+
+// std hashing
+static_assert(std::same_as<decltype(std::hash<isize>()(0_isize)), size_t>);
+static_assert(
+    std::same_as<decltype(std::equal_to<isize>()(0_isize, 1_isize)), bool>);
 
 TEST(isize, Traits) {
   // ** Signed only **

--- a/subspace/num/signed_integer.h
+++ b/subspace/num/signed_integer.h
@@ -16,6 +16,8 @@
 
 #include <stdint.h>
 
+#include <functional>  // TODO: remove this but we need to hash things > size_t.
+
 #include "num/__private/signed_integer_macros.h"
 
 namespace sus::num {

--- a/subspace/num/signed_integer.h
+++ b/subspace/num/signed_integer.h
@@ -65,6 +65,14 @@ struct isize final {
 
 }  // namespace sus::num
 
+namespace std {
+_sus__signed_hash_equal_to(::sus::num::i8);
+_sus__signed_hash_equal_to(::sus::num::i16);
+_sus__signed_hash_equal_to(::sus::num::i32);
+_sus__signed_hash_equal_to(::sus::num::i64);
+_sus__signed_hash_equal_to(::sus::num::isize);
+}  // namespace std
+
 _sus__integer_literal(i8, ::sus::num::i8);
 _sus__integer_literal(i16, ::sus::num::i16);
 _sus__integer_literal(i32, ::sus::num::i32);

--- a/subspace/num/u16_unittest.cc
+++ b/subspace/num/u16_unittest.cc
@@ -16,13 +16,13 @@
 
 #include "construct/into.h"
 #include "containers/array.h"
+#include "googletest/include/gtest/gtest.h"
 #include "num/num_concepts.h"
 #include "num/signed_integer.h"
 #include "num/unsigned_integer.h"
 #include "ops/eq.h"
 #include "ops/ord.h"
 #include "prelude.h"
-#include "googletest/include/gtest/gtest.h"
 #include "tuple/tuple.h"
 
 namespace {
@@ -74,6 +74,10 @@ concept MaxInRange = requires {
   { u16(uint16_t{0xffff}) } -> std::same_as<T>;
 };
 static_assert(MaxInRange<u16>);
+
+// std hashing
+static_assert(std::same_as<decltype(std::hash<u16>()(0_u16)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<u16>()(0_u16, 1_u16)), bool>);
 
 TEST(u16, Traits) {
   // ** Unsigned only

--- a/subspace/num/u32_unittest.cc
+++ b/subspace/num/u32_unittest.cc
@@ -17,6 +17,7 @@
 #include "construct/into.h"
 #include "construct/make_default.h"
 #include "containers/array.h"
+#include "googletest/include/gtest/gtest.h"
 #include "mem/relocate.h"
 #include "num/num_concepts.h"
 #include "num/signed_integer.h"
@@ -25,7 +26,6 @@
 #include "ops/ord.h"
 #include "option/option.h"
 #include "prelude.h"
-#include "googletest/include/gtest/gtest.h"
 #include "tuple/tuple.h"
 
 namespace {
@@ -73,10 +73,14 @@ static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
 static_assert(u32::MAX().primitive_value == 0xffffffff);
 template <class T>
 concept MaxInRange = requires {
-                       { 0xffffffff_u32 } -> std::same_as<T>;
-                       { u32(0xffffffff) } -> std::same_as<T>;
-                     };
+  { 0xffffffff_u32 } -> std::same_as<T>;
+  { u32(0xffffffff) } -> std::same_as<T>;
+};
 static_assert(MaxInRange<u32>);
+
+// std hashing
+static_assert(std::same_as<decltype(std::hash<u32>()(0_u32)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<u32>()(0_u32, 1_u32)), bool>);
 
 TEST(u32, Traits) {
   // ** Unsigned only

--- a/subspace/num/u64_unittest.cc
+++ b/subspace/num/u64_unittest.cc
@@ -16,13 +16,13 @@
 
 #include "construct/into.h"
 #include "containers/array.h"
+#include "googletest/include/gtest/gtest.h"
 #include "num/num_concepts.h"
 #include "num/signed_integer.h"
 #include "num/unsigned_integer.h"
 #include "ops/eq.h"
 #include "ops/ord.h"
 #include "prelude.h"
-#include "googletest/include/gtest/gtest.h"
 #include "tuple/tuple.h"
 
 namespace {
@@ -70,10 +70,14 @@ static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
 static_assert(u64::MAX().primitive_value == 0xffffffff'ffffffff);
 template <class T>
 concept MaxInRange = requires {
-                       { 0xffffffff'ffffffff_u64 } -> std::same_as<T>;
-                       { u64(0xffffffff'ffffffff) } -> std::same_as<T>;
-                     };
+  { 0xffffffff'ffffffff_u64 } -> std::same_as<T>;
+  { u64(0xffffffff'ffffffff) } -> std::same_as<T>;
+};
 static_assert(MaxInRange<u64>);
+
+// std hashing
+static_assert(std::same_as<decltype(std::hash<u64>()(0_u64)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<u64>()(0_u64, 1_u64)), bool>);
 
 TEST(u64, Traits) {
   // ** Unsigned only

--- a/subspace/num/u8_unittest.cc
+++ b/subspace/num/u8_unittest.cc
@@ -75,6 +75,10 @@ concept MaxInRange = requires {
 };
 static_assert(MaxInRange<u8>);
 
+// std hashing
+static_assert(std::same_as<decltype(std::hash<u8>()(0_u8)), size_t>);
+static_assert(std::same_as<decltype(std::equal_to<u8>()(0_u8, 1_u8)), bool>);
+
 TEST(u8, Traits) {
   // ** Unsigned only
   static_assert(!sus::num::Neg<u8>);

--- a/subspace/num/unsigned_integer.h
+++ b/subspace/num/unsigned_integer.h
@@ -16,6 +16,8 @@
 
 #include <stdint.h>
 
+#include <functional>  // TODO: remove this but we need to hash things > size_t.
+
 #include "num/__private/unsigned_integer_macros.h"
 
 namespace sus::num {

--- a/subspace/num/unsigned_integer.h
+++ b/subspace/num/unsigned_integer.h
@@ -58,6 +58,14 @@ struct usize final {
 
 }  // namespace sus::num
 
+namespace std {
+_sus__unsigned_hash_equal_to(::sus::num::u8);
+_sus__unsigned_hash_equal_to(::sus::num::u16);
+_sus__unsigned_hash_equal_to(::sus::num::u32);
+_sus__unsigned_hash_equal_to(::sus::num::u64);
+_sus__unsigned_hash_equal_to(::sus::num::usize);
+}  // namespace std
+
 _sus__integer_literal(u8, ::sus::num::u8);
 _sus__integer_literal(u16, ::sus::num::u16);
 _sus__integer_literal(u32, ::sus::num::u32);
@@ -71,4 +79,4 @@ using sus::num::u32;
 using sus::num::u64;
 using sus::num::u8;
 using sus::num::usize;
-}
+}  // namespace sus

--- a/subspace/num/usize_unittest.cc
+++ b/subspace/num/usize_unittest.cc
@@ -16,13 +16,13 @@
 
 #include "construct/into.h"
 #include "containers/array.h"
+#include "googletest/include/gtest/gtest.h"
 #include "num/num_concepts.h"
 #include "num/signed_integer.h"
 #include "num/unsigned_integer.h"
 #include "ops/eq.h"
 #include "ops/ord.h"
 #include "prelude.h"
-#include "googletest/include/gtest/gtest.h"
 #include "tuple/tuple.h"
 
 namespace {
@@ -80,6 +80,11 @@ concept MaxInRange = requires {
   } -> std::same_as<T>;
 };
 static_assert(MaxInRange<usize>);
+
+// std hashing
+static_assert(std::same_as<decltype(std::hash<usize>()(0_usize)), size_t>);
+static_assert(
+    std::same_as<decltype(std::equal_to<usize>()(0_usize, 1_usize)), bool>);
 
 TEST(usize, Traits) {
   // ** Unsigned only

--- a/subspace/option/__private/marker.h
+++ b/subspace/option/__private/marker.h
@@ -16,6 +16,11 @@
 
 namespace sus::option::__private {
 
+template <class T>
+struct SomeMarker {
+  T value;
+};
+
 struct NoneMarker {};
 
 }  // namespace sus::option::__private

--- a/subspace/option/__private/none_marker.h
+++ b/subspace/option/__private/none_marker.h
@@ -12,15 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cir/tests/cir_test.h"
+#pragma once
 
-TEST_F(CirTest, Smoke) {
-  auto output = run_code(R"(
-    int f() {
-      int i = 2;
-      return i;
-    })");
-  if (output.is_none()) return;
+namespace sus::option::__private {
 
-  llvm::errs() << sus::move(output).unwrap().to_string() << "\n";
-}
+struct NoneMarker {};
+
+}  // namespace sus::option::__private

--- a/subspace/option/option.h
+++ b/subspace/option/option.h
@@ -42,7 +42,7 @@
 #include "ops/ord.h"
 #include "option/__private/is_option_type.h"
 #include "option/__private/is_tuple_type.h"
-#include "option/__private/none_marker.h"
+#include "option/__private/marker.h"
 #include "option/__private/storage.h"
 #include "option/state.h"
 #include "result/__private/is_result_type.h"
@@ -136,6 +136,11 @@ class Option final {
 
   /// Construct an Option that is holding no value.
   static inline constexpr Option none() noexcept { return Option(); }
+
+  /// Construct an Option that is holding the given value, from the output of
+  /// `sus::option::some()`.
+  inline constexpr Option(__private::SomeMarker<T&&> m) noexcept
+      : Option(move_to_storage(::sus::move(m).value)) {}
 
   /// Construct an Option that is holding no value, from the output of
   /// `sus::option::none()`.
@@ -975,7 +980,7 @@ using sus::iter::__private::end;
 
 template <class T>
 inline constexpr auto some(T&& t) {
-  return Option<std::decay_t<T>>::some(::sus::forward<T>(t));
+  return __private::SomeMarker<T&&>(::sus::forward<T>(t));
 }
 
 inline constexpr auto none() { return __private::NoneMarker(); }

--- a/subspace/option/option.h
+++ b/subspace/option/option.h
@@ -42,6 +42,7 @@
 #include "ops/ord.h"
 #include "option/__private/is_option_type.h"
 #include "option/__private/is_tuple_type.h"
+#include "option/__private/none_marker.h"
 #include "option/__private/storage.h"
 #include "option/state.h"
 #include "result/__private/is_result_type.h"
@@ -135,6 +136,10 @@ class Option final {
 
   /// Construct an Option that is holding no value.
   static inline constexpr Option none() noexcept { return Option(); }
+
+  /// Construct an Option that is holding no value, from the output of
+  /// `sus::option::none()`.
+  inline constexpr Option(__private::NoneMarker) noexcept : Option() {}
 
   /// Construct an Option with the default value for the type it contains.
   ///
@@ -968,11 +973,20 @@ constexpr inline auto operator<=>(const Option<T>& l,
 using sus::iter::__private::begin;
 using sus::iter::__private::end;
 
+template <class T>
+inline constexpr auto some(T&& t) {
+  return Option<std::decay_t<T>>::some(::sus::forward<T>(t));
+}
+
+inline constexpr auto none() { return __private::NoneMarker(); }
+
 }  // namespace sus::option
 
 // Promote Option and its enum values into the `sus` namespace.
 namespace sus {
+using ::sus::option::none;
 using ::sus::option::None;
 using ::sus::option::Option;
 using ::sus::option::Some;
+using ::sus::option::some;
 }  // namespace sus

--- a/subspace/option/option_unittest.cc
+++ b/subspace/option/option_unittest.cc
@@ -17,6 +17,7 @@
 #include <math.h>  // TODO: Replace with f32::NAN()
 
 #include "containers/array.h"
+#include "googletest/include/gtest/gtest.h"
 #include "iter/iterator.h"
 #include "macros/__private/compiler_bugs.h"
 #include "macros/builtin.h"
@@ -26,7 +27,6 @@
 #include "prelude.h"
 #include "result/result.h"
 #include "test/behaviour_types.h"
-#include "googletest/include/gtest/gtest.h"
 #include "tuple/tuple.h"
 
 using sus::construct::make_default;
@@ -180,6 +180,26 @@ TEST(Option, Construct) {
     T t = i;
     auto z = Option<T>::some(mref(t));
   }
+}
+
+TEST(Option, SomeNoneHelpers) {
+  auto a = Option<i32>::some(2_i32);
+  auto a2 = sus::some(2_i32);
+  static_assert(std::same_as<decltype(a), decltype(a2)>);
+  EXPECT_EQ(a, a2);
+
+  auto b = Option<i32>::none();
+  Option<i32> b2 = sus::none();
+  static_assert(std::same_as<decltype(b), decltype(b2)>);
+  EXPECT_EQ(b, b2);
+
+  auto i = 2_i32;
+  auto c = Option<i32&>::some(i);
+  auto c2 = sus::some(i);
+  // The some() helper doesn't infer a reference type.
+  static_assert(!std::same_as<decltype(c), decltype(c2)>);
+  static_assert(std::same_as<Option<i32>, decltype(c2)>);
+  EXPECT_EQ(c, c2);
 }
 
 TEST(Option, Move) {
@@ -1373,7 +1393,7 @@ TEST(Option, Cloned) {
   };
   static_assert(!::sus::mem::Copy<Cloneable>);
   static_assert(::sus::mem::Clone<Cloneable>);
-  
+
   auto c = Cloneable();
   auto x = Option<Cloneable&>::none().cloned();
   IS_NONE(x);
@@ -1385,7 +1405,8 @@ TEST(Option, Cloned) {
   // optimization.
   // constexpr auto cc = Cloneable();
   // static_assert(Option<Cloneable&>::none().copied().is_none());
-  // static_assert(&Option<const Cloneable&>::some(cc).cloned().unwrap() == &cc);
+  // static_assert(&Option<const Cloneable&>::some(cc).cloned().unwrap() ==
+  // &cc);
 }
 
 TEST(Option, Flatten) {

--- a/subspace/option/option_unittest.cc
+++ b/subspace/option/option_unittest.cc
@@ -184,22 +184,17 @@ TEST(Option, Construct) {
 
 TEST(Option, SomeNoneHelpers) {
   auto a = Option<i32>::some(2_i32);
-  auto a2 = sus::some(2_i32);
-  static_assert(std::same_as<decltype(a), decltype(a2)>);
+  Option<i32> a2 = sus::some(2_i32);
   EXPECT_EQ(a, a2);
 
   auto b = Option<i32>::none();
   Option<i32> b2 = sus::none();
-  static_assert(std::same_as<decltype(b), decltype(b2)>);
   EXPECT_EQ(b, b2);
 
   auto i = 2_i32;
   auto c = Option<i32&>::some(i);
-  auto c2 = sus::some(i);
-  // The some() helper doesn't infer a reference type.
-  static_assert(!std::same_as<decltype(c), decltype(c2)>);
-  static_assert(std::same_as<Option<i32>, decltype(c2)>);
-  EXPECT_EQ(c, c2);
+  Option<i32&> c2 = sus::some(i);
+  EXPECT_EQ(&c.unwrap_ref(), &c2.unwrap_ref());
 }
 
 TEST(Option, Move) {

--- a/subspace/union/union.h
+++ b/subspace/union/union.h
@@ -19,6 +19,7 @@
 #include <type_traits>
 
 #include "macros/no_unique_address.h"
+#include "marker/unsafe.h"
 #include "mem/clone.h"
 #include "mem/copy.h"
 #include "mem/move.h"
@@ -116,6 +117,8 @@ class Union<__private::TypeList<Ts...>, Tags...> final {
   using StorageTypeOfTag = __private::StorageTypeOfTag<size_t{index<V>}, Ts...>;
 
  public:
+  using Tag = TagsType;
+
   // TODO: Can we construct Tuples of trivially constructible things (or some
   // set of things) without placement new and thus make this constexpr?
   template <TagsType V, class U, int&...,
@@ -431,7 +434,8 @@ class Union<__private::TypeList<Ts...>, Tags...> final {
   [[sus_no_unique_address]] Storage storage_;
   IndexType index_;
 
-  sus_class_never_value_field(unsafe_fn, Union, index_, kNeverValue);
+  sus_class_never_value_field(::sus::marker::unsafe_fn, Union, index_,
+                              kNeverValue);
 };
 
 }  // namespace sus::union_type

--- a/subspace/union/union_unittest.cc
+++ b/subspace/union/union_unittest.cc
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "union/union.h"
+
 #include <variant>
 
+#include "googletest/include/gtest/gtest.h"
 #include "macros/__private/compiler_bugs.h"
 #include "num/types.h"
 #include "option/option.h"
 #include "prelude.h"
-#include "googletest/include/gtest/gtest.h"
-#include "union/union.h"
 
 namespace {
 
@@ -47,6 +48,12 @@ inline constexpr size_t UamBytes = sus::Tuple<i32>::protects_uam ? 8 : 0;
 // on MSVC.
 static_assert(sizeof(Union<sus_value_types((Order::First, i32, u64))>) ==
               2 * sizeof(u64) + UamBytes + sus_if_msvc_else(sizeof(u64), 0));
+
+TEST(Union, Tag) {
+  using One = Union<sus_value_types((Order::First, u64), (Order::Second, u32))>;
+  // `Tag` is an alias for the tag type.
+  auto u = One::with<One::Tag::First>(1u);
+}
 
 TEST(Union, NeverValue) {
   using One = Union<sus_value_types((Order::First, u64), (Order::Second, u32))>;


### PR DESCRIPTION
For now it just supports builtin types. And it can print it out in the Function::to_string().