### PR TITLE
Use size_of() instead of sizeof()

### DIFF
--- a/subspace/containers/vec.h
+++ b/subspace/containers/vec.h
@@ -176,7 +176,6 @@ class Vec {
     if (cap <= capacity_) return;  // Nothing to do.
     const auto bytes = ::sus::mem::size_of<T>() * cap;
     check(bytes <= usize(size_t{PTRDIFF_MAX}));
-    static_assert(sizeof(size_t) == sizeof(usize));
     if (!is_alloced()) {
       storage_ = static_cast<char*>(malloc(bytes.primitive_value));
     } else {

--- a/subspace/iter/iterator_defn.h
+++ b/subspace/iter/iterator_defn.h
@@ -19,6 +19,7 @@
 #include "macros/__private/compiler_bugs.h"
 #include "num/unsigned_integer.h"
 #include "option/option.h"
+#include "mem/size_of.h"
 
 namespace sus::iter {
 
@@ -132,7 +133,8 @@ class Iterator final : public I {
   Iterator(Args&&... args) : I(static_cast<Args&&>(args)...) {
     // We want to be able to use Iterator<I> and I interchangably, so that if an
     // `I` gets stored in SizedIterator, it doesn't misbehave.
-    static_assert(sizeof(I) == sizeof(Iterator<I>), "");
+    static_assert(::sus::mem::size_of<I>() ==
+                  ::sus::mem::size_of<Iterator<I>>());
   }
 
  public:
@@ -145,7 +147,7 @@ class Iterator final : public I {
   ///
   /// Given an element the closure must return true or false. The returned
   /// iterator will yield only the elements for which the closure returns true.
-  Iterator<Filter<Item, sizeof(I), alignof(I),
+  Iterator<Filter<Item, ::sus::mem::size_of<I>(), alignof(I),
                   ::sus::mem::relocate_one_by_memcpy<I>>>
   filter(::sus::fn::FnMut<bool(const std::remove_reference_t<Item>&)>
              pred) && noexcept;

--- a/subspace/iter/iterator_impl.h
+++ b/subspace/iter/iterator_impl.h
@@ -20,6 +20,7 @@
 #include "iter/iterator_defn.h"
 #include "iter/sized_iterator.h"
 #include "mem/move.h"
+#include "mem/size_of.h"
 
 // IteratorBase provided functions are implemented in this file, so that they
 // can be easily included by library users, but don't have to be included in
@@ -44,7 +45,8 @@ bool IteratorBase<Item>::all(::sus::fn::FnMut<bool(Item)> f) noexcept {
     Option<Item> item = next();
     if (item.is_none()) return true;
     // Safety: `item` was checked to hold Some already.
-    if (!f(item.take().unwrap_unchecked(::sus::marker::unsafe_fn))) return false;
+    if (!f(item.take().unwrap_unchecked(::sus::marker::unsafe_fn)))
+      return false;
   }
 }
 
@@ -66,7 +68,7 @@ usize IteratorBase<Item>::count() noexcept {
 }
 
 template <class I>
-Iterator<Filter<typename I::Item, sizeof(I), alignof(I),
+Iterator<Filter<typename I::Item, ::sus::mem::size_of<I>(), alignof(I),
                 ::sus::mem::relocate_one_by_memcpy<I>>>
 Iterator<I>::filter(
     ::sus::fn::FnMut<bool(const std::remove_reference_t<typename I::Item>&)>

--- a/subspace/lib/lib.cc
+++ b/subspace/lib/lib.cc
@@ -12,14 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stddef.h>
 #include <limits.h>
+#include <stddef.h>
+
+#include "mem/size_of.h"
 
 // Architectural assumptions we make throughout the implementation of Subspace.
 static_assert(CHAR_BIT == 8);
-static_assert(sizeof(int) == 4);
-static_assert(sizeof(size_t) >= 4);
-static_assert(sizeof(size_t) <= 8);
+static_assert(::sus::mem::size_of<int>() == 4);
+static_assert(::sus::mem::size_of<size_t>() >= 4);
+static_assert(::sus::mem::size_of<size_t>() <= 8);
 
 // TODO: Consider if we should only support little endian? We probably make this
 // assumption. Support for endian *conversion* is still important for network

--- a/subspace/mem/size_of.h
+++ b/subspace/mem/size_of.h
@@ -23,7 +23,11 @@ namespace sus::mem {
 ///
 /// This is the number of bytes that will be allocated for a type T, and
 /// includes any tail padding.
+///
+/// Disallows calls with a reference type, since C++ does a surprising thing,
+/// where `sizeof(T&) == sizeof(T)`.
 template <class T>
+  requires(!std::is_reference_v<T>)
 constexpr sus_always_inline size_t size_of() noexcept {
   return sizeof(T);
 }
@@ -92,7 +96,11 @@ constexpr sus_always_inline size_t size_of() noexcept {
 /// In general, [[no_unique_address]] doesn't appear to do anything on MSVC, and
 /// subclasses also do not use padding bytes of the base class, with the
 /// exception of the base class being empty.
+///
+/// Disallows calls with a reference type, since C++ does a surprising thing,
+/// where `sizeof(T&) == sizeof(T)`.
 template <class T>
+  requires(!std::is_reference_v<T>)
 constexpr sus_always_inline size_t data_size_of() noexcept {
   return __private::data_size_finder<T>;
 }

--- a/subspace/num/__private/float_ordering.h
+++ b/subspace/num/__private/float_ordering.h
@@ -17,11 +17,12 @@
 #include <compare>
 
 #include "num/__private/intrinsics.h"
+#include "mem/size_of.h"
 
 namespace sus::num::__private {
 
 template <class T>
-  requires(std::is_floating_point_v<T> && sizeof(T) <= 8)
+  requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
 constexpr std::strong_ordering float_strong_ordering(T l, T r) noexcept {
   if (into_unsigned_integer(l) == into_unsigned_integer(r))
     return std::strong_ordering::equal;

--- a/subspace/num/__private/ptr_type.h
+++ b/subspace/num/__private/ptr_type.h
@@ -14,9 +14,10 @@
 
 #pragma once
 
+#include "mem/size_of.h"
 
 namespace sus::num::__private {
-template <unsigned int bytes = sizeof(void*)>
+template <unsigned int bytes = ::sus::mem::size_of<void*>()>
 struct ptr_type;
 
 template <>

--- a/subspace/num/__private/signed_integer_macros.h
+++ b/subspace/num/__private/signed_integer_macros.h
@@ -22,6 +22,7 @@
 #include "assertions/check.h"
 #include "assertions/endian.h"
 #include "marker/unsafe.h"
+#include "mem/size_of.h"
 #include "num/__private/int_log10.h"
 #include "num/__private/intrinsics.h"
 #include "num/__private/literals.h"
@@ -64,7 +65,7 @@ class Tuple;
   _sus__signed_bits(T);                             \
   _sus__signed_pow(T);                              \
   _sus__signed_log(T);                              \
-  _sus__signed_endian(T, UnsignedT, sizeof(PrimitiveT))
+  _sus__signed_endian(T, UnsignedT, ::sus::mem::size_of<PrimitiveT>())
 
 #define _sus__signed_storage(PrimitiveT)                                      \
   /** The inner primitive value, in case it needs to be unwrapped from the    \
@@ -94,19 +95,19 @@ class Tuple;
   /** Construction from signed primitive types where no bits are lost.         \
    */                                                                          \
   template <SignedPrimitiveInteger P>                                          \
-    requires(sizeof(P) <= sizeof(PrimitiveT))                                  \
+    requires(::sus::mem::size_of<P>() <= ::sus::mem::size_of<PrimitiveT>())    \
   constexpr inline T(P v) : primitive_value(v) {}                              \
                                                                                \
   /** Construction from unsigned primitive types where no bits are lost.       \
    */                                                                          \
   template <UnsignedPrimitiveInteger P>                                        \
-    requires(sizeof(P) < sizeof(PrimitiveT))                                   \
+    requires(::sus::mem::size_of<P>() < ::sus::mem::size_of<PrimitiveT>())     \
   constexpr inline T(P v) : primitive_value(v) {}                              \
                                                                                \
   /** Assignment from signed primitive types where no bits are lost.           \
    */                                                                          \
   template <SignedPrimitiveInteger P>                                          \
-    requires(sizeof(P) <= sizeof(PrimitiveT))                                  \
+    requires(::sus::mem::size_of<P>() <= ::sus::mem::size_of<PrimitiveT>())    \
   constexpr inline T& operator=(P v) noexcept {                                \
     primitive_value = v;                                                       \
     return *this;                                                              \
@@ -115,7 +116,7 @@ class Tuple;
   /** Assignment from unsigned primitive types where no bits are lost.         \
    */                                                                          \
   template <UnsignedPrimitiveInteger P>                                        \
-    requires(sizeof(P) < sizeof(PrimitiveT))                                   \
+    requires(::sus::mem::size_of<P>() < ::sus::mem::size_of<PrimitiveT>())     \
   constexpr inline T& operator=(P v) noexcept {                                \
     primitive_value = v;                                                       \
     return *this;                                                              \
@@ -182,12 +183,12 @@ class Tuple;
   }                                                                         \
   static_assert(true)
 
-#define _sus__signed_to_primitive(T, PrimitiveT) \
-  template <SignedPrimitiveInteger U>            \
-    requires(sizeof(U) >= sizeof(PrimitiveT))    \
-  constexpr inline explicit operator U() const { \
-    return primitive_value;                      \
-  }                                              \
+#define _sus__signed_to_primitive(T, PrimitiveT)                            \
+  template <SignedPrimitiveInteger U>                                       \
+    requires(::sus::mem::size_of<U>() >= ::sus::mem::size_of<PrimitiveT>()) \
+  constexpr inline explicit operator U() const {                            \
+    return primitive_value;                                                 \
+  }                                                                         \
   static_assert(true)
 
 #define _sus__signed_integer_comparison(T, PrimitiveT)                         \
@@ -1527,9 +1528,7 @@ class Tuple;
 #define _sus__signed_hash_equal_to(Type)                                   \
   template <>                                                              \
   struct hash<Type> {                                                      \
-    size_t operator()(const Type& u) const {                                 \
-      return u.primitive_value;  \
-    }                                                                      \
+    size_t operator()(const Type& u) const { return u.primitive_value; }   \
   };                                                                       \
   template <>                                                              \
   struct equal_to<Type> {                                                  \

--- a/subspace/num/__private/unsigned_integer_macros.h
+++ b/subspace/num/__private/unsigned_integer_macros.h
@@ -21,6 +21,7 @@
 
 #include "assertions/check.h"
 #include "assertions/endian.h"
+#include "mem/size_of.h"
 #include "macros/__private/compiler_bugs.h"
 #include "num/__private/int_log10.h"
 #include "num/__private/intrinsics.h"
@@ -69,7 +70,7 @@ class Tuple;
   _sus__unsigned_pow(T);                            \
   _sus__unsigned_log(T);                            \
   _sus__unsigned_power_of_two(T, PrimitiveT);       \
-  _sus__unsigned_endian(T, PrimitiveT, sizeof(PrimitiveT))
+  _sus__unsigned_endian(T, PrimitiveT, ::sus::mem::size_of<PrimitiveT>())
 
 #define _sus__unsigned_storage(PrimitiveT)                                    \
   /** The inner primitive value, in case it needs to be unwrapped from the    \
@@ -99,13 +100,13 @@ class Tuple;
   /** Construction from unsigned primitive types where no bits are lost.       \
    */                                                                          \
   template <UnsignedPrimitiveInteger P>                                        \
-    requires(sizeof(P) <= sizeof(PrimitiveT))                                  \
+    requires(::sus::mem::size_of<P>() <= ::sus::mem::size_of<PrimitiveT>())                                  \
   constexpr inline T(P v) : primitive_value(v) {}                              \
                                                                                \
   /** Assignment from unsigned primitive types where no bits are lost.         \
    */                                                                          \
   template <UnsignedPrimitiveInteger P>                                        \
-    requires(sizeof(P) <= sizeof(PrimitiveT))                                  \
+    requires(::sus::mem::size_of<P>() <= ::sus::mem::size_of<PrimitiveT>())                                  \
   constexpr inline T& operator=(P v) noexcept {                                \
     primitive_value = v;                                                       \
     return *this;                                                              \
@@ -171,12 +172,12 @@ class Tuple;
 
 #define _sus__unsigned_to_primitive(T, PrimitiveT) \
   template <UnsignedPrimitiveInteger U>            \
-    requires(sizeof(U) >= sizeof(PrimitiveT))      \
+    requires(::sus::mem::size_of<U>() >= ::sus::mem::size_of<PrimitiveT>())      \
   constexpr inline explicit operator U() const {   \
     return primitive_value;                        \
   }                                                \
   template <SignedPrimitiveInteger U>              \
-    requires(sizeof(U) > sizeof(PrimitiveT))       \
+    requires(::sus::mem::size_of<U>() > ::sus::mem::size_of<PrimitiveT>())       \
   constexpr inline explicit operator U() const {   \
     return primitive_value;                        \
   }                                                \

--- a/subspace/option/__private/storage.h
+++ b/subspace/option/__private/storage.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "macros/always_inline.h"
+#include "marker/unsafe.h"
 #include "mem/addressof.h"
 #include "mem/move.h"
 #include "mem/mref.h"
@@ -53,6 +54,30 @@ struct Storage<T, false> final {
   constexpr Storage& operator=(Storage&&)
     requires(std::is_trivially_move_assignable_v<T>)
   = default;
+
+  // Make the Storage have the same non-trivial copy/move characteristics, for
+  // Option to query. But these aren't used by Option, since it copies/moves the
+  // stored value itself.
+  constexpr Storage(const Storage&)
+    requires(!std::is_trivially_copy_constructible_v<T>)
+  {
+    sus::unreachable();
+  }
+  constexpr Storage& operator=(const Storage&)
+    requires(!std::is_trivially_copy_assignable_v<T>)
+  {
+    sus::unreachable();
+  }
+  constexpr Storage(Storage&&)
+    requires(!std::is_trivially_move_constructible_v<T>)
+  {
+    sus::unreachable();
+  }
+  constexpr Storage& operator=(Storage&&)
+    requires(!std::is_trivially_move_assignable_v<T>)
+  {
+    sus::unreachable();
+  }
 
   constexpr Storage() {}
   constexpr Storage(const std::remove_cvref_t<T>& t) : val_(t), state_(Some) {}
@@ -97,6 +122,9 @@ struct Storage<T, false> final {
     state_ = None;
     val_.~T();
   }
+
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                            decltype(val_));
 };
 
 template <class T>
@@ -120,6 +148,30 @@ struct Storage<T, true> final {
   constexpr Storage& operator=(Storage&&)
     requires(std::is_trivially_move_assignable_v<T>)
   = default;
+
+  // Make the Storage have the same non-trivial copy/move characteristics, for
+  // Option to query. But these aren't used by Option, since it copies/moves the
+  // stored value itself.
+  constexpr Storage(const Storage&)
+    requires(!std::is_trivially_copy_constructible_v<T>)
+  {
+    sus::unreachable();
+  }
+  constexpr Storage& operator=(const Storage&)
+    requires(!std::is_trivially_copy_assignable_v<T>)
+  {
+    sus::unreachable();
+  }
+  constexpr Storage(Storage&&)
+    requires(!std::is_trivially_move_constructible_v<T>)
+  {
+    sus::unreachable();
+  }
+  constexpr Storage& operator=(Storage&&)
+    requires(!std::is_trivially_move_assignable_v<T>)
+  {
+    sus::unreachable();
+  }
 
   constexpr Storage() : overlay_() {
     ::sus::mem::never_value_access<T>::set_never_value(::sus::marker::unsafe_fn,
@@ -185,6 +237,9 @@ struct Storage<T, true> final {
     ::sus::mem::never_value_access<T>::set_never_value(::sus::marker::unsafe_fn,
                                                        overlay_);
   }
+
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                            decltype(val_));
 };
 
 template <class T>

--- a/subspace/option/option.h
+++ b/subspace/option/option.h
@@ -37,6 +37,7 @@
 #include "mem/move.h"
 #include "mem/mref.h"
 #include "mem/replace.h"
+#include "mem/relocate.h"
 #include "mem/take.h"
 #include "num/num_concepts.h"
 #include "ops/eq.h"
@@ -897,7 +898,8 @@ class Option final {
                          Storage<U>>;
   StorageType<T> t_;
 
-  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn, T);
+  sus_class_maybe_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                            StorageType<T>);
 };
 
 /// sus::ops::Eq<Option<U>> trait.

--- a/subspace/union/__private/index_type.h
+++ b/subspace/union/__private/index_type.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "mem/size_of.h"
 #include "num/unsigned_integer.h"
 
 namespace sus::union_type::__private {
@@ -49,7 +50,7 @@ using IndexType =
   std::conditional_t<
       index_size<count, size_of_union, data_size_of_union>() == 32, uint32_t,
   std::conditional_t<
-      sizeof(size_t) == sizeof(uint64_t), uint64_t,
+      ::sus::mem::size_of<size_t>() == ::sus::mem::size_of<uint64_t>(), uint64_t,
   void>>>>;
 // clang-format on
 


### PR DESCRIPTION
TIL that sizeof(T&) == sizeof(T), which is surprising. So use size_of<T>() and ban calling it with a reference.

data_size<T&>() is called to test if something is memcpy-able and references are trivially copyable in a structure, so we make it return the size of the reference not the T.