### PR TITLE
Use NoCopyMove in unit tests for reference paths.

### DIFF
--- a/subspace/containers/array.h
+++ b/subspace/containers/array.h
@@ -314,7 +314,7 @@ class Array final {
   template <std::convertible_to<T> T1, std::convertible_to<T>... Ts>
   static inline void init_values(T* a, size_t index, T1&& t1, Ts&&... ts) {
     new (a + index) T(::sus::forward<T1>(t1));
-    init_values(a, index + 1, ::sus::forward<T1>(ts)...);
+    init_values(a, index + 1, ::sus::forward<Ts>(ts)...);
   }
   template <std::convertible_to<T> T1>
   static inline void init_values(T* a, size_t index, T1&& t1) {

--- a/subspace/mem/nonnull_unittest.cc
+++ b/subspace/mem/nonnull_unittest.cc
@@ -15,19 +15,24 @@
 #include "mem/nonnull.h"
 
 #include "construct/into.h"
+#include "googletest/include/gtest/gtest.h"
 #include "macros/__private/compiler_bugs.h"
 #include "mem/forward.h"
+#include "mem/never_value.h"
 #include "mem/relocate.h"
 #include "num/types.h"
 #include "ops/eq.h"
 #include "ops/ord.h"
+#include "option/option.h"
 #include "prelude.h"
-#include "googletest/include/gtest/gtest.h"
 
 using sus::mem::NonNull;
 
 static_assert(sus::mem::relocate_one_by_memcpy<NonNull<int>>);
 static_assert(sus::mem::relocate_array_by_memcpy<NonNull<int>>);
+
+static_assert(sus::mem::NeverValueField<NonNull<int>>);
+static_assert(sizeof(sus::Option<NonNull<int>>) == sizeof(int*));
 
 namespace {
 

--- a/subspace/option/option.h
+++ b/subspace/option/option.h
@@ -265,7 +265,7 @@ class Option final {
              !std::is_trivially_copy_assignable_v<T>)
   {
     if (o.t_.state() == Some)
-      t_.set_some(o.t_.val_);
+      t_.set_some(copy_to_storage(o.t_.val_));
     else if (t_.state() == Some)
       t_.set_none();
     return *this;
@@ -869,6 +869,15 @@ class Option final {
   template <class U>
   friend class Option;
 
+  // Since `T` may be a reference or a value type, this constructs the correct
+  // storage from a `T` object or a `T&&` (which is received as `T&`).
+  template <class U>
+  static constexpr inline decltype(auto) copy_to_storage(const U& t) {
+    if constexpr (std::is_reference_v<T>)
+      return StoragePointer<T&>(t);
+    else
+      return t;
+  }
   // Since `T` may be a reference or a value type, this constructs the correct
   // storage from a `T` object or a `T&&` (which is received as `T&`).
   template <class U>


### PR DESCRIPTION
Addresses https://github.com/chromium/subspace/issues/147