### PR TITLE
Require trivial relocatable iterators for chaining. Provide box() to heap-alloc an iterator and make it trivially-relocatable

### DIFF
--- a/subspace/CMakeLists.txt
+++ b/subspace/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(subspace STATIC
     "fn/fn_impl.h"
     "iter/__private/iterator_end.h"
     "iter/__private/iterator_loop.h"
+    "iter/boxed_iterator.h"
     "iter/filter.h"
     "iter/from_iterator.h"
     "iter/iterator.h"

--- a/subspace/iter/boxed_iterator.h
+++ b/subspace/iter/boxed_iterator.h
@@ -1,0 +1,74 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "convert/subclass.h"
+#include "mem/relocate.h"
+#include "mem/size_of.h"
+// Doesn't include iterator_defn.h because it's included from there.
+
+namespace sus::iter {
+
+template <class Item, size_t SubclassSize, size_t SubclassAlign>
+struct [[sus_trivial_abi]] BoxedIterator : public IteratorBase<Item> {
+  BoxedIterator(IteratorBase<Item>& iter,
+                void (*destroy)(IteratorBase<Item>& boxed))
+      : iter_(&iter), destroy_(destroy) {}
+
+  BoxedIterator(BoxedIterator&& o) noexcept
+      : iter_(::sus::mem::replace_ptr(mref(o.iter_), nullptr)),
+        destroy_(::sus::mem::replace_ptr(mref(o.destroy_), nullptr)) {}
+  BoxedIterator& operator=(BoxedIterator&& o) noexcept {
+    if (destroy_) destroy_(*iter_);
+    iter_ = ::sus::mem::replace_ptr(mref(o.iter_), nullptr);
+    destroy_ = ::sus::mem::replace_ptr(mref(o.destroy_), nullptr);
+  }
+
+  ~BoxedIterator() {
+    if (destroy_) destroy_(*iter_);
+  }
+
+  Option<Item> next() noexcept final { return iter_->next(); }
+
+ private:
+  IteratorBase<Item>* iter_;
+  void (*destroy_)(IteratorBase<Item>& boxed);
+
+  sus_class_assert_trivial_relocatable_types(::sus::marker::unsafe_fn,
+                                             decltype(iter_),
+                                             decltype(destroy_));
+};
+
+/// Make a BoxedIterator.
+///
+/// The BoxedIterator's internals will be on the heap, making the BoxedIterator
+/// itself be trivially relocatable, as it's just some pointers to the heap.
+template <::sus::mem::Move IteratorSubclass, int&...,
+          class SubclassItem = typename IteratorSubclass::Item,
+          class BoxedIteratorType = BoxedIterator<
+              SubclassItem, ::sus::mem::size_of<IteratorSubclass>(),
+              alignof(IteratorSubclass)>>
+inline BoxedIteratorType make_boxed_iterator(IteratorSubclass&& subclass)
+  requires(::sus::convert::SameOrSubclassOf<IteratorSubclass*,
+                                            IteratorBase<SubclassItem>*> &&
+           !::sus::mem::relocate_one_by_memcpy<IteratorSubclass>)
+{
+  return BoxedIteratorType(*new IteratorSubclass(::sus::move(subclass)),
+                           [](IteratorBase<SubclassItem>& iter) {
+                             delete reinterpret_cast<IteratorSubclass*>(&iter);
+                           });
+}
+
+}  // namespace sus::iter

--- a/subspace/iter/filter.h
+++ b/subspace/iter/filter.h
@@ -25,14 +25,12 @@ namespace sus::iter {
 using ::sus::iter::IteratorBase;
 using ::sus::mem::relocate_one_by_memcpy;
 
-template <class Item, size_t InnerIterSize, size_t InnerIterAlign,
-          bool InnerIterInlineStorage>
+template <class Item, size_t InnerIterSize, size_t InnerIterAlign>
 class Filter : public IteratorBase<Item> {
   using Pred = ::sus::fn::FnMut<bool(
       // TODO: write a sus::const_ref<T>?
       const std::remove_reference_t<const std::remove_reference_t<Item>&>&)>;
-  using InnerSizedIter = SizedIterator<Item, InnerIterSize, InnerIterAlign,
-                                       InnerIterInlineStorage>;
+  using InnerSizedIter = SizedIterator<Item, InnerIterSize, InnerIterAlign>;
 
  public:
   Option<Item> next() noexcept final {

--- a/subspace/iter/iterator_unittest.cc
+++ b/subspace/iter/iterator_unittest.cc
@@ -223,8 +223,12 @@ TEST(Iterator, FilterNonTriviallyRelocatable) {
   Filtering nums[5] = {Filtering(1), Filtering(2), Filtering(3), Filtering(4),
                        Filtering(5)};
 
-  auto fit = ArrayIterator<Filtering, 5>::with_array(nums).filter(
-      [](const Filtering& f) { return f.i >= 3; });
+  auto non_relocatable_it = ArrayIterator<Filtering, 5>::with_array(nums);
+  static_assert(!sus::mem::relocate_one_by_memcpy<decltype(non_relocatable_it)>);
+
+  auto fit = sus::move(non_relocatable_it).box().filter([](const Filtering& f) {
+    return f.i >= 3;
+  });
   EXPECT_EQ(fit.count(), 3_usize);
 }
 


### PR DESCRIPTION
Addresses https://github.com/chromium/subspace/issues/131