### PR TITLE
Update bots to use SUBSPACE_BUILD_CIR option.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,13 +110,14 @@ jobs:
           set(ENV{CC} ${{ matrix.config.cc }})
           set(ENV{CXX} ${{ matrix.config.cxx }})
 
+          build_cir="ON"
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             # Path to LLVM+Clang nightly that we have installed.
             set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
             set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
           else()
             # We don't have a copy of LLVM+Clang on the Windows bot.
-            set(ENV{SUBSPACE_NO_BUILD_CIR} "1")
+            build_cir="OFF"
           endif()
 
           if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
@@ -142,6 +143,7 @@ jobs:
               -D CMAKE_EXPORT_COMPILE_COMMANDS=1
               -G Ninja
               -D CMAKE_MAKE_PROGRAM=${ninja_program}
+              -D SUBSPACE_BUILD_CIR=${build_cir}
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,14 @@ jobs:
           set(ENV{CC} ${{ matrix.config.cc }})
           set(ENV{CXX} ${{ matrix.config.cxx }})
 
-          build_cir="ON"
+          set(BUILD_CIR ON)
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             # Path to LLVM+Clang nightly that we have installed.
             set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
             set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
           else()
             # We don't have a copy of LLVM+Clang on the Windows bot.
-            build_cir="OFF"
+            set(BUILD_CIR OFF)
           endif()
 
           if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
@@ -143,7 +143,7 @@ jobs:
               -D CMAKE_EXPORT_COMPILE_COMMANDS=1
               -G Ninja
               -D CMAKE_MAKE_PROGRAM=${ninja_program}
-              -D SUBSPACE_BUILD_CIR=${build_cir}
+              -D SUBSPACE_BUILD_CIR=${BUILD_CIR}
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/.github/workflows/clang-doc.yml
+++ b/.github/workflows/clang-doc.yml
@@ -30,6 +30,7 @@ jobs:
           export Clang_DIR="/usr/lib/llvm-16/lib/cmake/clang"
 
           sudo apt install build-essential cmake ninja-build
+          # Skip building documentation for Cir, which ends up building docs for all of
           cmake -G Ninja -B out -D CMAKE_EXPORT_COMPILE_COMMANDS=1 -D SUBSPACE_BUILD_CIR=OFF
 
       - name: Checkout docs

--- a/.github/workflows/clang-doc.yml
+++ b/.github/workflows/clang-doc.yml
@@ -24,17 +24,13 @@ jobs:
           sudo ./llvm.sh 16 all
 
       - name: Configure
-        env:
-          # Skip building documentation for Cir, which ends up building docs for all of
-          # Clang and LLVM too.
-          SUBSPACE_NO_BUILD_CIR: 1
         run: |
           # Path to LLVM+Clang nightly that we have installed.
           export LLVM_DIR="/usr/lib/llvm-16/lib/cmake/llvm"
           export Clang_DIR="/usr/lib/llvm-16/lib/cmake/clang"
 
           sudo apt install build-essential cmake ninja-build
-          cmake -G Ninja -B out -D CMAKE_EXPORT_COMPILE_COMMANDS=1
+          cmake -G Ninja -B out -D CMAKE_EXPORT_COMPILE_COMMANDS=1 -D SUBSPACE_BUILD_CIR=OFF
 
       - name: Checkout docs
         run: |

--- a/.github/workflows/clang-doc.yml
+++ b/.github/workflows/clang-doc.yml
@@ -31,6 +31,7 @@ jobs:
 
           sudo apt install build-essential cmake ninja-build
           # Skip building documentation for Cir, which ends up building docs for all of
+          # Clang and LLVM too.
           cmake -G Ninja -B out -D CMAKE_EXPORT_COMPILE_COMMANDS=1 -D SUBSPACE_BUILD_CIR=OFF
 
       - name: Checkout docs

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -110,14 +110,14 @@ jobs:
           set(ENV{CC} ${{ matrix.config.cc }})
           set(ENV{CXX} ${{ matrix.config.cxx }})
 
-          build_cir="ON"
+          set(BUILD_CIR ON)
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             # Path to LLVM+Clang nightly that we have installed.
             set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
             set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
           else()
             # We don't have a copy of LLVM+Clang on the Windows bot.
-            build_cir="OFF"
+            set(BUILD_CIR OFF)
           endif()
 
           if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
@@ -142,7 +142,7 @@ jobs:
               -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
               -G Ninja
               -D CMAKE_MAKE_PROGRAM=${ninja_program}
-              -D SUBSPACE_BUILD_CIR=${build_cir}
+              -D SUBSPACE_BUILD_CIR=${BUILD_CIR}
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -110,13 +110,14 @@ jobs:
           set(ENV{CC} ${{ matrix.config.cc }})
           set(ENV{CXX} ${{ matrix.config.cxx }})
 
+          build_cir="ON"
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             # Path to LLVM+Clang nightly that we have installed.
             set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
             set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
           else()
             # We don't have a copy of LLVM+Clang on the Windows bot.
-            set(ENV{SUBSPACE_NO_BUILD_CIR} "1")
+            build_cir="OFF"
           endif()
 
           if ("${{ runner.os }}" STREQUAL "Windows" AND NOT "x${{ matrix.config.environment_script }}" STREQUAL "x")
@@ -141,6 +142,7 @@ jobs:
               -D CMAKE_BUILD_TYPE=${{ matrix.config.build_type }}
               -G Ninja
               -D CMAKE_MAKE_PROGRAM=${ninja_program}
+              -D SUBSPACE_BUILD_CIR=${build_cir}
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,12 +23,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/tools/cm
 
 include(OptionIf)
 
-set(SUBSPACE_BUILD_CIR_DEFAULT ON)
-if (DEFINED ENV{SUBSPACE_NO_BUILD_CIR})
-  set(SUBSPACE_BUILD_CIR_DEFAULT OFF)
-endif()
-
-option_if_not_defined(SUBSPACE_BUILD_CIR "Build CIR (requires LLVM)" ${SUBSPACE_BUILD_CIR_DEFAULT})
+option_if_not_defined(SUBSPACE_BUILD_CIR "Build CIR (requires LLVM)" ON)
 
 message(STATUS "Build CIR: ${SUBSPACE_BUILD_CIR}")
 


### PR DESCRIPTION
This CL converts the bots from using the `SUBSPACE_NO_BUILD_CIR` environment variable to the new cmake `SUBSPACE_BUILD_CIR` option.