### PR TITLE
Revert: Remove most workarounds for missing Clang aggregate init support (#121)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,8 @@
 BasedOnStyle: Google
 Standard: Latest
 AllowShortCaseLabelsOnASingleLine: true
+DerivePointerAlignment: false
+PointerAlignment: Left
 
 # This would be nice but it also changes requires() and not wrapping requires clauses with () introduces clang-tidy bugs like:
 #```

--- a/cir/lib/source_span.h
+++ b/cir/lib/source_span.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "cir/llvm.h"
+#include "subspace/macros/__private/compiler_bugs.h"
 #include "subspace/prelude.h"
 
 namespace cir {
@@ -24,6 +25,11 @@ struct SourceSpan {
     return SourceSpan(decl.getASTContext().getFullLoc(decl.getBeginLoc()),
                       decl.getASTContext().getFullLoc(decl.getEndLoc()));
   }
+
+#if defined(__clang__) && !__has_feature(__cpp_aggregate_paren_init)
+  SourceSpan(clang::FullSourceLoc begin, clang::FullSourceLoc end)
+      : begin(begin), end(end) {}
+#endif
 
   clang::FullSourceLoc begin;
   clang::FullSourceLoc end;

--- a/cir/lib/syntax/function_id.h
+++ b/cir/lib/syntax/function_id.h
@@ -23,6 +23,10 @@
 namespace cir::syntax {
 
 struct FunctionId {
+#if defined(__clang__) && !__has_feature(__cpp_aggregate_paren_init)
+  FunctionId(u32 num) : num(num) {}
+#endif
+
   u32 num;
 };
 

--- a/cir/lib/visit.h
+++ b/cir/lib/visit.h
@@ -23,12 +23,14 @@ namespace cir {
 
 struct VisitCtx {
  public:
+#if defined(__clang__) && !__has_feature(__cpp_aggregate_paren_init)
+  VisitCtx() {}
+#endif
+
   syntax::FunctionId make_function_id() noexcept {
     u32 id = next_function_id;
     next_function_id += 1u;
-    return syntax::FunctionId{
-        .num = id,
-    };
+    return syntax::FunctionId(id);
   }
 
   u32 make_local_var_id() noexcept {

--- a/subspace/choice/__private/marker.h
+++ b/subspace/choice/__private/marker.h
@@ -57,9 +57,9 @@ struct ChoiceMarker<Tag, T> {
 template <auto Tag, class... Ts>
   requires(sizeof...(Ts) > 1)
 struct ChoiceMarker<Tag, Ts...> {
-  sus_clang_bug_54040(constexpr inline ChoiceMarker(Ts&&... value)
-                      : values(::sus::tuple_type::Tuple<Ts&&...>::with(
-                          ::sus::forward<Ts>(value)...)){});
+  sus_clang_bug_54040(
+      constexpr inline ChoiceMarker(::sus::tuple_type::Tuple<Ts&&...>&& values)
+      : values(::sus::move(values)){});
 
   ::sus::tuple_type::Tuple<Ts&&...> values;
 

--- a/subspace/choice/__private/marker.h
+++ b/subspace/choice/__private/marker.h
@@ -18,6 +18,8 @@
 
 #include <utility>  // TODO: Replace with our own integer_sequence.
 
+#include "macros/__private/compiler_bugs.h"
+#include "mem/forward.h"
 #include "tuple/tuple.h"
 
 namespace sus::choice_type {
@@ -40,6 +42,9 @@ struct ChoiceMarkerVoid {
 
 template <auto Tag, class T>
 struct ChoiceMarker<Tag, T> {
+  sus_clang_bug_54040(constexpr inline ChoiceMarker(T &&value)
+                      : value(::sus::forward<T>(value)){});
+
   T &&value;
 
   template <class TypeListOfMemberTypes, auto... Vs>
@@ -52,6 +57,10 @@ struct ChoiceMarker<Tag, T> {
 template <auto Tag, class... Ts>
   requires(sizeof...(Ts) > 1)
 struct ChoiceMarker<Tag, Ts...> {
+  sus_clang_bug_54040(constexpr inline ChoiceMarker(Ts &&...value)
+                      : values(::sus::tuple_type::Tuple<Ts &&...>::with(
+                          ::sus::forward<Ts>(value)...)){});
+
   ::sus::tuple_type::Tuple<Ts &&...> values;
 
   template <class TypeListOfMemberTypes, auto... Vs>

--- a/subspace/choice/__private/marker.h
+++ b/subspace/choice/__private/marker.h
@@ -35,20 +35,20 @@ struct ChoiceMarker;
 template <auto Tag>
 struct ChoiceMarkerVoid {
   template <class TypeListOfMemberTypes, auto... Vs>
-  inline constexpr operator Choice<TypeListOfMemberTypes, Vs...>() &&noexcept {
+  inline constexpr operator Choice<TypeListOfMemberTypes, Vs...>() && noexcept {
     return Choice<TypeListOfMemberTypes, Vs...>::template with<Tag>();
   }
 };
 
 template <auto Tag, class T>
 struct ChoiceMarker<Tag, T> {
-  sus_clang_bug_54040(constexpr inline ChoiceMarker(T &&value)
+  sus_clang_bug_54040(constexpr inline ChoiceMarker(T&& value)
                       : value(::sus::forward<T>(value)){});
 
-  T &&value;
+  T&& value;
 
   template <class TypeListOfMemberTypes, auto... Vs>
-  inline constexpr operator Choice<TypeListOfMemberTypes, Vs...>() &&noexcept {
+  inline constexpr operator Choice<TypeListOfMemberTypes, Vs...>() && noexcept {
     return Choice<TypeListOfMemberTypes, Vs...>::template with<Tag>(
         ::sus::forward<T>(value));
   }
@@ -57,16 +57,16 @@ struct ChoiceMarker<Tag, T> {
 template <auto Tag, class... Ts>
   requires(sizeof...(Ts) > 1)
 struct ChoiceMarker<Tag, Ts...> {
-  sus_clang_bug_54040(constexpr inline ChoiceMarker(Ts &&...value)
-                      : values(::sus::tuple_type::Tuple<Ts &&...>::with(
+  sus_clang_bug_54040(constexpr inline ChoiceMarker(Ts&&... value)
+                      : values(::sus::tuple_type::Tuple<Ts&&...>::with(
                           ::sus::forward<Ts>(value)...)){});
 
-  ::sus::tuple_type::Tuple<Ts &&...> values;
+  ::sus::tuple_type::Tuple<Ts&&...> values;
 
   template <class TypeListOfMemberTypes, auto... Vs>
-  inline constexpr operator Choice<TypeListOfMemberTypes, Vs...>() &&noexcept {
+  inline constexpr operator Choice<TypeListOfMemberTypes, Vs...>() && noexcept {
     using TupleType =
-        decltype(std::declval<Choice<TypeListOfMemberTypes, Vs...> &&>()
+        decltype(std::declval<Choice<TypeListOfMemberTypes, Vs...>&&>()
                      .template into_inner<Tag>());
     auto make_tuple =
         [this]<size_t... Is>(std::integer_sequence<size_t, Is...>) {

--- a/subspace/choice/choice_unittest.cc
+++ b/subspace/choice/choice_unittest.cc
@@ -392,6 +392,8 @@ TEST(Choice, StrongOrder) {
 }
 
 struct Weak {
+  sus_clang_bug_54040(constexpr inline Weak(i32 a, i32 b) : a(a), b(b){});
+
   constexpr auto operator==(const Weak& o) const& {
     return a == o.a && b == o.b;
   }

--- a/subspace/choice/choice_unittest.cc
+++ b/subspace/choice/choice_unittest.cc
@@ -17,7 +17,6 @@
 #include <variant>
 
 #include "googletest/include/gtest/gtest.h"
-#include "macros/__private/compiler_bugs.h"
 #include "num/types.h"
 #include "option/option.h"
 #include "prelude.h"

--- a/subspace/construct/into_unittest.cc
+++ b/subspace/construct/into_unittest.cc
@@ -14,10 +14,10 @@
 
 #include "construct/into.h"
 
+#include "googletest/include/gtest/gtest.h"
 #include "macros/__private/compiler_bugs.h"
 #include "mem/forward.h"
 #include "test/behaviour_types.h"
-#include "googletest/include/gtest/gtest.h"
 
 using sus::construct::From;
 using sus::construct::Into;
@@ -27,6 +27,7 @@ using namespace sus::test;
 namespace {
 
 struct S {
+  sus_clang_bug_54040(constexpr inline S(int val) : val(val){});
   int val = 5;
 };
 
@@ -144,6 +145,7 @@ TEST(Into, MoveInto) {
 }
 
 struct FromThings {
+  sus_clang_bug_54040(constexpr inline FromThings(int i) : got_value(i){});
   static auto from(int i) { return FromThings(i); }
   static auto from(S s) { return FromThings(s.val); }
   int got_value;

--- a/subspace/containers/__private/array_marker.h
+++ b/subspace/containers/__private/array_marker.h
@@ -18,16 +18,22 @@
 
 #include <utility>  // TODO: Replace with our own integer_sequence.
 
+#include "macros/__private/compiler_bugs.h"
+#include "mem/move.h"
 #include "tuple/tuple.h"
 
 namespace sus::containers::__private {
 
 template <class... Ts>
 struct ArrayMarker {
-  ::sus::tuple_type::Tuple<Ts &&...> values;
+  sus_clang_bug_54040(
+      constexpr inline ArrayMarker(::sus::tuple_type::Tuple<Ts&&...>&& values)
+      : values(::sus::move(values)){});
+
+  ::sus::tuple_type::Tuple<Ts&&...> values;
 
   template <class U>
-  inline constexpr operator Array<U, sizeof...(Ts)>() &&noexcept {
+  inline constexpr operator Array<U, sizeof...(Ts)>() && noexcept {
     auto make_array =
         [this]<size_t... Is>(std::integer_sequence<size_t, Is...>) {
           return Array<U, sizeof...(Is)>::with_values(

--- a/subspace/containers/__private/vec_marker.h
+++ b/subspace/containers/__private/vec_marker.h
@@ -18,16 +18,22 @@
 
 #include <utility>  // TODO: Replace with our own integer_sequence.
 
+#include "macros/__private/compiler_bugs.h"
+#include "mem/move.h"
 #include "tuple/tuple.h"
 
 namespace sus::containers::__private {
 
 template <class... Ts>
 struct VecMarker {
-  ::sus::tuple_type::Tuple<Ts &&...> values;
+  sus_clang_bug_54040(
+      constexpr inline VecMarker(::sus::tuple_type::Tuple<Ts&&...>&& values)
+      : values(::sus::move(values)){});
+
+  ::sus::tuple_type::Tuple<Ts&&...> values;
 
   template <class U>
-  inline constexpr operator Vec<U>() &&noexcept {
+  inline constexpr operator Vec<U>() && noexcept {
     auto v = Vec<U>::with_capacity(sizeof...(Ts));
 
     auto push_elements =

--- a/subspace/containers/vec.h
+++ b/subspace/containers/vec.h
@@ -62,7 +62,6 @@ class Vec {
  public:
   // sus::construct::Default trait.
   inline constexpr Vec() noexcept
-    requires(::sus::construct::Default<T>)
       : Vec(kDefault) {}
 
   static inline Vec with_capacity(usize cap) noexcept {

--- a/subspace/fn/fn_impl.h
+++ b/subspace/fn/fn_impl.h
@@ -138,8 +138,9 @@ R FnOnce<R(CallArgs...)>::operator()(CallArgs&&... args) && noexcept {
     case __private::Storage: {
       ::sus::check(storage_);  // Catch use-after-move.
       auto* storage = ::sus::mem::replace_ptr(mref(storage_), nullptr);
-      auto& vtable = static_cast<const __private::FnStorageVtable<R, CallArgs...>&>(
-          storage->vtable.unwrap_mut());
+      auto& vtable =
+          static_cast<const __private::FnStorageVtable<R, CallArgs...>&>(
+              storage->vtable.unwrap_mut());
 
       // Delete storage, after the call_once() is complete.
       //
@@ -168,8 +169,9 @@ R FnMut<R(CallArgs...)>::operator()(CallArgs&&... args) & noexcept {
       return Super::fn_ptr_(static_cast<CallArgs&&>(args)...);
     case __private::Storage: {
       ::sus::check(Super::storage_);  // Catch use-after-move.
-      auto& vtable = static_cast<const __private::FnStorageVtable<R, CallArgs...>&>(
-          Super::storage_->vtable.unwrap_mut());
+      auto& vtable =
+          static_cast<const __private::FnStorageVtable<R, CallArgs...>&>(
+              Super::storage_->vtable.unwrap_mut());
       return vtable.call_mut(
           static_cast<__private::FnStorageBase&>(*Super::storage_),
           ::sus::forward<CallArgs>(args)...);
@@ -187,8 +189,9 @@ R Fn<R(CallArgs...)>::operator()(CallArgs&&... args) const& noexcept {
       return Super::fn_ptr_(static_cast<CallArgs&&>(args)...);
     case __private::Storage: {
       ::sus::check(Super::storage_);  // Catch use-after-move.
-      auto& vtable = static_cast<const __private::FnStorageVtable<R, CallArgs...>&>(
-          Super::storage_->vtable.unwrap_mut());
+      auto& vtable =
+          static_cast<const __private::FnStorageVtable<R, CallArgs...>&>(
+              Super::storage_->vtable.unwrap_mut());
       return vtable.call(
           static_cast<const __private::FnStorageBase&>(*Super::storage_),
           ::sus::forward<CallArgs>(args)...);

--- a/subspace/iter/iterator_unittest.cc
+++ b/subspace/iter/iterator_unittest.cc
@@ -234,6 +234,8 @@ TEST(Iterator, FilterNonTriviallyRelocatable) {
 
 template <class T>
 struct CollectSum {
+  sus_clang_bug_54040(CollectSum(T sum) : sum(sum){});
+
   static constexpr CollectSum from_iter(IteratorBase<T>&& iter) noexcept {
     T sum = T();
     for (const T& t : iter) sum += t;

--- a/subspace/macros/__private/compiler_bugs.h
+++ b/subspace/macros/__private/compiler_bugs.h
@@ -38,10 +38,7 @@
 // TODO: https://github.com/llvm/llvm-project/issues/54040
 // Aggregate initialization via () paren syntax.
 //
-// Support for this landed and was reverted in clang 16. The first time it
-// landed it still did not work when:
-// * A destructor is present in the aggregate.
-// * A member of the aggregate has a concept-defined conversion operator.
+// Support for this landed and was reverted in clang 16.
 #if defined(__clang__) && !__has_feature(__cpp_aggregate_paren_init)
 #define sus_clang_bug_54040(...) __VA_ARGS__
 #define sus_clang_bug_54040_else(...)

--- a/subspace/macros/__private/compiler_bugs.h
+++ b/subspace/macros/__private/compiler_bugs.h
@@ -36,10 +36,13 @@
 #endif
 
 // TODO: https://github.com/llvm/llvm-project/issues/54040
-// Aggregate initialization in Clang doesn't work when:
+// Aggregate initialization via () paren syntax.
+//
+// Support for this landed and was reverted in clang 16. The first time it
+// landed it still did not work when:
 // * A destructor is present in the aggregate.
 // * A member of the aggregate has a concept-defined conversion operator.
-#if __clang_major__ <= 16  // TODO: Update when the bug is fixed.
+#if defined(__clang__) && !__has_feature(__cpp_aggregate_paren_init)
 #define sus_clang_bug_54040(...) __VA_ARGS__
 #define sus_clang_bug_54040_else(...)
 #else
@@ -115,9 +118,9 @@
 #define sus_gcc_bug_108169_else(...) __VA_ARGS__
 #endif
 
-
 // TODO: https://github.com/llvm/llvm-project/issues/49358
-// Clang-cl doesn't support either [[no_unique_address]] nor [[msvc::no_unique_address]]
+// Clang-cl doesn't support either [[no_unique_address]] nor
+// [[msvc::no_unique_address]]
 #if _MSC_VER && __clang_major__ > 0  // TODO: Update when the bug is fixed.
 #define sus_clang_bug_49358(...) __VA_ARGS__
 #define sus_clang_bug_49358_else(...)

--- a/subspace/mem/addressof_unittest.cc
+++ b/subspace/mem/addressof_unittest.cc
@@ -23,6 +23,7 @@ using sus::mem::addressof;
 
 TEST(AddressOf, Object) {
   struct S {
+    sus_clang_bug_54040(constexpr inline S(int i) : i(i) {})
     int i;
   };
   auto s = S(0);

--- a/subspace/ops/ord_unittest.cc
+++ b/subspace/ops/ord_unittest.cc
@@ -30,6 +30,8 @@ using sus::ops::min_by;
 using sus::ops::min_by_key;
 
 struct Strong {
+  sus_clang_bug_54040(Strong(i32 i, i32 id) : i(i), id(id){});
+
   i32 i;
   i32 id;
 
@@ -40,6 +42,8 @@ struct Strong {
 static_assert(sus::ops::Ord<Strong>);
 
 struct NoCmp {
+  sus_clang_bug_54040(NoCmp(i32 i, i32 id) : i(i), id(id){});
+
   i32 i;
   i32 id;
 };

--- a/subspace/option/option_unittest.cc
+++ b/subspace/option/option_unittest.cc
@@ -1114,7 +1114,9 @@ TEST(Option, GetOrInsertDefault) {
   IS_SOME(x);
   EXPECT_EQ(sus::move(x).unwrap().i, 2);
 
-  auto y = Option<DefaultConstructible>::some(DefaultConstructible(404));
+  auto y = Option<DefaultConstructible>::some(
+      sus_clang_bug_54040(DefaultConstructible{404})
+          sus_clang_bug_54040_else(DefaultConstructible(404)));
   auto& ry = y.get_or_insert_default();
   static_assert(std::is_same_v<decltype(ry), DefaultConstructible&>);
   EXPECT_EQ(ry.i, 404);

--- a/subspace/option/option_unittest.cc
+++ b/subspace/option/option_unittest.cc
@@ -483,6 +483,7 @@ TEST(Option, UnwrapOrDefault) {
 
 TEST(Option, Map) {
   struct Mapped {
+    sus_clang_bug_54040(constexpr inline Mapped(int i) : i(i){});
     int i;
   };
 
@@ -540,6 +541,7 @@ TEST(Option, Map) {
 
 TEST(Option, MapOr) {
   struct Mapped {
+    sus_clang_bug_54040(constexpr inline Mapped(int i) : i(i){});
     int i;
   };
 
@@ -573,6 +575,7 @@ TEST(Option, MapOr) {
 
 TEST(Option, MapOrElse) {
   struct Mapped {
+    sus_clang_bug_54040(constexpr inline Mapped(int i) : i(i){});
     int i;
   };
 
@@ -800,6 +803,7 @@ TEST(Option, And) {
 
 TEST(Option, AndThen) {
   struct And {
+    sus_clang_bug_54040(constexpr inline And(int i) : i(i){});
     int i;
   };
 
@@ -1944,7 +1948,7 @@ struct CollectSum {
   sus_clang_bug_54050(CollectSum(T sum) : sum(sum){});
 
   static constexpr CollectSum from_iter(
-      sus::iter::IteratorBase<T>&& iter) noexcept {
+      ::sus::iter::IteratorBase<T>&& iter) noexcept {
     T sum = T();
     for (const T& t : iter) sum += t;
     return CollectSum(sum);

--- a/subspace/result/__private/marker.h
+++ b/subspace/result/__private/marker.h
@@ -21,10 +21,13 @@ namespace sus::result::__private {
 
 template <class T>
 struct OkMarker {
-  T &&value;
+  sus_clang_bug_54040(constexpr inline OkMarker(T&& value)
+                      : value(::sus::forward<T>(value)){});
+
+  T&& value;
 
   template <class U, class E>
-  inline constexpr operator Result<U, E>() &&noexcept
+  inline constexpr operator Result<U, E>() && noexcept
       // `value` is a const reference.
     requires(std::is_const_v<std::remove_reference_t<T>>)
   {
@@ -32,16 +35,16 @@ struct OkMarker {
   }
 
   template <class U, class E>
-  inline constexpr operator Result<U, E>() &&noexcept
+  inline constexpr operator Result<U, E>() && noexcept
       // `value` is a mutable lvalue reference.
     requires(
-        std::same_as<T &&, std::remove_const_t<std::remove_reference_t<T>> &>)
+        std::same_as<T &&, std::remove_const_t<std::remove_reference_t<T>>&>)
   {
     return Result<U, E>::with(mref(value));
   }
 
   template <class U, class E>
-  inline constexpr operator Result<U, E>() &&noexcept
+  inline constexpr operator Result<U, E>() && noexcept
       // `value` is an rvalue reference.
     requires(
         std::same_as<T &&, std::remove_const_t<std::remove_reference_t<T>> &&>)
@@ -52,10 +55,13 @@ struct OkMarker {
 
 template <class T>
 struct ErrMarker {
-  T &&value;
+  sus_clang_bug_54040(constexpr inline ErrMarker(T&& value)
+                      : value(::sus::forward<T>(value)){});
+
+  T&& value;
 
   template <class U, class E>
-  inline constexpr operator Result<U, E>() &&noexcept
+  inline constexpr operator Result<U, E>() && noexcept
       // `value` is a const reference.
     requires(std::is_const_v<std::remove_reference_t<T>>)
   {
@@ -63,16 +69,16 @@ struct ErrMarker {
   }
 
   template <class U, class E>
-  inline constexpr operator Result<U, E>() &&noexcept
+  inline constexpr operator Result<U, E>() && noexcept
       // `value` is a mutable lvalue reference.
     requires(
-        std::same_as<T &&, std::remove_const_t<std::remove_reference_t<T>> &>)
+        std::same_as<T &&, std::remove_const_t<std::remove_reference_t<T>>&>)
   {
     return Result<U, E>::with_err(mref(value));
   }
 
   template <class U, class E>
-  inline constexpr operator Result<U, E>() &&noexcept
+  inline constexpr operator Result<U, E>() && noexcept
       // `value` is an rvalue reference.
     requires(
         std::same_as<T &&, std::remove_const_t<std::remove_reference_t<T>> &&>)

--- a/subspace/tuple/__private/storage.h
+++ b/subspace/tuple/__private/storage.h
@@ -17,7 +17,6 @@
 #include <type_traits>
 #include <utility>  // TODO: Replace std::index_sequence to remove this header.
 
-#include "macros/__private/compiler_bugs.h"
 #include "macros/no_unique_address.h"
 #include "mem/addressof.h"
 #include "mem/forward.h"

--- a/subspace/tuple/tuple.h
+++ b/subspace/tuple/tuple.h
@@ -19,10 +19,12 @@
 
 #include "assertions/check.h"
 #include "construct/default.h"
+#include "macros/__private/compiler_bugs.h"
 #include "macros/no_unique_address.h"
 #include "mem/clone.h"
 #include "mem/copy.h"
 #include "mem/forward.h"
+#include "mem/move.h"
 #include "mem/replace.h"
 #include "num/num_concepts.h"
 #include "ops/eq.h"
@@ -253,6 +255,9 @@ decltype(auto) get(Tuple<Ts...>&& t) noexcept {
 namespace __private {
 template <class... Ts>
 struct TupleMarker {
+  sus_clang_bug_54040(constexpr inline TupleMarker(Tuple<Ts&&...>&& values)
+                      : values(::sus::move(values)){});
+
   Tuple<Ts&&...> values;
 
   template <class... Us>


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/54040 has been reverted due to a compiler crash, so we must restore all our workaround constructors for it.