### PR TITLE
Introduce the sus::construct::TryFrom concept, and implement it for integers

### DIFF
--- a/subspace/CMakeLists.txt
+++ b/subspace/CMakeLists.txt
@@ -96,6 +96,7 @@ add_library(subspace STATIC
     "num/fp_category.h"
     "num/integer_concepts.h"
     "num/signed_integer.h"
+    "num/try_from_int_error.h"
     "num/num_concepts.h"
     "num/unsigned_integer.h"
     "option/__private/is_option_type.h"

--- a/subspace/construct/from.h
+++ b/subspace/construct/from.h
@@ -16,6 +16,8 @@
 
 #include <concepts>
 
+#include "subspace/result/__private/is_result_type.h"
+
 namespace sus::construct {
 
 /// A concept that indicates `ToType` can be constructed from a `FromType`, via
@@ -45,9 +47,19 @@ concept From = requires(FromType&& from) {
   { ToType::from(static_cast<FromType&&>(from)) } -> std::same_as<ToType>;
 };
 
+/// A concept that indicates `ToType` can be (sometimes) constructed from a
+/// `FromType`, via `ToType::try_from(FromType)`.
+///
+/// Unlike `sus::construct::From`, using the `try_from()` method gives the
+/// opportunity to catch failures since the return type is a
+/// `sus::result::Result`.
 template <class ToType, class FromType>
 concept TryFrom = requires(FromType&& from) {
-  { ToType::try_from(static_cast<FromType&&>(from)) } -> std::same_as<ToType>;
+  { ToType::try_from(static_cast<FromType&&>(from)) };
+  requires std::same_as<
+      typename ::sus::result::__private::IsResultType<decltype(ToType::try_from(
+          static_cast<FromType&&>(from)))>::ok_type,
+      ToType>;
 };
 
 }  // namespace sus::construct

--- a/subspace/containers/vec.h
+++ b/subspace/containers/vec.h
@@ -56,9 +56,6 @@ class Vec {
   static_assert(::sus::mem::Move<T>,
                 "Vec<T> requires that `T` is `sus::mem::Move`.");
 
-  // The documentation in this class assumes isize::MAX == PTRDIFF_MAX.
-  static_assert(isize::MAX == isize(PTRDIFF_MAX));
-
  public:
   // sus::construct::Default trait.
   inline constexpr Vec() noexcept

--- a/subspace/fn/fn_defn.h
+++ b/subspace/fn/fn_defn.h
@@ -19,7 +19,6 @@
 #include "subspace/mem/move.h"
 #include "subspace/mem/never_value.h"
 #include "subspace/mem/relocate.h"
-#include "subspace/num/types.h"
 
 namespace sus::fn {
 

--- a/subspace/iter/__private/adaptors.h
+++ b/subspace/iter/__private/adaptors.h
@@ -1,12 +1,26 @@
 #pragma once
 
-#include "subspace/iter/iterator_defn.h"
 #include "subspace/option/option.h"
 
 namespace sus::result {
 template <class T, class E>
 class Result;
 }
+
+namespace sus::iter {
+template <class Item>
+class Once;
+template <class ItemT>
+class IteratorBase;
+template <class I>
+class Iterator;
+namespace __private {
+template <class T>
+constexpr auto begin(const T& t) noexcept;
+template <class T>
+constexpr auto end(const T& t) noexcept;
+}  // namespace __private
+}  // namespace sus::iter
 
 namespace sus::iter::__private {
 

--- a/subspace/iter/iterator.h
+++ b/subspace/iter/iterator.h
@@ -16,10 +16,15 @@
 
 #include "subspace/iter/iterator_defn.h"
 
-// Once is included here, because there is a cycle between
-// Option->Once->IteratorBase, so Option can't include Once itself. But as long
+// Once is included here, because there is a cycle between:
+// * Option->Once->IteratorBase->Option
+// * Result->Iterator->usize->Result
+// So Option and Result can't include Once or Iterator directly. But as long
 // as the user includes "iterator.h" they should be able to use the iterators on
 // Option.
 #include "subspace/iter/once.h"
 
+// Headers that define iterators that Iterator can construct and return. They
+// are forward declared in iterator_defn.h so that transitive includes don't get
+// them all every time.
 #include "subspace/iter/filter.h"

--- a/subspace/lib/lib.cc
+++ b/subspace/lib/lib.cc
@@ -16,13 +16,18 @@
 #include <stddef.h>
 
 #include "subspace/mem/size_of.h"
+#include "subspace/num/signed_integer.h"
 
 // Architectural assumptions we make throughout the implementation of Subspace.
 static_assert(CHAR_BIT == 8);
-static_assert(::sus::mem::size_of<int>() == 4);
-static_assert(::sus::mem::size_of<size_t>() >= 4);
-static_assert(::sus::mem::size_of<size_t>() <= 8);
+static_assert(sus::mem::size_of<int>() == 4);
+static_assert(sus::mem::size_of<size_t>() >= 4);
+static_assert(sus::mem::size_of<size_t>() <= 8);
 
 // TODO: Consider if we should only support little endian? We probably make this
 // assumption. Support for endian *conversion* is still important for network
 // byte order etc.
+
+// The Vec class, along with any other class with pointer arithmetic, assumes
+// isize::MAX == PTRDIFF_MAX.
+static_assert(sus::isize::MAX == PTRDIFF_MAX);

--- a/subspace/num/i16_unittest.cc
+++ b/subspace/num/i16_unittest.cc
@@ -226,6 +226,16 @@ TEST(i16, From) {
   static_assert(sus::construct::From<i16, uint16_t>);
   static_assert(sus::construct::From<i16, uint32_t>);
   static_assert(sus::construct::From<i16, uint64_t>);
+  static_assert(sus::construct::TryFrom<i16, char>);
+  static_assert(sus::construct::TryFrom<i16, size_t>);
+  static_assert(sus::construct::TryFrom<i16, int8_t>);
+  static_assert(sus::construct::TryFrom<i16, int16_t>);
+  static_assert(sus::construct::TryFrom<i16, int32_t>);
+  static_assert(sus::construct::TryFrom<i16, int64_t>);
+  static_assert(sus::construct::TryFrom<i16, uint8_t>);
+  static_assert(sus::construct::TryFrom<i16, uint16_t>);
+  static_assert(sus::construct::TryFrom<i16, uint32_t>);
+  static_assert(sus::construct::TryFrom<i16, uint64_t>);
 
   EXPECT_EQ(i16::from(char{2}), 2_i16);
   EXPECT_EQ(i16::from(size_t{2}), 2_i16);
@@ -238,6 +248,22 @@ TEST(i16, From) {
   EXPECT_EQ(i16::from(uint32_t{2}), 2_i16);
   EXPECT_EQ(i16::from(uint64_t{2}), 2_i16);
 
+  EXPECT_EQ(i16::try_from(char{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(size_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(int8_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(int16_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(int32_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(int64_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(uint8_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(uint16_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(uint32_t{2}).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(uint64_t{2}).unwrap(), 2_i16);
+
+  EXPECT_TRUE(i16::try_from(int32_t{i32::MIN}).is_err());
+  EXPECT_TRUE(i16::try_from(int32_t{i32::MAX}).is_err());
+  EXPECT_TRUE(i16::try_from(uint16_t{u16::MAX}).is_err());
+  EXPECT_TRUE(i16::try_from(uint32_t{u32::MAX}).is_err());
+
   static_assert(sus::construct::From<i16, i8>);
   static_assert(sus::construct::From<i16, i16>);
   static_assert(sus::construct::From<i16, i32>);
@@ -248,6 +274,16 @@ TEST(i16, From) {
   static_assert(sus::construct::From<i16, u32>);
   static_assert(sus::construct::From<i16, u64>);
   static_assert(sus::construct::From<i16, usize>);
+  static_assert(sus::construct::TryFrom<i16, i8>);
+  static_assert(sus::construct::TryFrom<i16, i16>);
+  static_assert(sus::construct::TryFrom<i16, i32>);
+  static_assert(sus::construct::TryFrom<i16, i64>);
+  static_assert(sus::construct::TryFrom<i16, isize>);
+  static_assert(sus::construct::TryFrom<i16, u8>);
+  static_assert(sus::construct::TryFrom<i16, u16>);
+  static_assert(sus::construct::TryFrom<i16, u32>);
+  static_assert(sus::construct::TryFrom<i16, u64>);
+  static_assert(sus::construct::TryFrom<i16, usize>);
 
   EXPECT_EQ(i16::from(2_i8), 2_i16);
   EXPECT_EQ(i16::from(2_i16), 2_i16);
@@ -259,6 +295,22 @@ TEST(i16, From) {
   EXPECT_EQ(i16::from(2_u32), 2_i16);
   EXPECT_EQ(i16::from(2_u64), 2_i16);
   EXPECT_EQ(i16::from(2_usize), 2_i16);
+
+  EXPECT_EQ(i16::try_from(2_i8).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_i16).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_i32).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_i64).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_isize).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_u8).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_u16).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_u32).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_u64).unwrap(), 2_i16);
+  EXPECT_EQ(i16::try_from(2_usize).unwrap(), 2_i16);
+
+  EXPECT_TRUE(i16::try_from(i32::MIN).is_err());
+  EXPECT_TRUE(i16::try_from(i32::MAX).is_err());
+  EXPECT_TRUE(i16::try_from(u16::MAX).is_err());
+  EXPECT_TRUE(i16::try_from(u32::MAX).is_err());
 }
 
 TEST(i16DeathTest, FromOutOfRange) {

--- a/subspace/num/i32_unittest.cc
+++ b/subspace/num/i32_unittest.cc
@@ -234,6 +234,16 @@ TEST(i32, From) {
   static_assert(sus::construct::From<i32, uint16_t>);
   static_assert(sus::construct::From<i32, uint32_t>);
   static_assert(sus::construct::From<i32, uint64_t>);
+  static_assert(sus::construct::TryFrom<i32, char>);
+  static_assert(sus::construct::TryFrom<i32, size_t>);
+  static_assert(sus::construct::TryFrom<i32, int8_t>);
+  static_assert(sus::construct::TryFrom<i32, int16_t>);
+  static_assert(sus::construct::TryFrom<i32, int32_t>);
+  static_assert(sus::construct::TryFrom<i32, int64_t>);
+  static_assert(sus::construct::TryFrom<i32, uint8_t>);
+  static_assert(sus::construct::TryFrom<i32, uint16_t>);
+  static_assert(sus::construct::TryFrom<i32, uint32_t>);
+  static_assert(sus::construct::TryFrom<i32, uint64_t>);
 
   EXPECT_EQ(i32::from(char{2}), 2_i32);
   EXPECT_EQ(i32::from(size_t{2}), 2_i32);
@@ -246,6 +256,22 @@ TEST(i32, From) {
   EXPECT_EQ(i32::from(uint32_t{2}), 2_i32);
   EXPECT_EQ(i32::from(uint64_t{2}), 2_i32);
 
+  EXPECT_EQ(i32::try_from(char{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(size_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(int8_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(int16_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(int32_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(int64_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(uint8_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(uint16_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(uint32_t{2}).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(uint64_t{2}).unwrap(), 2_i32);
+
+  EXPECT_TRUE(i32::try_from(int64_t{i64::MAX}).is_err());
+  EXPECT_TRUE(i32::try_from(int64_t{i64::MIN}).is_err());
+  EXPECT_TRUE(i32::try_from(uint32_t{u32::MAX}).is_err());
+  EXPECT_TRUE(i32::try_from(uint64_t{u64::MAX}).is_err());
+
   static_assert(sus::construct::From<i32, i8>);
   static_assert(sus::construct::From<i32, i16>);
   static_assert(sus::construct::From<i32, i32>);
@@ -256,6 +282,16 @@ TEST(i32, From) {
   static_assert(sus::construct::From<i32, u32>);
   static_assert(sus::construct::From<i32, u64>);
   static_assert(sus::construct::From<i32, usize>);
+  static_assert(sus::construct::TryFrom<i32, i8>);
+  static_assert(sus::construct::TryFrom<i32, i16>);
+  static_assert(sus::construct::TryFrom<i32, i32>);
+  static_assert(sus::construct::TryFrom<i32, i64>);
+  static_assert(sus::construct::TryFrom<i32, isize>);
+  static_assert(sus::construct::TryFrom<i32, u8>);
+  static_assert(sus::construct::TryFrom<i32, u16>);
+  static_assert(sus::construct::TryFrom<i32, u32>);
+  static_assert(sus::construct::TryFrom<i32, u64>);
+  static_assert(sus::construct::TryFrom<i32, usize>);
 
   EXPECT_EQ(i32::from(2_i8), 2_i32);
   EXPECT_EQ(i32::from(2_i16), 2_i32);
@@ -267,6 +303,22 @@ TEST(i32, From) {
   EXPECT_EQ(i32::from(2_u32), 2_i32);
   EXPECT_EQ(i32::from(2_u64), 2_i32);
   EXPECT_EQ(i32::from(2_usize), 2_i32);
+
+  EXPECT_EQ(i32::try_from(2_i8).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_i16).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_i32).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_i64).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_isize).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_u8).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_u16).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_u32).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_u64).unwrap(), 2_i32);
+  EXPECT_EQ(i32::try_from(2_usize).unwrap(), 2_i32);
+
+  EXPECT_TRUE(i32::try_from(i64::MAX).is_err());
+  EXPECT_TRUE(i32::try_from(i64::MIN).is_err());
+  EXPECT_TRUE(i32::try_from(u32::MAX).is_err());
+  EXPECT_TRUE(i32::try_from(u64::MAX).is_err());
 }
 
 TEST(i32DeathTest, FromOutOfRange) {
@@ -279,6 +331,28 @@ TEST(i32DeathTest, FromOutOfRange) {
   EXPECT_DEATH(i32::from(u64::MAX), "");
   EXPECT_DEATH(i32::from(usize::MAX), "");
 #endif
+}
+
+TEST(i32, TryFromBoundaries) {
+  // Signed primitives.
+  EXPECT_TRUE(i32::try_from(int64_t{i64::from(i32::MIN)}).is_ok());
+  EXPECT_TRUE(i32::try_from(int64_t{i64::from(i32::MIN) - 1}).is_err());
+  EXPECT_TRUE(i32::try_from(int64_t{i64::from(i32::MAX)}).is_ok());
+  EXPECT_TRUE(i32::try_from(int64_t{i64::from(i32::MAX) + 1}).is_err());
+
+  // Signed integers.
+  EXPECT_TRUE(i32::try_from(i64::from(i32::MIN)).is_ok());
+  EXPECT_TRUE(i32::try_from(i64::from(i32::MIN) - 1).is_err());
+  EXPECT_TRUE(i32::try_from(i64::from(i32::MAX)).is_ok());
+  EXPECT_TRUE(i32::try_from(i64::from(i32::MAX) + 1).is_err());
+
+  // Unsigned primitives.
+  EXPECT_TRUE(i32::try_from(uint32_t{u32::from(i32::MAX)}).is_ok());
+  EXPECT_TRUE(i32::try_from(uint32_t{u32::from(i32::MAX) + 1u}).is_err());
+
+  // Unsigned integers.
+  EXPECT_TRUE(i32::try_from(u32::from(i32::MAX)).is_ok());
+  EXPECT_TRUE(i32::try_from(u32::from(i32::MAX) + 1u).is_err());
 }
 
 // ** Signed only

--- a/subspace/num/i64_unittest.cc
+++ b/subspace/num/i64_unittest.cc
@@ -227,6 +227,16 @@ TEST(i64, From) {
   static_assert(sus::construct::From<i64, uint16_t>);
   static_assert(sus::construct::From<i64, uint32_t>);
   static_assert(sus::construct::From<i64, uint64_t>);
+  static_assert(sus::construct::TryFrom<i64, char>);
+  static_assert(sus::construct::TryFrom<i64, size_t>);
+  static_assert(sus::construct::TryFrom<i64, int8_t>);
+  static_assert(sus::construct::TryFrom<i64, int16_t>);
+  static_assert(sus::construct::TryFrom<i64, int32_t>);
+  static_assert(sus::construct::TryFrom<i64, int64_t>);
+  static_assert(sus::construct::TryFrom<i64, uint8_t>);
+  static_assert(sus::construct::TryFrom<i64, uint16_t>);
+  static_assert(sus::construct::TryFrom<i64, uint32_t>);
+  static_assert(sus::construct::TryFrom<i64, uint64_t>);
 
   EXPECT_EQ(i64::from(char{2}), 2_i64);
   EXPECT_EQ(i64::from(size_t{2}), 2_i64);
@@ -239,6 +249,19 @@ TEST(i64, From) {
   EXPECT_EQ(i64::from(uint32_t{2}), 2_i64);
   EXPECT_EQ(i64::from(uint64_t{2}), 2_i64);
 
+  EXPECT_EQ(i64::try_from(char{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(size_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(int8_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(int16_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(int32_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(int64_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(uint8_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(uint16_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(uint32_t{2}).unwrap(), 2_i64);
+  EXPECT_EQ(i64::try_from(uint64_t{2}).unwrap(), 2_i64);
+
+  EXPECT_TRUE(i64::try_from(uint64_t{u64::MAX}).is_err());
+
   static_assert(sus::construct::From<i64, i8>);
   static_assert(sus::construct::From<i64, i16>);
   static_assert(sus::construct::From<i64, i32>);
@@ -249,6 +272,16 @@ TEST(i64, From) {
   static_assert(sus::construct::From<i64, u32>);
   static_assert(sus::construct::From<i64, u64>);
   static_assert(sus::construct::From<i64, usize>);
+  static_assert(sus::construct::TryFrom<i64, i8>);
+  static_assert(sus::construct::TryFrom<i64, i16>);
+  static_assert(sus::construct::TryFrom<i64, i32>);
+  static_assert(sus::construct::TryFrom<i64, i64>);
+  static_assert(sus::construct::TryFrom<i64, isize>);
+  static_assert(sus::construct::TryFrom<i64, u8>);
+  static_assert(sus::construct::TryFrom<i64, u16>);
+  static_assert(sus::construct::TryFrom<i64, u32>);
+  static_assert(sus::construct::TryFrom<i64, u64>);
+  static_assert(sus::construct::TryFrom<i64, usize>);
 
   EXPECT_EQ(i64::from(2_i8), 2_i64);
   EXPECT_EQ(i64::from(2_i16), 2_i64);
@@ -260,6 +293,19 @@ TEST(i64, From) {
   EXPECT_EQ(i64::from(2_u32), 2_i64);
   EXPECT_EQ(i64::from(2_u64), 2_i64);
   EXPECT_EQ(i64::from(2_usize), 2_i64);
+
+  EXPECT_EQ(i64::try_from(2_i8).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_i16).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_i32).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_i64).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_isize).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_u8).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_u16).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_u32).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_u64).unwrap(), 2_i16);
+  EXPECT_EQ(i64::try_from(2_usize).unwrap(), 2_i16);
+
+  EXPECT_TRUE(i64::try_from(u64::MAX).is_err());
 }
 
 TEST(i64DeathTest, FromOutOfRange) {

--- a/subspace/num/i8_unittest.cc
+++ b/subspace/num/i8_unittest.cc
@@ -14,6 +14,7 @@
 
 #include <type_traits>
 
+#include "googletest/include/gtest/gtest.h"
 #include "subspace/construct/into.h"
 #include "subspace/containers/array.h"
 #include "subspace/num/num_concepts.h"
@@ -22,7 +23,6 @@
 #include "subspace/ops/eq.h"
 #include "subspace/ops/ord.h"
 #include "subspace/prelude.h"
-#include "googletest/include/gtest/gtest.h"
 #include "subspace/tuple/tuple.h"
 
 namespace {
@@ -224,6 +224,16 @@ TEST(i8, From) {
   static_assert(sus::construct::From<i8, uint16_t>);
   static_assert(sus::construct::From<i8, uint32_t>);
   static_assert(sus::construct::From<i8, uint64_t>);
+  static_assert(sus::construct::TryFrom<i8, char>);
+  static_assert(sus::construct::TryFrom<i8, size_t>);
+  static_assert(sus::construct::TryFrom<i8, int8_t>);
+  static_assert(sus::construct::TryFrom<i8, int16_t>);
+  static_assert(sus::construct::TryFrom<i8, int32_t>);
+  static_assert(sus::construct::TryFrom<i8, int64_t>);
+  static_assert(sus::construct::TryFrom<i8, uint8_t>);
+  static_assert(sus::construct::TryFrom<i8, uint16_t>);
+  static_assert(sus::construct::TryFrom<i8, uint32_t>);
+  static_assert(sus::construct::TryFrom<i8, uint64_t>);
 
   EXPECT_EQ(i8::from(char{2}), 2_i8);
   EXPECT_EQ(i8::from(size_t{2}), 2_i8);
@@ -236,6 +246,22 @@ TEST(i8, From) {
   EXPECT_EQ(i8::from(uint32_t{2}), 2_i8);
   EXPECT_EQ(i8::from(uint64_t{2}), 2_i8);
 
+  EXPECT_EQ(i8::try_from(char{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(size_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(int8_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(int16_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(int32_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(int64_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(uint8_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(uint16_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(uint32_t{2}).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(uint64_t{2}).unwrap(), 2_i8);
+
+  EXPECT_TRUE(i8::try_from(int16_t{i16::MIN}).is_err());
+  EXPECT_TRUE(i8::try_from(int16_t{i16::MAX}).is_err());
+  EXPECT_TRUE(i8::try_from(uint8_t{u8::MAX}).is_err());
+  EXPECT_TRUE(i8::try_from(uint16_t{u16::MAX}).is_err());
+
   static_assert(sus::construct::From<i8, i8>);
   static_assert(sus::construct::From<i8, i16>);
   static_assert(sus::construct::From<i8, i32>);
@@ -246,6 +272,16 @@ TEST(i8, From) {
   static_assert(sus::construct::From<i8, u32>);
   static_assert(sus::construct::From<i8, u64>);
   static_assert(sus::construct::From<i8, usize>);
+  static_assert(sus::construct::TryFrom<i8, i8>);
+  static_assert(sus::construct::TryFrom<i8, i16>);
+  static_assert(sus::construct::TryFrom<i8, i32>);
+  static_assert(sus::construct::TryFrom<i8, i64>);
+  static_assert(sus::construct::TryFrom<i8, isize>);
+  static_assert(sus::construct::TryFrom<i8, u8>);
+  static_assert(sus::construct::TryFrom<i8, u16>);
+  static_assert(sus::construct::TryFrom<i8, u32>);
+  static_assert(sus::construct::TryFrom<i8, u64>);
+  static_assert(sus::construct::TryFrom<i8, usize>);
 
   EXPECT_EQ(i8::from(2_i8), 2_i8);
   EXPECT_EQ(i8::from(2_i16), 2_i8);
@@ -257,6 +293,22 @@ TEST(i8, From) {
   EXPECT_EQ(i8::from(2_u32), 2_i8);
   EXPECT_EQ(i8::from(2_u64), 2_i8);
   EXPECT_EQ(i8::from(2_usize), 2_i8);
+
+  EXPECT_EQ(i8::try_from(2_i8).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_i16).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_i32).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_i64).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_isize).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_u8).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_u16).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_u32).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_u64).unwrap(), 2_i8);
+  EXPECT_EQ(i8::try_from(2_usize).unwrap(), 2_i8);
+
+  EXPECT_TRUE(i8::try_from(i16::MIN).is_err());
+  EXPECT_TRUE(i8::try_from(i16::MAX).is_err());
+  EXPECT_TRUE(i8::try_from(u8::MAX).is_err());
+  EXPECT_TRUE(i8::try_from(u16::MAX).is_err());
 }
 
 TEST(i8DeathTest, FromOutOfRange) {

--- a/subspace/num/isize_unittest.cc
+++ b/subspace/num/isize_unittest.cc
@@ -268,6 +268,16 @@ TEST(isize, From) {
   static_assert(sus::construct::From<isize, uint16_t>);
   static_assert(sus::construct::From<isize, uint32_t>);
   static_assert(sus::construct::From<isize, uint64_t>);
+  static_assert(sus::construct::TryFrom<i32, char>);
+  static_assert(sus::construct::TryFrom<i32, size_t>);
+  static_assert(sus::construct::TryFrom<i32, int8_t>);
+  static_assert(sus::construct::TryFrom<i32, int16_t>);
+  static_assert(sus::construct::TryFrom<i32, int32_t>);
+  static_assert(sus::construct::TryFrom<i32, int64_t>);
+  static_assert(sus::construct::TryFrom<i32, uint8_t>);
+  static_assert(sus::construct::TryFrom<i32, uint16_t>);
+  static_assert(sus::construct::TryFrom<i32, uint32_t>);
+  static_assert(sus::construct::TryFrom<i32, uint64_t>);
 
   EXPECT_EQ(isize::from(char{2}), 2_isize);
   EXPECT_EQ(isize::from(size_t{2}), 2_isize);
@@ -280,6 +290,24 @@ TEST(isize, From) {
   EXPECT_EQ(isize::from(uint32_t{2}), 2_isize);
   EXPECT_EQ(isize::from(uint64_t{2}), 2_isize);
 
+  EXPECT_EQ(isize::try_from(char{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(size_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(int8_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(int16_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(int32_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(int64_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(uint8_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(uint16_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(uint32_t{2}).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(uint64_t{2}).unwrap(), 2_isize);
+
+  if constexpr (sizeof(isize) == sizeof(i32)) {
+    EXPECT_TRUE(isize::try_from(uint32_t{u32::MAX}).is_err());
+    EXPECT_TRUE(isize::try_from(int64_t{i64::MIN}).is_err());
+    EXPECT_TRUE(isize::try_from(int64_t{i64::MAX}).is_err());
+  }
+  EXPECT_TRUE(isize::try_from(uint64_t{u64::MAX}).is_err());
+
   static_assert(sus::construct::From<isize, i8>);
   static_assert(sus::construct::From<isize, i16>);
   static_assert(sus::construct::From<isize, i32>);
@@ -290,6 +318,16 @@ TEST(isize, From) {
   static_assert(sus::construct::From<isize, u32>);
   static_assert(sus::construct::From<isize, u64>);
   static_assert(sus::construct::From<isize, usize>);
+  static_assert(sus::construct::TryFrom<i32, i8>);
+  static_assert(sus::construct::TryFrom<i32, i16>);
+  static_assert(sus::construct::TryFrom<i32, i32>);
+  static_assert(sus::construct::TryFrom<i32, i64>);
+  static_assert(sus::construct::TryFrom<i32, isize>);
+  static_assert(sus::construct::TryFrom<i32, u8>);
+  static_assert(sus::construct::TryFrom<i32, u16>);
+  static_assert(sus::construct::TryFrom<i32, u32>);
+  static_assert(sus::construct::TryFrom<i32, u64>);
+  static_assert(sus::construct::TryFrom<i32, usize>);
 
   EXPECT_EQ(isize::from(2_i8), 2_isize);
   EXPECT_EQ(isize::from(2_i16), 2_isize);
@@ -301,6 +339,24 @@ TEST(isize, From) {
   EXPECT_EQ(isize::from(2_u32), 2_isize);
   EXPECT_EQ(isize::from(2_u64), 2_isize);
   EXPECT_EQ(isize::from(2_usize), 2_isize);
+
+  EXPECT_EQ(isize::try_from(2_i8).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_i16).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_i32).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_i64).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_isize).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_u8).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_u16).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_u32).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_u64).unwrap(), 2_isize);
+  EXPECT_EQ(isize::try_from(2_usize).unwrap(), 2_isize);
+
+  if constexpr (sizeof(isize) == sizeof(i32)) {
+    EXPECT_TRUE(isize::try_from(u32::MAX).is_err());
+    EXPECT_TRUE(isize::try_from(u64::MIN).is_err());
+    EXPECT_TRUE(isize::try_from(u64::MAX).is_err());
+  }
+  EXPECT_TRUE(isize::try_from(u64::MAX).is_err());
 }
 
 TEST(isizeDeathTest, FromOutOfRange) {

--- a/subspace/num/try_from_int_error.h
+++ b/subspace/num/try_from_int_error.h
@@ -1,0 +1,45 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "subspace/assertions/unreachable.h"
+
+namespace sus::num {
+
+/// The error type returned when a checked integral type conversion fails.
+class TryFromIntError {
+ public:
+  /// The type of error which occured.
+  enum class Kind {
+    OutOfBounds,
+  };
+
+  /// Constructs a TryFromIntError with a `kind`.
+  explicit constexpr TryFromIntError(Kind kind) : kind_(kind) {}
+
+  std::string to_string() noexcept {
+    switch (kind_) {
+      case Kind::OutOfBounds: return std::string("out of bounds");
+    }
+    ::sus::assertions::unreachable_unchecked(::sus::marker::unsafe_fn);
+  }
+
+ private:
+  Kind kind_;
+};
+
+}  // namespace sus::num

--- a/subspace/num/u16_unittest.cc
+++ b/subspace/num/u16_unittest.cc
@@ -229,6 +229,16 @@ TEST(u16, From) {
   static_assert(sus::construct::From<u16, uint16_t>);
   static_assert(sus::construct::From<u16, uint32_t>);
   static_assert(sus::construct::From<u16, uint64_t>);
+  static_assert(sus::construct::TryFrom<u16, char>);
+  static_assert(sus::construct::TryFrom<u16, size_t>);
+  static_assert(sus::construct::TryFrom<u16, int8_t>);
+  static_assert(sus::construct::TryFrom<u16, int16_t>);
+  static_assert(sus::construct::TryFrom<u16, int32_t>);
+  static_assert(sus::construct::TryFrom<u16, int64_t>);
+  static_assert(sus::construct::TryFrom<u16, uint8_t>);
+  static_assert(sus::construct::TryFrom<u16, uint16_t>);
+  static_assert(sus::construct::TryFrom<u16, uint32_t>);
+  static_assert(sus::construct::TryFrom<u16, uint64_t>);
 
   EXPECT_EQ(u16::from(char{2}), 2_u16);
   EXPECT_EQ(u16::from(size_t{2}), 2_u16);
@@ -241,6 +251,23 @@ TEST(u16, From) {
   EXPECT_EQ(u16::from(uint32_t{2}), 2_u16);
   EXPECT_EQ(u16::from(uint64_t{2}), 2_u16);
 
+  EXPECT_EQ(u16::try_from(char{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(size_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(int8_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(int16_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(int32_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(int64_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(uint8_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(uint16_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(uint32_t{2}).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(uint64_t{2}).unwrap(), 2_u16);
+
+  EXPECT_TRUE(u16::try_from(int16_t{i16::MIN}).is_err());
+  EXPECT_TRUE(u16::try_from(int16_t{i16::MAX}).is_ok());
+  EXPECT_TRUE(u16::try_from(int32_t{i32::MIN}).is_err());
+  EXPECT_TRUE(u16::try_from(int32_t{i32::MAX}).is_err());
+  EXPECT_TRUE(u16::try_from(uint32_t{u32::MAX}).is_err());
+
   static_assert(sus::construct::From<u16, i8>);
   static_assert(sus::construct::From<u16, i16>);
   static_assert(sus::construct::From<u16, i32>);
@@ -251,6 +278,16 @@ TEST(u16, From) {
   static_assert(sus::construct::From<u16, u32>);
   static_assert(sus::construct::From<u16, u64>);
   static_assert(sus::construct::From<u16, usize>);
+  static_assert(sus::construct::TryFrom<u16, i8>);
+  static_assert(sus::construct::TryFrom<u16, i16>);
+  static_assert(sus::construct::TryFrom<u16, i32>);
+  static_assert(sus::construct::TryFrom<u16, i64>);
+  static_assert(sus::construct::TryFrom<u16, isize>);
+  static_assert(sus::construct::TryFrom<u16, u8>);
+  static_assert(sus::construct::TryFrom<u16, u16>);
+  static_assert(sus::construct::TryFrom<u16, u32>);
+  static_assert(sus::construct::TryFrom<u16, u64>);
+  static_assert(sus::construct::TryFrom<u16, usize>);
 
   EXPECT_EQ(u16::from(2_i8), 2_u16);
   EXPECT_EQ(u16::from(2_i16), 2_u16);
@@ -262,6 +299,23 @@ TEST(u16, From) {
   EXPECT_EQ(u16::from(2_u32), 2_u16);
   EXPECT_EQ(u16::from(2_u64), 2_u16);
   EXPECT_EQ(u16::from(2_usize), 2_u16);
+
+  EXPECT_EQ(u16::try_from(2_i8).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_i16).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_i32).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_i64).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_isize).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_u8).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_u16).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_u32).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_u64).unwrap(), 2_u16);
+  EXPECT_EQ(u16::try_from(2_usize).unwrap(), 2_u16);
+
+  EXPECT_TRUE(u16::try_from(i16::MIN).is_err());
+  EXPECT_TRUE(u16::try_from(i16::MAX).is_ok());
+  EXPECT_TRUE(u16::try_from(i32::MIN).is_err());
+  EXPECT_TRUE(u16::try_from(i32::MAX).is_err());
+  EXPECT_TRUE(u16::try_from(u32::MAX).is_err());
 }
 
 TEST(u16DeathTest, FromOutOfRange) {

--- a/subspace/num/u32_unittest.cc
+++ b/subspace/num/u32_unittest.cc
@@ -238,6 +238,16 @@ TEST(u32, From) {
   static_assert(sus::construct::From<u32, uint16_t>);
   static_assert(sus::construct::From<u32, uint32_t>);
   static_assert(sus::construct::From<u32, uint64_t>);
+  static_assert(sus::construct::TryFrom<u32, char>);
+  static_assert(sus::construct::TryFrom<u32, size_t>);
+  static_assert(sus::construct::TryFrom<u32, int8_t>);
+  static_assert(sus::construct::TryFrom<u32, int16_t>);
+  static_assert(sus::construct::TryFrom<u32, int32_t>);
+  static_assert(sus::construct::TryFrom<u32, int64_t>);
+  static_assert(sus::construct::TryFrom<u32, uint8_t>);
+  static_assert(sus::construct::TryFrom<u32, uint16_t>);
+  static_assert(sus::construct::TryFrom<u32, uint32_t>);
+  static_assert(sus::construct::TryFrom<u32, uint64_t>);
 
   EXPECT_EQ(u32::from(char{2}), 2_u32);
   EXPECT_EQ(u32::from(size_t{2}), 2_u32);
@@ -250,6 +260,23 @@ TEST(u32, From) {
   EXPECT_EQ(u32::from(uint32_t{2}), 2_u32);
   EXPECT_EQ(u32::from(uint64_t{2}), 2_u32);
 
+  EXPECT_EQ(u32::try_from(char{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(size_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(int8_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(int16_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(int32_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(int64_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(uint8_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(uint16_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(uint32_t{2}).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(uint64_t{2}).unwrap(), 2_u32);
+
+  EXPECT_TRUE(u32::try_from(int32_t{i32::MIN}).is_err());
+  EXPECT_TRUE(u32::try_from(int32_t{i32::MAX}).is_ok());
+  EXPECT_TRUE(u32::try_from(int64_t{i64::MIN}).is_err());
+  EXPECT_TRUE(u32::try_from(int64_t{i64::MAX}).is_err());
+  EXPECT_TRUE(u32::try_from(uint64_t{u64::MAX}).is_err());
+
   static_assert(sus::construct::From<u32, i8>);
   static_assert(sus::construct::From<u32, i16>);
   static_assert(sus::construct::From<u32, i32>);
@@ -260,6 +287,16 @@ TEST(u32, From) {
   static_assert(sus::construct::From<u32, u32>);
   static_assert(sus::construct::From<u32, u64>);
   static_assert(sus::construct::From<u32, usize>);
+  static_assert(sus::construct::TryFrom<u32, i8>);
+  static_assert(sus::construct::TryFrom<u32, i16>);
+  static_assert(sus::construct::TryFrom<u32, i32>);
+  static_assert(sus::construct::TryFrom<u32, i64>);
+  static_assert(sus::construct::TryFrom<u32, isize>);
+  static_assert(sus::construct::TryFrom<u32, u8>);
+  static_assert(sus::construct::TryFrom<u32, u16>);
+  static_assert(sus::construct::TryFrom<u32, u32>);
+  static_assert(sus::construct::TryFrom<u32, u64>);
+  static_assert(sus::construct::TryFrom<u32, usize>);
 
   EXPECT_EQ(u32::from(2_i8), 2_u32);
   EXPECT_EQ(u32::from(2_i16), 2_u32);
@@ -271,6 +308,23 @@ TEST(u32, From) {
   EXPECT_EQ(u32::from(2_u32), 2_u32);
   EXPECT_EQ(u32::from(2_u64), 2_u32);
   EXPECT_EQ(u32::from(2_usize), 2_u32);
+
+  EXPECT_EQ(u32::try_from(2_i8).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_i16).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_i32).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_i64).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_isize).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_u8).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_u16).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_u32).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_u64).unwrap(), 2_u32);
+  EXPECT_EQ(u32::try_from(2_usize).unwrap(), 2_u32);
+
+  EXPECT_TRUE(u32::try_from(i32::MIN).is_err());
+  EXPECT_TRUE(u32::try_from(i32::MAX).is_ok());
+  EXPECT_TRUE(u32::try_from(i64::MIN).is_err());
+  EXPECT_TRUE(u32::try_from(i64::MAX).is_err());
+  EXPECT_TRUE(u32::try_from(u64::MAX).is_err());
 }
 
 TEST(u32DeathTest, FromOutOfRange) {
@@ -285,6 +339,28 @@ TEST(u32DeathTest, FromOutOfRange) {
   EXPECT_DEATH(u32::from(-1_i64), "");
   EXPECT_DEATH(u32::from(-1_isize), "");
 #endif
+}
+
+TEST(u32, TryFromBoundaries) {
+  // Signed primitives.
+  EXPECT_TRUE(u32::try_from(int64_t{i64::from(u32::MAX)}).is_ok());
+  EXPECT_TRUE(u32::try_from(int64_t{i64::from(u32::MAX) + 1}).is_err());
+  EXPECT_TRUE(u32::try_from(int64_t{0}).is_ok());
+  EXPECT_TRUE(u32::try_from(int64_t{-1}).is_err());
+
+  // Signed integers.
+  EXPECT_TRUE(u32::try_from(i64::from(u32::MAX)).is_ok());
+  EXPECT_TRUE(u32::try_from(i64::from(u32::MAX) + 1).is_err());
+  EXPECT_TRUE(u32::try_from(0_i32).is_ok());
+  EXPECT_TRUE(u32::try_from(-1_i32).is_err());
+
+  // Unsigned primitives.
+  EXPECT_TRUE(u32::try_from(uint64_t{u64::from(u32::MAX)}).is_ok());
+  EXPECT_TRUE(u32::try_from(uint64_t{u64::from(u32::MAX) + 1u}).is_err());
+
+  // Unsigned integers.
+  EXPECT_TRUE(u32::try_from(u64::from(u32::MAX)).is_ok());
+  EXPECT_TRUE(u32::try_from(u64::from(u32::MAX) + 1u).is_err());
 }
 
 TEST(u32, AbsDiff) {

--- a/subspace/num/u64_unittest.cc
+++ b/subspace/num/u64_unittest.cc
@@ -235,6 +235,16 @@ TEST(u64, From) {
   static_assert(sus::construct::From<u64, uint16_t>);
   static_assert(sus::construct::From<u64, uint32_t>);
   static_assert(sus::construct::From<u64, uint64_t>);
+  static_assert(sus::construct::TryFrom<u64, char>);
+  static_assert(sus::construct::TryFrom<u64, size_t>);
+  static_assert(sus::construct::TryFrom<u64, int8_t>);
+  static_assert(sus::construct::TryFrom<u64, int16_t>);
+  static_assert(sus::construct::TryFrom<u64, int32_t>);
+  static_assert(sus::construct::TryFrom<u64, int64_t>);
+  static_assert(sus::construct::TryFrom<u64, uint8_t>);
+  static_assert(sus::construct::TryFrom<u64, uint16_t>);
+  static_assert(sus::construct::TryFrom<u64, uint32_t>);
+  static_assert(sus::construct::TryFrom<u64, uint64_t>);
 
   EXPECT_EQ(u64::from(char{2}), 2_u64);
   EXPECT_EQ(u64::from(size_t{2}), 2_u64);
@@ -247,6 +257,20 @@ TEST(u64, From) {
   EXPECT_EQ(u64::from(uint32_t{2}), 2_u64);
   EXPECT_EQ(u64::from(uint64_t{2}), 2_u64);
 
+  EXPECT_EQ(u64::try_from(char{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(size_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(int8_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(int16_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(int32_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(int64_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(uint8_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(uint16_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(uint32_t{2}).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(uint64_t{2}).unwrap(), 2_u64);
+
+  EXPECT_TRUE(u64::try_from(int64_t{i64::MIN}).is_err());
+  EXPECT_TRUE(u64::try_from(int64_t{i64::MAX}).is_ok());
+
   static_assert(sus::construct::From<u64, i8>);
   static_assert(sus::construct::From<u64, i16>);
   static_assert(sus::construct::From<u64, i32>);
@@ -257,6 +281,16 @@ TEST(u64, From) {
   static_assert(sus::construct::From<u64, u32>);
   static_assert(sus::construct::From<u64, u64>);
   static_assert(sus::construct::From<u64, usize>);
+  static_assert(sus::construct::TryFrom<u64, i8>);
+  static_assert(sus::construct::TryFrom<u64, i16>);
+  static_assert(sus::construct::TryFrom<u64, i32>);
+  static_assert(sus::construct::TryFrom<u64, i64>);
+  static_assert(sus::construct::TryFrom<u64, isize>);
+  static_assert(sus::construct::TryFrom<u64, u8>);
+  static_assert(sus::construct::TryFrom<u64, u16>);
+  static_assert(sus::construct::TryFrom<u64, u32>);
+  static_assert(sus::construct::TryFrom<u64, u64>);
+  static_assert(sus::construct::TryFrom<u64, usize>);
 
   EXPECT_EQ(u64::from(2_i8), 2_u64);
   EXPECT_EQ(u64::from(2_i16), 2_u64);
@@ -268,6 +302,20 @@ TEST(u64, From) {
   EXPECT_EQ(u64::from(2_u32), 2_u64);
   EXPECT_EQ(u64::from(2_u64), 2_u64);
   EXPECT_EQ(u64::from(2_usize), 2_u64);
+
+  EXPECT_EQ(u64::try_from(2_i8).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_i16).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_i32).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_i64).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_isize).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_u8).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_u16).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_u32).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_u64).unwrap(), 2_u64);
+  EXPECT_EQ(u64::try_from(2_usize).unwrap(), 2_u64);
+
+  EXPECT_TRUE(u64::try_from(i64::MIN).is_err());
+  EXPECT_TRUE(u64::try_from(i64::MAX).is_ok());
 }
 
 TEST(u64DeathTest, FromOutOfRange) {

--- a/subspace/num/u8_unittest.cc
+++ b/subspace/num/u8_unittest.cc
@@ -227,6 +227,16 @@ TEST(u8, From) {
   static_assert(sus::construct::From<u8, uint16_t>);
   static_assert(sus::construct::From<u8, uint32_t>);
   static_assert(sus::construct::From<u8, uint64_t>);
+  static_assert(sus::construct::TryFrom<u8, char>);
+  static_assert(sus::construct::TryFrom<u8, size_t>);
+  static_assert(sus::construct::TryFrom<u8, int8_t>);
+  static_assert(sus::construct::TryFrom<u8, int16_t>);
+  static_assert(sus::construct::TryFrom<u8, int32_t>);
+  static_assert(sus::construct::TryFrom<u8, int64_t>);
+  static_assert(sus::construct::TryFrom<u8, uint8_t>);
+  static_assert(sus::construct::TryFrom<u8, uint16_t>);
+  static_assert(sus::construct::TryFrom<u8, uint32_t>);
+  static_assert(sus::construct::TryFrom<u8, uint64_t>);
 
   EXPECT_EQ(u8::from(char{2}), 2_u8);
   EXPECT_EQ(u8::from(size_t{2}), 2_u8);
@@ -239,6 +249,23 @@ TEST(u8, From) {
   EXPECT_EQ(u8::from(uint32_t{2}), 2_u8);
   EXPECT_EQ(u8::from(uint64_t{2}), 2_u8);
 
+  EXPECT_EQ(u8::try_from(char{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(size_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(int8_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(int16_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(int32_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(int64_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(uint8_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(uint16_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(uint32_t{2}).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(uint64_t{2}).unwrap(), 2_u8);
+
+  EXPECT_TRUE(u8::try_from(int8_t{i8::MIN}).is_err());
+  EXPECT_TRUE(u8::try_from(int8_t{i8::MAX}).is_ok());
+  EXPECT_TRUE(u8::try_from(int16_t{i16::MIN}).is_err());
+  EXPECT_TRUE(u8::try_from(int16_t{i16::MAX}).is_err());
+  EXPECT_TRUE(u8::try_from(uint16_t{u16::MAX}).is_err());
+
   static_assert(sus::construct::From<u8, i8>);
   static_assert(sus::construct::From<u8, i16>);
   static_assert(sus::construct::From<u8, i32>);
@@ -249,6 +276,16 @@ TEST(u8, From) {
   static_assert(sus::construct::From<u8, u32>);
   static_assert(sus::construct::From<u8, u64>);
   static_assert(sus::construct::From<u8, usize>);
+  static_assert(sus::construct::TryFrom<u8, i8>);
+  static_assert(sus::construct::TryFrom<u8, i16>);
+  static_assert(sus::construct::TryFrom<u8, i32>);
+  static_assert(sus::construct::TryFrom<u8, i64>);
+  static_assert(sus::construct::TryFrom<u8, isize>);
+  static_assert(sus::construct::TryFrom<u8, u8>);
+  static_assert(sus::construct::TryFrom<u8, u16>);
+  static_assert(sus::construct::TryFrom<u8, u32>);
+  static_assert(sus::construct::TryFrom<u8, u64>);
+  static_assert(sus::construct::TryFrom<u8, usize>);
 
   EXPECT_EQ(u8::from(2_i8), 2_u8);
   EXPECT_EQ(u8::from(2_i16), 2_u8);
@@ -260,6 +297,23 @@ TEST(u8, From) {
   EXPECT_EQ(u8::from(2_u32), 2_u8);
   EXPECT_EQ(u8::from(2_u64), 2_u8);
   EXPECT_EQ(u8::from(2_usize), 2_u8);
+
+  EXPECT_EQ(u8::try_from(2_i8).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_i16).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_i32).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_i64).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_isize).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_u8).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_u16).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_u32).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_u64).unwrap(), 2_u8);
+  EXPECT_EQ(u8::try_from(2_usize).unwrap(), 2_u8);
+
+  EXPECT_TRUE(u8::try_from(i8::MIN).is_err());
+  EXPECT_TRUE(u8::try_from(i8::MAX).is_ok());
+  EXPECT_TRUE(u8::try_from(i16::MIN).is_err());
+  EXPECT_TRUE(u8::try_from(i16::MAX).is_err());
+  EXPECT_TRUE(u8::try_from(u16::MAX).is_err());
 }
 
 TEST(u8DeathTest, FromOutOfRange) {

--- a/subspace/num/usize_unittest.cc
+++ b/subspace/num/usize_unittest.cc
@@ -253,6 +253,16 @@ TEST(usize, From) {
   static_assert(sus::construct::From<usize, uint16_t>);
   static_assert(sus::construct::From<usize, uint32_t>);
   static_assert(sus::construct::From<usize, uint64_t>);
+  static_assert(sus::construct::TryFrom<usize, char>);
+  static_assert(sus::construct::TryFrom<usize, size_t>);
+  static_assert(sus::construct::TryFrom<usize, int8_t>);
+  static_assert(sus::construct::TryFrom<usize, int16_t>);
+  static_assert(sus::construct::TryFrom<usize, int32_t>);
+  static_assert(sus::construct::TryFrom<usize, int64_t>);
+  static_assert(sus::construct::TryFrom<usize, uint8_t>);
+  static_assert(sus::construct::TryFrom<usize, uint16_t>);
+  static_assert(sus::construct::TryFrom<usize, uint32_t>);
+  static_assert(sus::construct::TryFrom<usize, uint64_t>);
 
   EXPECT_EQ(usize::from(char{2}), 2_usize);
   EXPECT_EQ(usize::from(size_t{2}), 2_usize);
@@ -265,6 +275,24 @@ TEST(usize, From) {
   EXPECT_EQ(usize::from(uint32_t{2}), 2_usize);
   EXPECT_EQ(usize::from(uint64_t{2}), 2_usize);
 
+  EXPECT_EQ(usize::try_from(char{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(size_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(int8_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(int16_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(int32_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(int64_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(uint8_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(uint16_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(uint32_t{2}).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(uint64_t{2}).unwrap(), 2_usize);
+
+  if constexpr (sizeof(usize) == sizeof(u32)) {
+    EXPECT_TRUE(usize::try_from(uint32_t{u32::MAX}).is_ok());
+    EXPECT_TRUE(usize::try_from(uint64_t{u64::MAX}).is_err());
+  }
+  EXPECT_TRUE(usize::try_from(int64_t{i64::MIN}).is_err());
+  EXPECT_TRUE(usize::try_from(int64_t{i64::MAX}).is_ok());
+
   static_assert(sus::construct::From<usize, i8>);
   static_assert(sus::construct::From<usize, i16>);
   static_assert(sus::construct::From<usize, i32>);
@@ -275,6 +303,16 @@ TEST(usize, From) {
   static_assert(sus::construct::From<usize, u32>);
   static_assert(sus::construct::From<usize, u64>);
   static_assert(sus::construct::From<usize, usize>);
+  static_assert(sus::construct::TryFrom<usize, i8>);
+  static_assert(sus::construct::TryFrom<usize, i16>);
+  static_assert(sus::construct::TryFrom<usize, i32>);
+  static_assert(sus::construct::TryFrom<usize, i64>);
+  static_assert(sus::construct::TryFrom<usize, isize>);
+  static_assert(sus::construct::TryFrom<usize, u8>);
+  static_assert(sus::construct::TryFrom<usize, u16>);
+  static_assert(sus::construct::TryFrom<usize, u32>);
+  static_assert(sus::construct::TryFrom<usize, u64>);
+  static_assert(sus::construct::TryFrom<usize, usize>);
 
   EXPECT_EQ(usize::from(2_i8), 2_usize);
   EXPECT_EQ(usize::from(2_i16), 2_usize);
@@ -286,6 +324,24 @@ TEST(usize, From) {
   EXPECT_EQ(usize::from(2_u32), 2_usize);
   EXPECT_EQ(usize::from(2_u64), 2_usize);
   EXPECT_EQ(usize::from(2_usize), 2_usize);
+
+  EXPECT_EQ(usize::try_from(2_i8).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_i16).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_i32).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_i64).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_isize).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_u8).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_u16).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_u32).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_u64).unwrap(), 2_usize);
+  EXPECT_EQ(usize::try_from(2_usize).unwrap(), 2_usize);
+
+  if constexpr (sizeof(usize) == sizeof(u32)) {
+    EXPECT_TRUE(usize::try_from(u32::MAX).is_ok());
+    EXPECT_TRUE(usize::try_from(u64::MAX).is_err());
+  }
+  EXPECT_TRUE(usize::try_from(i64::MIN).is_err());
+  EXPECT_TRUE(usize::try_from(i64::MAX).is_ok());
 }
 
 TEST(usizeDeathTest, FromOutOfRange) {

--- a/subspace/option/option.h
+++ b/subspace/option/option.h
@@ -969,7 +969,7 @@ template <class T, class U>
 constexpr inline auto operator<=>(const Option<T>& l,
                                   const Option<U>& r) noexcept = delete;
 
-// Implicit for-ranged loop iteration via `Array::iter()`.
+// Implicit for-ranged loop iteration via `Option::iter()`.
 using sus::iter::__private::begin;
 using sus::iter::__private::end;
 

--- a/subspace/result/result.h
+++ b/subspace/result/result.h
@@ -23,8 +23,6 @@
 #include "subspace/assertions/check.h"
 #include "subspace/assertions/unreachable.h"
 #include "subspace/iter/__private/adaptors.h"
-#include "subspace/iter/iterator_defn.h"
-#include "subspace/iter/once.h"
 #include "subspace/macros/no_unique_address.h"
 #include "subspace/marker/unsafe.h"
 #include "subspace/mem/clone.h"
@@ -37,6 +35,15 @@
 #include "subspace/option/option.h"
 #include "subspace/result/__private/marker.h"
 #include "subspace/result/__private/storage.h"
+
+namespace sus::iter {
+template <class Item>
+class Once;
+template <class ItemT>
+class IteratorBase;
+template <class I>
+class Iterator;
+}  // namespace sus::iter
 
 namespace sus::result {
 
@@ -375,28 +382,28 @@ class [[nodiscard]] Result final {
   constexpr Iterator<Once<const T&>> iter() const& noexcept {
     ::sus::check(state_ != IsMoved);
     if (state_ == IsOk)
-      return sus::iter::once(Option<const T&>::some(storage_.ok_));
+      return Iterator<Once<const T&>>(Option<const T&>::some(storage_.ok_));
     else
-      return sus::iter::once(Option<const T&>::none());
+      return Iterator<Once<const T&>>(Option<const T&>::none());
   }
   Iterator<Once<const T&>> iter() const&& = delete;
 
   constexpr Iterator<Once<T&>> iter_mut() & noexcept {
     ::sus::check(state_ != IsMoved);
     if (state_ == IsOk)
-      return sus::iter::once(Option<T&>::some(mref(storage_.ok_)));
+      return Iterator<Once<T&>>(Option<T&>::some(mref(storage_.ok_)));
     else
-      return sus::iter::once(Option<T&>::none());
+      return Iterator<Once<T&>>(Option<T&>::none());
   }
 
   constexpr Iterator<Once<T>> into_iter() && noexcept {
     ::sus::check(state_ != IsMoved);
     if (::sus::mem::replace(mref(state_), IsMoved) == IsOk) {
-      return sus::iter::once(Option<T>::some(::sus::mem::take_and_destruct(
+      return Iterator<Once<T>>(Option<T>::some(::sus::mem::take_and_destruct(
           ::sus::marker::unsafe_fn, mref(storage_.ok_))));
     } else {
       storage_.err_.~E();
-      return sus::iter::once(Option<T>::none());
+      return Iterator<Once<T>>(Option<T>::none());
     }
   }
 


### PR DESCRIPTION
The TryFrom concept is like From, but it returns a Result instead of possibly panicking.

TryFrom is implemented for all integer types.