### PR TITLE
Address TODOs for f32 and f64 consts conflicting with <cmath>

### DIFF
--- a/subspace/CMakeLists.txt
+++ b/subspace/CMakeLists.txt
@@ -149,6 +149,7 @@ add_executable(subspace_unittests
     "mem/swap_unittest.cc"
     "mem/take_unittest.cc"
     "num/__private/literals_unittest.cc"
+    "num/cmath_macros_unittest.cc"
     "num/f32_unittest.cc"
     "num/f64_unittest.cc"
     "num/i8_unittest.cc"

--- a/subspace/choice/choice_unittest.cc
+++ b/subspace/choice/choice_unittest.cc
@@ -445,7 +445,7 @@ TEST(Choice, PartialOrder) {
   EXPECT_EQ(std::partial_order(u1, u2), std::partial_ordering::less);
 
   // NaN is unordered.
-  auto u3 = ChoiceFloatFloat::with<Order::First>(f32::TODO_NAN);
+  auto u3 = ChoiceFloatFloat::with<Order::First>(f32::NAN);
   EXPECT_EQ(std::partial_order(u1, u3), std::partial_ordering::unordered);
 
   // 0 == -0.

--- a/subspace/num/__private/intrinsics.h
+++ b/subspace/num/__private/intrinsics.h
@@ -1209,7 +1209,7 @@ sus_always_inline constexpr T nan() noexcept {
 template <class T>
   requires(std::is_floating_point_v<T>)
 sus_always_inline constexpr T infinity() noexcept {
-  // SAFETY: The value being constructed is non a NaN so we can do this in a
+  // SAFETY: The value being constructed is not a NaN so we can do this in a
   // constexpr way.
   if constexpr (::sus::mem::size_of<T>() == ::sus::mem::size_of<float>())
     return into_float_constexpr(::sus::marker::unsafe_fn, uint32_t{0x7f800000});

--- a/subspace/num/cmath_macros.h
+++ b/subspace/num/cmath_macros.h
@@ -1,0 +1,37 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+// By including math.h (and cmath) and then #undef-ing NAN and INFINITY, we
+// prevent these macros from polluting the symbol namespace, which would
+// conflict with constants in f32 and f64. We provide alternative STD_NAN and
+// STD_INFINITY macros that provide NaN and Infinity float values.
+//
+// A codebase in migration to subspace would use STD_NAN in place of NAN and
+// STD_INFINITY in place of INFINITY, or could move to using the constants in
+// std::numeric_limits<float>.
+#include <math.h>
+
+#include <cmath>
+
+#undef NAN
+#undef INFINITY
+
+#include "subspace/num/__private/intrinsics.h"
+
+/// A macro that replaces the NAN macro from <cmath>.
+#define STD_NAN ::sus::num::__private::nan<float>()
+/// A macro that replaces the INFINITY macro from <cmath>.
+#define STD_INFINITY ::sus::num::__private::infinity<float>()

--- a/subspace/num/cmath_macros_unittest.cc
+++ b/subspace/num/cmath_macros_unittest.cc
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+
+#include "googletest/include/gtest/gtest.h"
+#include "subspace/num/float.h"
+
+TEST(CMathMacros, Nan) {
+  // The NAN macro conflicts with a constant name. So we redefine it as STD_NAN.
+  constexpr auto nan = STD_NAN;  // Must be a constant expression.
+  EXPECT_TRUE(std::isnan(nan));  // constexpr in C++23.
+}
+
+TEST(CMathMacros, Inf) {
+  // The INFINITY macro conflicts with a constant name. So we redefine it as
+  // STD_INFINITY.
+  constexpr auto inf = STD_INFINITY;  // Must be a constant expression.
+  EXPECT_TRUE(std::isinf(inf));       // constexpr in C++23.
+}

--- a/subspace/num/f32_unittest.cc
+++ b/subspace/num/f32_unittest.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <math.h>
-
 #include <bit>
 #include <limits>
 
@@ -73,7 +71,7 @@ TEST(f32, Traits) {
   static_assert(!(1_f32 == 2_f32));
   static_assert(1_f32 != 2_f32);
   static_assert(!(1_f32 != 1_f32));
-  EXPECT_NE(f32::TODO_NAN, f32::TODO_NAN);
+  EXPECT_NE(f32::NAN, f32::NAN);
 
   // Verify constexpr.
   constexpr f32 c = 1_f32 + 2_f32 - 3_f32 * 4_f32 / 5_f32 % 6_f32;
@@ -109,9 +107,9 @@ TEST(f32, Consts) {
   EXPECT_EQ(f32::MAX_EXP, 128_i32);
   EXPECT_EQ(f32::MIN_10_EXP, -37_i32);
   EXPECT_EQ(f32::MAX_10_EXP, 38_i32);
-  EXPECT_TRUE(::isnan(f32::TODO_NAN.primitive_value));
-  EXPECT_TRUE(::isinf(f32::TODO_INFINITY.primitive_value));
-  EXPECT_GT(f32::TODO_INFINITY, 0_f32);
+  EXPECT_TRUE(::isnan(f32::NAN.primitive_value));
+  EXPECT_TRUE(::isinf(f32::INFINITY.primitive_value));
+  EXPECT_GT(f32::INFINITY, 0_f32);
   EXPECT_TRUE(::isinf(f32::NEG_INFINITY.primitive_value));
   EXPECT_LT(f32::NEG_INFINITY, 0_f32);
 
@@ -309,7 +307,7 @@ TEST(f32, TotalCmp) {
   EXPECT_FALSE(sus::num::__private::float_is_nan_quiet(
       neg_signaling_nan2.primitive_value));
 
-  const auto inf = f32::TODO_INFINITY;
+  const auto inf = f32::INFINITY;
   const auto neg_inf = f32::NEG_INFINITY;
   EXPECT_EQ(::fpclassify(inf.primitive_value), FP_INFINITE);
   EXPECT_EQ(::fpclassify(neg_inf.primitive_value), FP_INFINITE);
@@ -621,10 +619,10 @@ TEST(f32, Copysign) {
   EXPECT_EQ(a, 0.456_f32);
   auto b = (0.456_f32).copysign(-1_f32);
   EXPECT_EQ(b, -0.456_f32);
-  auto c = f32::TODO_NAN.copysign(-1_f32);
+  auto c = f32::NAN.copysign(-1_f32);
   EXPECT_TRUE(::isnan(c.primitive_value));    // TODO: is_nan()
   EXPECT_TRUE(::signbit(c.primitive_value));  // TODO: is_positive()
-  auto d = f32::TODO_NAN.copysign(1_f32);
+  auto d = f32::NAN.copysign(1_f32);
   EXPECT_TRUE(::isnan(d.primitive_value));     // TODO: is_nan()
   EXPECT_TRUE(!::signbit(d.primitive_value));  // TODO: is_positive()
 }
@@ -712,9 +710,9 @@ TEST(f32, Max) {
   EXPECT_EQ(a, 0.456_f32);
   auto b = (0.456_f32).max(0.457_f32);
   EXPECT_EQ(b, 0.457_f32);
-  auto c = f32::TODO_NAN.max(0.457_f32);
+  auto c = f32::NAN.max(0.457_f32);
   EXPECT_EQ(c, 0.457_f32);
-  auto d = (0.456_f32).max(f32::TODO_NAN);
+  auto d = (0.456_f32).max(f32::NAN);
   EXPECT_EQ(d, 0.456_f32);
 }
 
@@ -723,9 +721,9 @@ TEST(f32, Min) {
   EXPECT_EQ(a, -0.456_f32);
   auto b = (0.456_f32).min(0.457_f32);
   EXPECT_EQ(b, 0.456_f32);
-  auto c = f32::TODO_NAN.min(0.457_f32);
+  auto c = f32::NAN.min(0.457_f32);
   EXPECT_EQ(c, 0.457_f32);
-  auto d = (0.456_f32).min(f32::TODO_NAN);
+  auto d = (0.456_f32).min(f32::NAN);
   EXPECT_EQ(d, 0.456_f32);
 }
 
@@ -747,7 +745,7 @@ TEST(f32, Powi) {
 TEST(f32, Recip) {
   auto a = (0.456_f32).recip();
   F32_NEAR(a, 2.19298245614_f32, 0.00001_f32);
-  auto b = f32::TODO_NAN.recip();
+  auto b = f32::NAN.recip();
   EXPECT_TRUE(::isnan(b.primitive_value));  // TODO: is_nan()
 }
 
@@ -767,10 +765,10 @@ TEST(f32, Signum) {
   EXPECT_EQ((-0_f32).signum(), -1_f32);
   EXPECT_EQ((123_f32).signum(), 1_f32);
   EXPECT_EQ((-123_f32).signum(), -1_f32);
-  EXPECT_EQ(f32::TODO_INFINITY.signum(), 1_f32);
+  EXPECT_EQ(f32::INFINITY.signum(), 1_f32);
   EXPECT_EQ(f32::NEG_INFINITY.signum(), -1_f32);
   EXPECT_TRUE(
-      ::isnan(f32::TODO_NAN.signum().primitive_value));  // TODO: is_nan()
+      ::isnan(f32::NAN.signum().primitive_value));  // TODO: is_nan()
 }
 
 TEST(f32, Sin) {
@@ -866,8 +864,8 @@ TEST(f32, ToBits) {
 }
 
 TEST(f32, Classify) {
-  EXPECT_EQ(f32::TODO_NAN.classify(), FpCategory::Nan);
-  EXPECT_EQ(f32::TODO_INFINITY.classify(), FpCategory::Infinite);
+  EXPECT_EQ(f32::NAN.classify(), FpCategory::Nan);
+  EXPECT_EQ(f32::INFINITY.classify(), FpCategory::Infinite);
   EXPECT_EQ(f32::NEG_INFINITY.classify(), FpCategory::Infinite);
   EXPECT_EQ((0_f32).classify(), FpCategory::Zero);
   EXPECT_EQ((-0_f32).classify(), FpCategory::Zero);
@@ -877,9 +875,9 @@ TEST(f32, Classify) {
       FpCategory::Subnormal);
   EXPECT_EQ((123_f32).classify(), FpCategory::Normal);
 
-  auto a = f32::TODO_NAN.classify();
+  auto a = f32::NAN.classify();
   EXPECT_EQ(a, FpCategory::Nan);
-  constexpr auto b = f32::TODO_INFINITY.classify();
+  constexpr auto b = f32::INFINITY.classify();
   EXPECT_EQ(b, FpCategory::Infinite);
   constexpr auto c = f32::NEG_INFINITY.classify();
   EXPECT_EQ(c, FpCategory::Infinite);
@@ -896,9 +894,9 @@ TEST(f32, Classify) {
 }
 
 TEST(f32, IsFinite) {
-  EXPECT_FALSE(f32::TODO_INFINITY.is_finite());
+  EXPECT_FALSE(f32::INFINITY.is_finite());
   EXPECT_FALSE(f32::NEG_INFINITY.is_finite());
-  EXPECT_FALSE(f32::TODO_NAN.is_finite());
+  EXPECT_FALSE(f32::NAN.is_finite());
   EXPECT_TRUE((0_f32).is_finite());
   EXPECT_TRUE((-0_f32).is_finite());
   EXPECT_TRUE(
@@ -908,9 +906,9 @@ TEST(f32, IsFinite) {
 }
 
 TEST(f32, IsInfinite) {
-  EXPECT_TRUE(f32::TODO_INFINITY.is_infinite());
+  EXPECT_TRUE(f32::INFINITY.is_infinite());
   EXPECT_TRUE(f32::NEG_INFINITY.is_infinite());
-  EXPECT_FALSE(f32::TODO_NAN.is_infinite());
+  EXPECT_FALSE(f32::NAN.is_infinite());
   EXPECT_FALSE((0_f32).is_infinite());
   EXPECT_FALSE((-0_f32).is_infinite());
   EXPECT_FALSE(
@@ -920,9 +918,9 @@ TEST(f32, IsInfinite) {
 }
 
 TEST(f32, IsNan) {
-  EXPECT_FALSE(f32::TODO_INFINITY.is_nan());
+  EXPECT_FALSE(f32::INFINITY.is_nan());
   EXPECT_FALSE(f32::NEG_INFINITY.is_nan());
-  EXPECT_TRUE(f32::TODO_NAN.is_nan());
+  EXPECT_TRUE(f32::NAN.is_nan());
   EXPECT_FALSE((0_f32).is_nan());
   EXPECT_FALSE((-0_f32).is_nan());
   EXPECT_FALSE(
@@ -932,9 +930,9 @@ TEST(f32, IsNan) {
 }
 
 TEST(f32, IsNormal) {
-  EXPECT_FALSE(f32::TODO_INFINITY.is_normal());
+  EXPECT_FALSE(f32::INFINITY.is_normal());
   EXPECT_FALSE(f32::NEG_INFINITY.is_normal());
-  EXPECT_FALSE(f32::TODO_NAN.is_normal());
+  EXPECT_FALSE(f32::NAN.is_normal());
   EXPECT_FALSE((0_f32).is_normal());
   EXPECT_FALSE((-0_f32).is_normal());
   EXPECT_FALSE(
@@ -944,9 +942,9 @@ TEST(f32, IsNormal) {
 }
 
 TEST(f32, IsSignNegative) {
-  EXPECT_FALSE(f32::TODO_INFINITY.is_sign_negative());
+  EXPECT_FALSE(f32::INFINITY.is_sign_negative());
   EXPECT_TRUE(f32::NEG_INFINITY.is_sign_negative());
-  EXPECT_FALSE(f32::TODO_NAN.is_sign_negative());
+  EXPECT_FALSE(f32::NAN.is_sign_negative());
   EXPECT_FALSE((0_f32).is_sign_negative());
   EXPECT_TRUE((-0_f32).is_sign_negative());
   EXPECT_FALSE(
@@ -960,9 +958,9 @@ TEST(f32, IsSignNegative) {
 }
 
 TEST(f32, IsSignPositive) {
-  EXPECT_TRUE(f32::TODO_INFINITY.is_sign_positive());
+  EXPECT_TRUE(f32::INFINITY.is_sign_positive());
   EXPECT_FALSE(f32::NEG_INFINITY.is_sign_positive());
-  EXPECT_TRUE(f32::TODO_NAN.is_sign_positive());
+  EXPECT_TRUE(f32::NAN.is_sign_positive());
   EXPECT_TRUE((0_f32).is_sign_positive());
   EXPECT_FALSE((-0_f32).is_sign_positive());
   EXPECT_TRUE(
@@ -976,9 +974,9 @@ TEST(f32, IsSignPositive) {
 }
 
 TEST(f32, IsSubnormal) {
-  EXPECT_FALSE(f32::TODO_INFINITY.is_subnormal());
+  EXPECT_FALSE(f32::INFINITY.is_subnormal());
   EXPECT_FALSE(f32::NEG_INFINITY.is_subnormal());
-  EXPECT_FALSE(f32::TODO_NAN.is_subnormal());
+  EXPECT_FALSE(f32::NAN.is_subnormal());
   EXPECT_FALSE((0_f32).is_subnormal());
   EXPECT_FALSE((-0_f32).is_subnormal());
   EXPECT_TRUE(
@@ -991,7 +989,7 @@ TEST(f32, Clamp) {
   EXPECT_TRUE((-3.0_f32).clamp(-2.0_f32, 1.0_f32) == -2.0_f32);
   EXPECT_TRUE((0.0_f32).clamp(-2.0_f32, 1.0_f32) == 0.0_f32);
   EXPECT_TRUE((2.0_f32).clamp(-2.0_f32, 1.0_f32) == 1.0_f32);
-  EXPECT_TRUE((f32::TODO_NAN).clamp(-2.0_f32, 1.0_f32).is_nan());
+  EXPECT_TRUE((f32::NAN).clamp(-2.0_f32, 1.0_f32).is_nan());
 }
 
 TEST(f32, DivEuclid) {

--- a/subspace/num/f64_unittest.cc
+++ b/subspace/num/f64_unittest.cc
@@ -64,7 +64,7 @@ TEST(f64, Traits) {
   static_assert(!(1_f64 == 2_f64));
   static_assert(1_f64 != 2_f64);
   static_assert(!(1_f64 != 1_f64));
-  EXPECT_NE(f64::TODO_NAN, f64::TODO_NAN);
+  EXPECT_NE(f64::NAN, f64::NAN);
 
   // Verify constexpr.
   constexpr f64 c = 1_f64 + 2_f64 - 3_f64 * 4_f64 / 5_f64 % 6_f64;
@@ -100,9 +100,9 @@ TEST(f64, Consts) {
   EXPECT_EQ(f64::MAX_EXP, 1024_i32);
   EXPECT_EQ(f64::MIN_10_EXP, -307_i32);
   EXPECT_EQ(f64::MAX_10_EXP, 308_i32);
-  EXPECT_TRUE(isnan(f64::TODO_NAN.primitive_value));
-  EXPECT_TRUE(isinf(f64::TODO_INFINITY.primitive_value));
-  EXPECT_GT(f64::TODO_INFINITY, 0_f64);
+  EXPECT_TRUE(isnan(f64::NAN.primitive_value));
+  EXPECT_TRUE(isinf(f64::INFINITY.primitive_value));
+  EXPECT_GT(f64::INFINITY, 0_f64);
   EXPECT_TRUE(isinf(f64::NEG_INFINITY.primitive_value));
   EXPECT_LT(f64::NEG_INFINITY, 0_f64);
 
@@ -304,7 +304,7 @@ TEST(f64, TotalCmp) {
   EXPECT_FALSE(sus::num::__private::float_is_nan_quiet(
       neg_signaling_nan2.primitive_value));
 
-  const auto inf = f64::TODO_INFINITY;
+  const auto inf = f64::INFINITY;
   const auto neg_inf = f64::NEG_INFINITY;
   EXPECT_EQ(::fpclassify(inf.primitive_value), FP_INFINITE);
   EXPECT_EQ(::fpclassify(neg_inf.primitive_value), FP_INFINITE);
@@ -616,10 +616,10 @@ TEST(f64, Copysign) {
   EXPECT_EQ(a, 0.456_f64);
   auto b = (0.456_f64).copysign(-1_f64);
   EXPECT_EQ(b, -0.456_f64);
-  auto c = f64::TODO_NAN.copysign(-1_f64);
+  auto c = f64::NAN.copysign(-1_f64);
   EXPECT_TRUE(::isnan(c.primitive_value));    // TODO: is_nan()
   EXPECT_TRUE(::signbit(c.primitive_value));  // TODO: is_positive()
-  auto d = f64::TODO_NAN.copysign(1_f64);
+  auto d = f64::NAN.copysign(1_f64);
   EXPECT_TRUE(::isnan(d.primitive_value));     // TODO: is_nan()
   EXPECT_TRUE(!::signbit(d.primitive_value));  // TODO: is_positive()
 }
@@ -707,9 +707,9 @@ TEST(f64, Max) {
   EXPECT_EQ(a, 0.456_f64);
   auto b = (0.456_f64).max(0.457_f64);
   EXPECT_EQ(b, 0.457_f64);
-  auto c = f64::TODO_NAN.max(0.457_f64);
+  auto c = f64::NAN.max(0.457_f64);
   EXPECT_EQ(c, 0.457_f64);
-  auto d = (0.456_f64).max(f64::TODO_NAN);
+  auto d = (0.456_f64).max(f64::NAN);
   EXPECT_EQ(d, 0.456_f64);
 }
 
@@ -718,9 +718,9 @@ TEST(f64, Min) {
   EXPECT_EQ(a, -0.456_f64);
   auto b = (0.456_f64).min(0.457_f64);
   EXPECT_EQ(b, 0.456_f64);
-  auto c = f64::TODO_NAN.min(0.457_f64);
+  auto c = f64::NAN.min(0.457_f64);
   EXPECT_EQ(c, 0.457_f64);
-  auto d = (0.456_f64).min(f64::TODO_NAN);
+  auto d = (0.456_f64).min(f64::NAN);
   EXPECT_EQ(d, 0.456_f64);
 }
 
@@ -742,7 +742,7 @@ TEST(f64, Powi) {
 TEST(f64, Recip) {
   auto a = (0.456_f64).recip();
   F64_NEAR(a, 2.19298245614_f64, 0.0000001_f64);
-  auto b = f64::TODO_NAN.recip();
+  auto b = f64::NAN.recip();
   EXPECT_TRUE(::isnan(b.primitive_value));  // TODO: is_nan()
 }
 
@@ -762,10 +762,9 @@ TEST(f64, Signum) {
   EXPECT_EQ((-0_f64).signum(), -1_f64);
   EXPECT_EQ((123_f64).signum(), 1_f64);
   EXPECT_EQ((-123_f64).signum(), -1_f64);
-  EXPECT_EQ(f64::TODO_INFINITY.signum(), 1_f64);
+  EXPECT_EQ(f64::INFINITY.signum(), 1_f64);
   EXPECT_EQ(f64::NEG_INFINITY.signum(), -1_f64);
-  EXPECT_TRUE(
-      ::isnan(f64::TODO_NAN.signum().primitive_value));  // TODO: is_nan()
+  EXPECT_TRUE(::isnan(f64::NAN.signum().primitive_value));  // TODO: is_nan()
 }
 
 TEST(f64, Sin) {
@@ -861,8 +860,8 @@ TEST(f64, ToBits) {
 }
 
 TEST(f64, Classify) {
-  EXPECT_EQ(f64::TODO_NAN.classify(), FpCategory::Nan);
-  EXPECT_EQ(f64::TODO_INFINITY.classify(), FpCategory::Infinite);
+  EXPECT_EQ(f64::NAN.classify(), FpCategory::Nan);
+  EXPECT_EQ(f64::INFINITY.classify(), FpCategory::Infinite);
   EXPECT_EQ(f64::NEG_INFINITY.classify(), FpCategory::Infinite);
   EXPECT_EQ((0_f64).classify(), FpCategory::Zero);
   EXPECT_EQ((-0_f64).classify(), FpCategory::Zero);
@@ -872,9 +871,9 @@ TEST(f64, Classify) {
       FpCategory::Subnormal);
   EXPECT_EQ((123_f64).classify(), FpCategory::Normal);
 
-  auto a = f64::TODO_NAN.classify();
+  auto a = f64::NAN.classify();
   EXPECT_EQ(a, FpCategory::Nan);
-  constexpr auto b = f64::TODO_INFINITY.classify();
+  constexpr auto b = f64::INFINITY.classify();
   EXPECT_EQ(b, FpCategory::Infinite);
   constexpr auto c = f64::NEG_INFINITY.classify();
   EXPECT_EQ(c, FpCategory::Infinite);
@@ -891,9 +890,9 @@ TEST(f64, Classify) {
 }
 
 TEST(f64, IsFinite) {
-  EXPECT_FALSE(f64::TODO_INFINITY.is_finite());
+  EXPECT_FALSE(f64::INFINITY.is_finite());
   EXPECT_FALSE(f64::NEG_INFINITY.is_finite());
-  EXPECT_FALSE(f64::TODO_NAN.is_finite());
+  EXPECT_FALSE(f64::NAN.is_finite());
   EXPECT_TRUE((0_f64).is_finite());
   EXPECT_TRUE((-0_f64).is_finite());
   EXPECT_TRUE(
@@ -903,9 +902,9 @@ TEST(f64, IsFinite) {
 }
 
 TEST(f64, IsInfinite) {
-  EXPECT_TRUE(f64::TODO_INFINITY.is_infinite());
+  EXPECT_TRUE(f64::INFINITY.is_infinite());
   EXPECT_TRUE(f64::NEG_INFINITY.is_infinite());
-  EXPECT_FALSE(f64::TODO_NAN.is_infinite());
+  EXPECT_FALSE(f64::NAN.is_infinite());
   EXPECT_FALSE((0_f64).is_infinite());
   EXPECT_FALSE((-0_f64).is_infinite());
   EXPECT_FALSE(
@@ -915,9 +914,9 @@ TEST(f64, IsInfinite) {
 }
 
 TEST(f64, IsNan) {
-  EXPECT_FALSE(f64::TODO_INFINITY.is_nan());
+  EXPECT_FALSE(f64::INFINITY.is_nan());
   EXPECT_FALSE(f64::NEG_INFINITY.is_nan());
-  EXPECT_TRUE(f64::TODO_NAN.is_nan());
+  EXPECT_TRUE(f64::NAN.is_nan());
   EXPECT_FALSE((0_f64).is_nan());
   EXPECT_FALSE((-0_f64).is_nan());
   EXPECT_FALSE(
@@ -927,9 +926,9 @@ TEST(f64, IsNan) {
 }
 
 TEST(f64, IsNormal) {
-  EXPECT_FALSE(f64::TODO_INFINITY.is_normal());
+  EXPECT_FALSE(f64::INFINITY.is_normal());
   EXPECT_FALSE(f64::NEG_INFINITY.is_normal());
-  EXPECT_FALSE(f64::TODO_NAN.is_normal());
+  EXPECT_FALSE(f64::NAN.is_normal());
   EXPECT_FALSE((0_f64).is_normal());
   EXPECT_FALSE((-0_f64).is_normal());
   EXPECT_FALSE(
@@ -939,9 +938,9 @@ TEST(f64, IsNormal) {
 }
 
 TEST(f64, IsSignNegative) {
-  EXPECT_FALSE(f64::TODO_INFINITY.is_sign_negative());
+  EXPECT_FALSE(f64::INFINITY.is_sign_negative());
   EXPECT_TRUE(f64::NEG_INFINITY.is_sign_negative());
-  EXPECT_FALSE(f64::TODO_NAN.is_sign_negative());
+  EXPECT_FALSE(f64::NAN.is_sign_negative());
   EXPECT_FALSE((0_f64).is_sign_negative());
   EXPECT_TRUE((-0_f64).is_sign_negative());
   EXPECT_FALSE(
@@ -955,9 +954,9 @@ TEST(f64, IsSignNegative) {
 }
 
 TEST(f64, IsSignPositive) {
-  EXPECT_TRUE(f64::TODO_INFINITY.is_sign_positive());
+  EXPECT_TRUE(f64::INFINITY.is_sign_positive());
   EXPECT_FALSE(f64::NEG_INFINITY.is_sign_positive());
-  EXPECT_TRUE(f64::TODO_NAN.is_sign_positive());
+  EXPECT_TRUE(f64::NAN.is_sign_positive());
   EXPECT_TRUE((0_f64).is_sign_positive());
   EXPECT_FALSE((-0_f64).is_sign_positive());
   EXPECT_TRUE(
@@ -971,9 +970,9 @@ TEST(f64, IsSignPositive) {
 }
 
 TEST(f64, IsSubnormal) {
-  EXPECT_FALSE(f64::TODO_INFINITY.is_subnormal());
+  EXPECT_FALSE(f64::INFINITY.is_subnormal());
   EXPECT_FALSE(f64::NEG_INFINITY.is_subnormal());
-  EXPECT_FALSE(f64::TODO_NAN.is_subnormal());
+  EXPECT_FALSE(f64::NAN.is_subnormal());
   EXPECT_FALSE((0_f64).is_subnormal());
   EXPECT_FALSE((-0_f64).is_subnormal());
   EXPECT_TRUE(
@@ -986,7 +985,7 @@ TEST(f64, Clamp) {
   EXPECT_TRUE((-3.0_f64).clamp(-2.0_f64, 1.0_f64) == -2.0_f64);
   EXPECT_TRUE((0.0_f64).clamp(-2.0_f64, 1.0_f64) == 0.0_f64);
   EXPECT_TRUE((2.0_f64).clamp(-2.0_f64, 1.0_f64) == 1.0_f64);
-  EXPECT_TRUE((f64::TODO_NAN).clamp(-2.0_f64, 1.0_f64).is_nan());
+  EXPECT_TRUE((f64::NAN).clamp(-2.0_f64, 1.0_f64).is_nan());
 }
 
 TEST(f64, DivEuclid) {

--- a/subspace/option/option_unittest.cc
+++ b/subspace/option/option_unittest.cc
@@ -1606,7 +1606,7 @@ TEST(Option, Eq) {
   EXPECT_EQ(Option<int>::none(), Option<int>::none());
   EXPECT_EQ(Option<f32>::some(1.f), Option<f32>::some(1.f));
   EXPECT_EQ(Option<f32>::some(0.f), Option<f32>::some(-0.f));
-  EXPECT_NE(Option<f32>::some(f32::TODO_NAN), Option<f32>::some(f32::TODO_NAN));
+  EXPECT_NE(Option<f32>::some(f32::NAN), Option<f32>::some(f32::NAN));
 }
 
 TEST(Option, Ord) {
@@ -1675,13 +1675,13 @@ TEST(Option, PartialOrder) {
       std::partial_order(Option<float>::some(11.f), Option<float>::some(12.f)),
       std::partial_ordering::less);
   EXPECT_EQ(std::partial_order(Option<f32>::some(11.f),
-                               Option<f32>::some(f32::TODO_NAN)),
+                               Option<f32>::some(f32::NAN)),
             std::partial_ordering::unordered);
-  EXPECT_EQ(std::partial_order(Option<f32>::some(f32::TODO_NAN),
-                               Option<f32>::some(f32::TODO_NAN)),
+  EXPECT_EQ(std::partial_order(Option<f32>::some(f32::NAN),
+                               Option<f32>::some(f32::NAN)),
             std::partial_ordering::unordered);
   EXPECT_EQ(std::partial_order(Option<f32>::some(0.f),
-                               Option<f32>::some(f32::TODO_INFINITY)),
+                               Option<f32>::some(f32::INFINITY)),
             std::partial_ordering::less);
   EXPECT_EQ(std::partial_order(Option<f32>::some(0.f),
                                Option<f32>::some(f32::NEG_INFINITY)),
@@ -1690,7 +1690,7 @@ TEST(Option, PartialOrder) {
   EXPECT_EQ(std::partial_order(Option<f32>::some(0.f), Option<f32>::none()),
             std::partial_ordering::greater);
   EXPECT_EQ(
-      std::partial_order(Option<f32>::none(), Option<f32>::some(f32::TODO_NAN)),
+      std::partial_order(Option<f32>::none(), Option<f32>::some(f32::NAN)),
       std::partial_ordering::less);
 }
 

--- a/subspace/tuple/tuple_unittest.cc
+++ b/subspace/tuple/tuple_unittest.cc
@@ -362,7 +362,7 @@ TEST(Tuple, Eq) {
   EXPECT_EQ(Tuple<f32>::with(1.f), Tuple<f32>::with(1.f));
   EXPECT_EQ(Tuple<f32>::with(0.f), Tuple<f32>::with(0.f));
   EXPECT_EQ(Tuple<f32>::with(0.f), Tuple<f32>::with(-0.f));
-  EXPECT_NE(Tuple<f32>::with(f32::TODO_NAN), Tuple<f32>::with(f32::TODO_NAN));
+  EXPECT_NE(Tuple<f32>::with(f32::NAN), Tuple<f32>::with(f32::NAN));
 
   auto n1 = NoCopyMove();
   auto tn1 = Tuple<NoCopyMove&>::with(mref(n1));
@@ -448,13 +448,13 @@ TEST(Tuple, PartialOrder) {
   EXPECT_EQ(std::partial_order(Tuple<f32>::with(0.f), Tuple<f32>::with(1.f)),
             std::partial_ordering::less);
   EXPECT_EQ(std::partial_order(Tuple<f32>::with(0.f),
-                               Tuple<f32>::with(f32::TODO_NAN)),
+                               Tuple<f32>::with(f32::NAN)),
             std::partial_ordering::unordered);
-  EXPECT_EQ(std::partial_order(Tuple<f32>::with(f32::TODO_NAN),
-                               Tuple<f32>::with(f32::TODO_NAN)),
+  EXPECT_EQ(std::partial_order(Tuple<f32>::with(f32::NAN),
+                               Tuple<f32>::with(f32::NAN)),
             std::partial_ordering::unordered);
   EXPECT_EQ(std::partial_order(Tuple<f32>::with(0.f),
-                               Tuple<f32>::with(f32::TODO_INFINITY)),
+                               Tuple<f32>::with(f32::INFINITY)),
             std::partial_ordering::less);
   EXPECT_EQ(std::partial_order(Tuple<f32>::with(0.f),
                                Tuple<f32>::with(f32::NEG_INFINITY)),


### PR DESCRIPTION
The NAN and INFINITY macros pollute the symbol namespace and conflict with reasonable constant names in f32 and f64. So we include the header and undef the macros, and provide constexpr alternatives as STD_NAN and STD_INFINITY.