### PR TITLE
Combine relocate_array_by_memcpy and relocate_one_by_memcpy

### DIFF
--- a/subspace/containers/array.h
+++ b/subspace/containers/array.h
@@ -337,8 +337,7 @@ class Array final {
 
   sus_class_trivial_relocatable_value(
       ::sus::marker::unsafe_fn,
-      (N >= 2 && ::sus::mem::relocate_array_by_memcpy<T>) ||
-          (N == 1 && ::sus::mem::relocate_one_by_memcpy<T>) || N == 0);
+      N == 0 || ::sus::mem::relocate_by_memcpy<T>);
 };
 
 namespace __private {

--- a/subspace/containers/array_unittest.cc
+++ b/subspace/containers/array_unittest.cc
@@ -26,8 +26,7 @@
 #include "subspace/prelude.h"
 
 using ::sus::containers::Array;
-using ::sus::mem::relocate_array_by_memcpy;
-using ::sus::mem::relocate_one_by_memcpy;
+using ::sus::mem::relocate_by_memcpy;
 
 namespace {
 
@@ -59,8 +58,7 @@ static_assert(!std::is_assignable_v<Array<T, 2>, const T&>);
 static_assert(!std::is_constructible_v<Array<T, 2>, T>);
 static_assert(!std::is_assignable_v<Array<T, 2>, T>);
 static_assert(std::is_nothrow_destructible_v<Array<T, 2>>);
-static_assert(relocate_one_by_memcpy<Array<T, 2>>);
-static_assert(relocate_array_by_memcpy<Array<T, 2>>);
+static_assert(relocate_by_memcpy<Array<T, 2>>);
 }  // namespace trivially_relocatable
 
 struct NonAggregate {

--- a/subspace/containers/vec.h
+++ b/subspace/containers/vec.h
@@ -189,7 +189,7 @@ class Vec {
     if (!is_alloced()) {
       storage_ = static_cast<char*>(malloc(bytes.primitive_value));
     } else {
-      if constexpr (::sus::mem::relocate_array_by_memcpy<T>) {
+      if constexpr (::sus::mem::relocate_by_memcpy<T>) {
         storage_ = static_cast<char*>(realloc(storage_, bytes.primitive_value));
       } else {
         auto* const new_storage =
@@ -410,7 +410,7 @@ class Vec {
 
   sus_class_never_value_field(::sus::marker::unsafe_fn, Vec, storage_, nullptr);
   sus_class_trivial_relocatable_value(::sus::marker::unsafe_fn,
-                                      sus::mem::relocate_array_by_memcpy<T>);
+                                      sus::mem::relocate_by_memcpy<T>);
 };
 
 /// Used to construct a Vec<T> with the parameters as its values.

--- a/subspace/fn/fn_unittest.cc
+++ b/subspace/fn/fn_unittest.cc
@@ -92,9 +92,9 @@ static_assert(std::is_move_constructible_v<Fn<void()>>);
 static_assert(std::is_move_assignable_v<Fn<void()>>);
 
 // Closures are trivially relocatable.
-static_assert(sus::mem::relocate_one_by_memcpy<FnOnce<void()>>);
-static_assert(sus::mem::relocate_one_by_memcpy<FnMut<void()>>);
-static_assert(sus::mem::relocate_one_by_memcpy<Fn<void()>>);
+static_assert(sus::mem::relocate_by_memcpy<FnOnce<void()>>);
+static_assert(sus::mem::relocate_by_memcpy<FnMut<void()>>);
+static_assert(sus::mem::relocate_by_memcpy<Fn<void()>>);
 
 // A function pointer, or convertible lambda, can be bound to FnOnce, FnMut and Fn.
 static_assert(std::is_constructible_v<FnOnce<void()>, decltype([](){})>);

--- a/subspace/iter/boxed_iterator.h
+++ b/subspace/iter/boxed_iterator.h
@@ -63,7 +63,7 @@ template <::sus::mem::Move IteratorSubclass, int&...,
 inline BoxedIteratorType make_boxed_iterator(IteratorSubclass&& subclass)
   requires(::sus::convert::SameOrSubclassOf<IteratorSubclass*,
                                             IteratorBase<SubclassItem>*> &&
-           !::sus::mem::relocate_one_by_memcpy<IteratorSubclass>)
+           !::sus::mem::relocate_by_memcpy<IteratorSubclass>)
 {
   return BoxedIteratorType(*new IteratorSubclass(::sus::move(subclass)),
                            [](IteratorBase<SubclassItem>& iter) {

--- a/subspace/iter/filter.h
+++ b/subspace/iter/filter.h
@@ -23,7 +23,7 @@
 namespace sus::iter {
 
 using ::sus::iter::IteratorBase;
-using ::sus::mem::relocate_one_by_memcpy;
+using ::sus::mem::relocate_by_memcpy;
 
 template <class Item, size_t InnerIterSize, size_t InnerIterAlign>
 class Filter : public IteratorBase<Item> {

--- a/subspace/iter/iterator_defn.h
+++ b/subspace/iter/iterator_defn.h
@@ -138,7 +138,7 @@ class [[nodiscard]] Iterator final : public I {
   Iterator<
       BoxedIterator<typename I::Item, ::sus::mem::size_of<I>(), alignof(I)>>
   box() && noexcept
-    requires(!::sus::mem::relocate_one_by_memcpy<I>);
+    requires(!::sus::mem::relocate_by_memcpy<I>);
 
   /// Tests whether all elements of the iterator match a predicate.
   ///
@@ -182,7 +182,7 @@ class [[nodiscard]] Iterator final : public I {
   Iterator<Filter<Item, ::sus::mem::size_of<I>(), alignof(I)>> filter(
       ::sus::fn::FnMut<bool(const std::remove_reference_t<Item>&)>
           pred) && noexcept
-    requires(::sus::mem::relocate_one_by_memcpy<I>);
+    requires(::sus::mem::relocate_by_memcpy<I>);
 
   /// Transforms an iterator into a collection.
   ///
@@ -257,7 +257,7 @@ template <class I>
 template <class I>
 Iterator<BoxedIterator<typename I::Item, ::sus::mem::size_of<I>(), alignof(I)>>
 Iterator<I>::box() && noexcept
-  requires(!::sus::mem::relocate_one_by_memcpy<I>)
+  requires(!::sus::mem::relocate_by_memcpy<I>)
 {
   return make_boxed_iterator(::sus::move(*this));
 }
@@ -267,7 +267,7 @@ Iterator<Filter<typename I::Item, ::sus::mem::size_of<I>(), alignof(I)>>
 Iterator<I>::filter(
     ::sus::fn::FnMut<bool(const std::remove_reference_t<typename I::Item>&)>
         pred) && noexcept
-  requires(::sus::mem::relocate_one_by_memcpy<I>)
+  requires(::sus::mem::relocate_by_memcpy<I>)
 {
   // TODO: make_sized_iterator immediately copies `this` to either the body of
   // the output iterator or to a heap allocation (if it can't be trivially

--- a/subspace/iter/iterator_unittest.cc
+++ b/subspace/iter/iterator_unittest.cc
@@ -217,7 +217,7 @@ struct Filtering {
   ~Filtering() {}
   int i;
 };
-static_assert(!::sus::mem::relocate_one_by_memcpy<Filtering>);
+static_assert(!::sus::mem::relocate_by_memcpy<Filtering>);
 
 TEST(Iterator, FilterNonTriviallyRelocatable) {
   Filtering nums[5] = {Filtering(1), Filtering(2), Filtering(3), Filtering(4),
@@ -225,7 +225,7 @@ TEST(Iterator, FilterNonTriviallyRelocatable) {
 
   auto non_relocatable_it = ArrayIterator<Filtering, 5>::with_array(nums);
   static_assert(
-      !sus::mem::relocate_one_by_memcpy<decltype(non_relocatable_it)>);
+      !sus::mem::relocate_by_memcpy<decltype(non_relocatable_it)>);
 
   auto fit = sus::move(non_relocatable_it).box().filter([](const Filtering& f) {
     return f.i >= 3;

--- a/subspace/iter/sized_iterator.h
+++ b/subspace/iter/sized_iterator.h
@@ -48,8 +48,8 @@ struct [[sus_trivial_abi]] SizedIterator final {
   // clang-format off
   sus_class_trivial_relocatable_value(
       ::sus::marker::unsafe_fn,
-      ::sus::mem::relocate_array_by_memcpy<char> &&
-      ::sus::mem::relocate_one_by_memcpy<decltype(destroy)>);
+      ::sus::mem::relocate_by_memcpy<decltype(sized)> &&
+      ::sus::mem::relocate_by_memcpy<decltype(destroy)>);
   // clang-format on
 };
 
@@ -66,7 +66,7 @@ template <::sus::mem::Move IteratorSubclass, int&...,
 inline SizedIteratorType make_sized_iterator(IteratorSubclass&& subclass)
   requires(::sus::convert::SameOrSubclassOf<IteratorSubclass*,
                                             IteratorBase<SubclassItem>*> &&
-           ::sus::mem::relocate_one_by_memcpy<IteratorSubclass>)
+           ::sus::mem::relocate_by_memcpy<IteratorSubclass>)
 {
   auto it = SizedIteratorType([](char& sized) {
     reinterpret_cast<IteratorSubclass&>(sized).~IteratorSubclass();

--- a/subspace/mem/__private/relocatable_storage.h
+++ b/subspace/mem/__private/relocatable_storage.h
@@ -26,7 +26,7 @@ template <class T>
 struct [[sus_trivial_abi]] RelocatableStorage;
 
 template <::sus::mem::Move T>
-  requires(!::sus::mem::relocate_one_by_memcpy<T>)
+  requires(!::sus::mem::relocate_by_memcpy<T>)
 struct [[sus_trivial_abi]] RelocatableStorage<T> final {
   RelocatableStorage(Option<T>&& t)
       : heap_(::sus::move(t).and_then([](T&& t) {
@@ -70,7 +70,7 @@ struct [[sus_trivial_abi]] RelocatableStorage<T> final {
 };
 
 template <class T>
-  requires(::sus::mem::relocate_one_by_memcpy<T>)
+  requires(::sus::mem::relocate_by_memcpy<T>)
 struct [[sus_trivial_abi]] RelocatableStorage<T> final {
   RelocatableStorage(Option<T>&& t) : stack_(::sus::move(t)) {}
 

--- a/subspace/mem/nonnull_types_unittest.cc
+++ b/subspace/mem/nonnull_types_unittest.cc
@@ -19,8 +19,7 @@
 
 using sus::construct::Default;
 using sus::mem::NonNull;
-using sus::mem::relocate_array_by_memcpy;
-using sus::mem::relocate_one_by_memcpy;
+using sus::mem::relocate_by_memcpy;
 
 namespace default_constructible {
 using T = NonNull<sus::test::DefaultConstructible>;
@@ -48,8 +47,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace default_constructible
 
 namespace not_default_constructible {
@@ -78,8 +76,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace not_default_constructible
 
 namespace trivially_copyable {
@@ -107,8 +104,7 @@ static_assert(std::is_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivially_copyable
 
 namespace trivially_moveable_and_relocatable {
@@ -137,8 +133,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_and_relocatable
 
 namespace trivially_copyable_not_destructible {
@@ -167,8 +162,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivially_copyable_not_destructible
 
 namespace trivially_moveable_not_destructible {
@@ -197,8 +191,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_not_destructible
 
 namespace not_trivially_relocatable_copyable_or_moveable {
@@ -227,8 +220,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace not_trivially_relocatable_copyable_or_moveable
 
 namespace trivial_abi_relocatable {
@@ -257,6 +249,5 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivial_abi_relocatable

--- a/subspace/mem/nonnull_unittest.cc
+++ b/subspace/mem/nonnull_unittest.cc
@@ -28,8 +28,7 @@
 
 using sus::mem::NonNull;
 
-static_assert(sus::mem::relocate_one_by_memcpy<NonNull<int>>);
-static_assert(sus::mem::relocate_array_by_memcpy<NonNull<int>>);
+static_assert(sus::mem::relocate_by_memcpy<NonNull<int>>);
 
 static_assert(sus::mem::NeverValueField<NonNull<int>>);
 static_assert(sizeof(sus::Option<NonNull<int>>) == sizeof(int*));

--- a/subspace/mem/relocate.h
+++ b/subspace/mem/relocate.h
@@ -53,20 +53,25 @@ struct relocatable_tag final {
 /// - You must memcpy without including the padding bytes (i.e.
 ///   `data_size_of<T>()` bytes).
 ///
+/// Volatile types are excluded, as they can not be safely memcpy()'d
+/// byte-by-byte without introducing tearing.
+///
+/// Tests against `std::remove_all_extents_t<T>` so that the same answer is
+/// returned for `T` or `T[]` or `T[][][]` etc.
 //
 // clang-format off
 template <class... T>
-struct relocate_one_by_memcpy_helper final
+struct relocate_by_memcpy_helper final
     : public std::integral_constant<
         bool,
         (... &&
-         (sus::mem::data_size_of<T>()
-          && (relocatable_tag<T>::value(0)
+         (!std::is_volatile_v<std::remove_all_extents_t<T>>
+          && sus::mem::data_size_of<std::remove_all_extents_t<T>>()
+          && (relocatable_tag<std::remove_all_extents_t<T>>::value(0)
+              || (std::is_trivially_move_constructible_v<std::remove_all_extents_t<T>> &&
+                  std::is_trivially_destructible_v<std::remove_all_extents_t<T>>)
 #if __has_extension(trivially_relocatable)
-              || __is_trivially_relocatable(T)
-#else
-              || (std::is_trivially_move_constructible_v<T> &&
-                  std::is_trivially_destructible_v<T>)
+              || __is_trivially_relocatable(std::remove_all_extents_t<T>)
 #endif
              )
          )
@@ -74,47 +79,11 @@ struct relocate_one_by_memcpy_helper final
       > {};
 // clang-format on
 
-/// Tests if an array of type T[] can be relocated with memcpy(). Checking for
-/// trivially movable and destructible is not sufficient - this also honors the
-/// [[trivial_abi]] clang attribute, as types annotated with the attribute are
-/// now considered "trivially relocatable" in https://reviews.llvm.org/D114732.
-///
-/// Tests against `std::remove_all_extents_t<T>` so that the same answer is
-/// returned for `T` or `T[]` or `T[][][]` etc.
-///
-/// Volatile types are excluded, since if we have a range of volatile Foo, then
-/// the user is probably expecting us to follow the abstract machine and copy
-/// the Foo objects one by one, instead of byte-by-byte (possible tearing). See:
-/// https://reviews.llvm.org/D61761?id=198907#inline-548830
-//
-// clang-format off
-template <class T>
-struct relocate_array_by_memcpy_helper final
-    : public std::integral_constant<
-        bool,
-        sus::mem::data_size_of<T>() &&
-        (relocatable_tag<T>::value(0)
-
-#if __has_extension(trivially_relocatable)
-         || __is_trivially_relocatable(std::remove_all_extents_t<T>)
-#else
-         || (std::is_trivially_move_constructible_v<std::remove_all_extents_t<T>>
-             && std::is_trivially_destructible_v<std::remove_all_extents_t<T>>)
-#endif
-        )
-        && !std::is_volatile_v<std::remove_all_extents_t<T>>
-      > {};
-// clang-format on
-
 }  // namespace __private
 
-template <class T>
-concept relocate_array_by_memcpy =
-    __private::relocate_array_by_memcpy_helper<T>::value;
-
 template <class... T>
-concept relocate_one_by_memcpy =
-    __private::relocate_one_by_memcpy_helper<T...>::value;
+concept relocate_by_memcpy =
+    __private::relocate_by_memcpy_helper<T...>::value;
 
 }  // namespace sus::mem
 
@@ -140,17 +109,16 @@ concept relocate_one_by_memcpy =
 ///
 /// To additionally allow the class to be passed in registers, the class can be
 /// marked with the `sus_trivial_abi` attribute.
-#define sus_class_trivial_relocatable(unsafe_fn)       \
-  static_assert(std::is_same_v<decltype(unsafe_fn),    \
+#define sus_class_trivial_relocatable(unsafe_fn)                      \
+  static_assert(std::is_same_v<decltype(unsafe_fn),                   \
                                const ::sus::marker::UnsafeFnMarker>); \
   template <class SusOuterClassTypeForTriviallyReloc>                 \
   friend struct ::sus::mem::__private::relocatable_tag;               \
   static constexpr bool SusUnsafeTrivialRelocate = true
 
 /// Mark a class as trivially relocatable based on a compile-time condition.
-#define sus_class_trivial_relocatable_value(unsafe_fn,        \
-                                            is_trivially_reloc)              \
-  static_assert(std::is_same_v<decltype(unsafe_fn),           \
+#define sus_class_trivial_relocatable_value(unsafe_fn, is_trivially_reloc)   \
+  static_assert(std::is_same_v<decltype(unsafe_fn),                          \
                                const ::sus::marker::UnsafeFnMarker>);        \
   static_assert(                                                             \
       std::is_same_v<std::remove_cv_t<decltype(is_trivially_reloc)>, bool>); \
@@ -160,26 +128,23 @@ concept relocate_one_by_memcpy =
 
 /// Mark a class as trivially relocatable if all of the types passed as
 /// arguments are also marked as such.
-#define sus_class_maybe_trivial_relocatable_types(unsafe_fn, \
-                                                  ...)                      \
-  static_assert(std::is_same_v<decltype(unsafe_fn),          \
-                               const ::sus::marker::UnsafeFnMarker>);       \
-  template <class SusOuterClassTypeForTriviallyReloc>                       \
-  friend struct ::sus::mem::__private::relocatable_tag;                     \
-  static constexpr bool SusUnsafeTrivialRelocate =                          \
-      ::sus::mem::relocate_one_by_memcpy<__VA_ARGS__>
+#define sus_class_maybe_trivial_relocatable_types(unsafe_fn, ...)     \
+  static_assert(std::is_same_v<decltype(unsafe_fn),                   \
+                               const ::sus::marker::UnsafeFnMarker>); \
+  template <class SusOuterClassTypeForTriviallyReloc>                 \
+  friend struct ::sus::mem::__private::relocatable_tag;               \
+  static constexpr bool SusUnsafeTrivialRelocate =                    \
+      ::sus::mem::relocate_by_memcpy<__VA_ARGS__>
 
 /// Mark a class as unconditionally trivially relocatable while also asserting
 /// that all of the types passed as arguments are also marked as such.
 ///
 /// To additionally allow the class to be passed in registers, the class can be
 /// marked with the `sus_trivial_abi` attribute.
-#define sus_class_assert_trivial_relocatable_types(unsafe_fn, \
-                                                   ...)                      \
-  static_assert(std::is_same_v<decltype(unsafe_fn),           \
-                               const ::sus::marker::UnsafeFnMarker>);        \
-  sus_class_maybe_trivial_relocatable_types(unsafe_fn,        \
-                                            __VA_ARGS__);                    \
-  static_assert(SusUnsafeTrivialRelocate,                                    \
-                "Type is not trivially "                                     \
+#define sus_class_assert_trivial_relocatable_types(unsafe_fn, ...)    \
+  static_assert(std::is_same_v<decltype(unsafe_fn),                   \
+                               const ::sus::marker::UnsafeFnMarker>); \
+  sus_class_maybe_trivial_relocatable_types(unsafe_fn, __VA_ARGS__);  \
+  static_assert(SusUnsafeTrivialRelocate,                             \
+                "Type is not trivially "                              \
                 "relocatable");

--- a/subspace/mem/replace.h
+++ b/subspace/mem/replace.h
@@ -38,7 +38,7 @@ template <class T>
 
   // memcpy() is not constexpr so we can't use it in constexpr evaluation.
   bool can_memcpy =
-      ::sus::mem::relocate_one_by_memcpy<T> && !std::is_constant_evaluated();
+      ::sus::mem::relocate_by_memcpy<T> && !std::is_constant_evaluated();
   if (can_memcpy) {
     memcpy(::sus::mem::addressof(dest), ::sus::mem::addressof(src),
            ::sus::mem::data_size_of<T>());
@@ -56,7 +56,7 @@ template <class T>
 
   // memcpy() is not constexpr so we can't use it in constexpr evaluation.
   bool can_memcpy =
-      ::sus::mem::relocate_one_by_memcpy<T> && !std::is_constant_evaluated();
+      ::sus::mem::relocate_by_memcpy<T> && !std::is_constant_evaluated();
   if (can_memcpy) {
     memcpy(::sus::mem::addressof(dest), ::sus::mem::addressof(src),
            ::sus::mem::data_size_of<T>());
@@ -72,7 +72,7 @@ template <class T>
 inline void replace_and_discard(T& dest, const T& src) noexcept {
   // memcpy() is not constexpr so we can't use it in constexpr evaluation.
   bool can_memcpy =
-      ::sus::mem::relocate_one_by_memcpy<T> && !std::is_constant_evaluated();
+      ::sus::mem::relocate_by_memcpy<T> && !std::is_constant_evaluated();
   if (can_memcpy) {
     memcpy(::sus::mem::addressof(dest), ::sus::mem::addressof(src),
            ::sus::mem::data_size_of<T>());
@@ -86,7 +86,7 @@ template <class T>
 inline void replace_and_discard(T& dest, T&& src) noexcept {
   // memcpy() is not constexpr so we can't use it in constexpr evaluation.
   bool can_memcpy =
-      ::sus::mem::relocate_one_by_memcpy<T> && !std::is_constant_evaluated();
+      ::sus::mem::relocate_by_memcpy<T> && !std::is_constant_evaluated();
   if (can_memcpy) {
     memcpy(::sus::mem::addressof(dest), ::sus::mem::addressof(src),
            ::sus::mem::data_size_of<T>());

--- a/subspace/mem/replace_unittest.cc
+++ b/subspace/mem/replace_unittest.cc
@@ -28,7 +28,7 @@ namespace {
 
 TEST(Replace, ConstexprTrivialRelocate) {
   using T = int;
-  static_assert(::sus::mem::relocate_one_by_memcpy<T>, "");
+  static_assert(::sus::mem::relocate_by_memcpy<T>, "");
 
   auto i = []() constexpr {
     T i(2);
@@ -58,7 +58,7 @@ TEST(Replace, ConstexprTrivialAbi) {
   // This means `S` is only "trivially relocatable" if achieved through
   // [[sus_trivial_abi]].
   static_assert(!std::is_trivially_move_constructible_v<S>, "");
-  static_assert(::sus::mem::relocate_one_by_memcpy<S> ==
+  static_assert(::sus::mem::relocate_by_memcpy<S> ==
                     __has_extension(trivially_relocatable),
                 "");
 
@@ -89,7 +89,7 @@ TEST(Replace, ConstexprNonTrivial) {
     int num;
     int assigns = 0;
   };
-  static_assert(!::sus::mem::relocate_one_by_memcpy<S>, "");
+  static_assert(!::sus::mem::relocate_by_memcpy<S>, "");
 
   auto i = []() constexpr {
     S i(2);
@@ -109,7 +109,7 @@ TEST(Replace, ConstexprNonTrivial) {
 
 TEST(Replace, TrivialRelocate) {
   using T = int;
-  static_assert(::sus::mem::relocate_one_by_memcpy<T>, "");
+  static_assert(::sus::mem::relocate_by_memcpy<T>, "");
 
   T i(2);
   T j(::sus::mem::replace(mref(i), T(5)));
@@ -148,7 +148,7 @@ TEST(Replace, TrivialAbi) {
   // This means `S` is only "trivially relocatable" if achieved through
   // [[sus_trivial_abi]].
   static_assert(!std::is_trivially_move_constructible_v<S>, "");
-  static_assert(::sus::mem::relocate_one_by_memcpy<S> ==
+  static_assert(::sus::mem::relocate_by_memcpy<S> ==
                     __has_extension(trivially_relocatable),
                 "");
 
@@ -219,7 +219,7 @@ TEST(Replace, NonTrivial) {
     int num;
     int assigns = 0;
   };
-  static_assert(!::sus::mem::relocate_one_by_memcpy<S>, "");
+  static_assert(!::sus::mem::relocate_by_memcpy<S>, "");
 
   S i(2);
   S j(::sus::mem::replace(mref(i), S(5)));

--- a/subspace/mem/swap.h
+++ b/subspace/mem/swap.h
@@ -31,7 +31,7 @@ template <class T>
 constexpr void swap(T& lhs, T& rhs) noexcept {
   // memcpy() is not constexpr so we can't use it in constexpr evaluation.
   bool can_memcpy =
-      ::sus::mem::relocate_one_by_memcpy<T> && !std::is_constant_evaluated();
+      ::sus::mem::relocate_by_memcpy<T> && !std::is_constant_evaluated();
   if (can_memcpy) {
     char temp[::sus::mem::data_size_of<T>()];
     memcpy(temp, ::sus::mem::addressof(lhs), ::sus::mem::data_size_of<T>());

--- a/subspace/mem/swap_unittest.cc
+++ b/subspace/mem/swap_unittest.cc
@@ -25,7 +25,7 @@ namespace {
 
 TEST(Swap, ConstexprTrivialRelocate) {
   using T = int;
-  static_assert(relocate_one_by_memcpy<T>, "");
+  static_assert(relocate_by_memcpy<T>, "");
 
   auto i = []() constexpr {
     T i(2);
@@ -55,7 +55,7 @@ TEST(Swap, ConstexprTrivialAbi) {
   // [[sus_trivial_abi]].
   static_assert(!std::is_trivially_move_constructible_v<S>, "");
   static_assert(
-      relocate_one_by_memcpy<S> == __has_extension(trivially_relocatable), "");
+      relocate_by_memcpy<S> == __has_extension(trivially_relocatable), "");
 
   auto i = []() constexpr {
     S i(2);
@@ -84,7 +84,7 @@ TEST(Swap, ConstexprNonTrivial) {
     int num;
     int moves = 0;
   };
-  static_assert(!relocate_one_by_memcpy<S>, "");
+  static_assert(!relocate_by_memcpy<S>, "");
 
   auto i = []() constexpr {
     S i(2);
@@ -107,7 +107,7 @@ TEST(Swap, ConstexprNonTrivial) {
 
 TEST(Swap, TrivialRelocate) {
   using T = int;
-  static_assert(relocate_one_by_memcpy<T>, "");
+  static_assert(relocate_by_memcpy<T>, "");
 
   T i(2);
   T j(5);
@@ -131,7 +131,7 @@ TEST(Swap, TrivialAbi) {
   // [[sus_trivial_abi]].
   static_assert(!std::is_trivially_move_constructible_v<S>, "");
   static_assert(
-      relocate_one_by_memcpy<S> == __has_extension(trivially_relocatable), "");
+      relocate_by_memcpy<S> == __has_extension(trivially_relocatable), "");
 
   S i(2);
   S j(5);
@@ -158,7 +158,7 @@ TEST(Swap, NonTrivial) {
     int num;
     int moves = 0;
   };
-  static_assert(!relocate_one_by_memcpy<S>, "");
+  static_assert(!relocate_by_memcpy<S>, "");
 
   S i(2);
   S j(5);

--- a/subspace/num/i16_unittest.cc
+++ b/subspace/num/i16_unittest.cc
@@ -61,8 +61,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // i16::MAX

--- a/subspace/num/i32_unittest.cc
+++ b/subspace/num/i32_unittest.cc
@@ -64,8 +64,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // i32::MAX

--- a/subspace/num/i64_unittest.cc
+++ b/subspace/num/i64_unittest.cc
@@ -61,8 +61,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // i64::MAX

--- a/subspace/num/i8_unittest.cc
+++ b/subspace/num/i8_unittest.cc
@@ -61,8 +61,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // i8::MAX

--- a/subspace/num/isize_unittest.cc
+++ b/subspace/num/isize_unittest.cc
@@ -69,8 +69,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(sus::construct::Default<T>);
-static_assert(sus::mem::relocate_one_by_memcpy<T>);
-static_assert(sus::mem::relocate_array_by_memcpy<T>);
+static_assert(sus::mem::relocate_by_memcpy<T>);
 }  // namespace behaviour
 
 // isize::MAX

--- a/subspace/num/u16_unittest.cc
+++ b/subspace/num/u16_unittest.cc
@@ -61,8 +61,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // u16::MAX

--- a/subspace/num/u32_unittest.cc
+++ b/subspace/num/u32_unittest.cc
@@ -64,8 +64,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // u32::MAX

--- a/subspace/num/u64_unittest.cc
+++ b/subspace/num/u64_unittest.cc
@@ -61,8 +61,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // u64::MAX

--- a/subspace/num/u8_unittest.cc
+++ b/subspace/num/u8_unittest.cc
@@ -61,8 +61,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>, "");
 static_assert(std::is_assignable_v<T, From>, "");
 static_assert(std::is_nothrow_destructible_v<T>, "");
 static_assert(sus::construct::Default<T>, "");
-static_assert(sus::mem::relocate_one_by_memcpy<T>, "");
-static_assert(sus::mem::relocate_array_by_memcpy<T>, "");
+static_assert(sus::mem::relocate_by_memcpy<T>, "");
 }  // namespace behaviour
 
 // u8::MAX

--- a/subspace/num/usize_unittest.cc
+++ b/subspace/num/usize_unittest.cc
@@ -61,8 +61,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(sus::construct::Default<T>);
-static_assert(sus::mem::relocate_one_by_memcpy<T>);
-static_assert(sus::mem::relocate_array_by_memcpy<T>);
+static_assert(sus::mem::relocate_by_memcpy<T>);
 }  // namespace behaviour
 
 // usize::MAX

--- a/subspace/option/option_types_unittest.cc
+++ b/subspace/option/option_types_unittest.cc
@@ -18,8 +18,7 @@
 #include "subspace/test/behaviour_types.h"
 
 using sus::construct::Default;
-using sus::mem::relocate_array_by_memcpy;
-using sus::mem::relocate_one_by_memcpy;
+using sus::mem::relocate_by_memcpy;
 using sus::option::Option;
 
 namespace default_constructible {
@@ -48,8 +47,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace default_constructible
 
 namespace not_default_constructible {
@@ -78,8 +76,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace not_default_constructible
 
 namespace trivially_copyable {
@@ -108,8 +105,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(!std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_copyable
 
 namespace trivially_moveable_and_relocatable {
@@ -138,8 +134,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_and_relocatable
 
 namespace trivially_copyable_not_destructible {
@@ -168,8 +163,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(!std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_copyable_not_destructible
 
 namespace trivially_moveable_not_destructible {
@@ -198,8 +192,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_not_destructible
 
 namespace not_trivially_relocatable_copyable_or_moveable {
@@ -228,8 +221,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace not_trivially_relocatable_copyable_or_moveable
 
 namespace trivial_abi_relocatable {
@@ -258,6 +250,5 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivial_abi_relocatable

--- a/subspace/option/option_unittest.cc
+++ b/subspace/option/option_unittest.cc
@@ -36,8 +36,7 @@ using sus::Option;
 using sus::Some;
 using sus::Tuple;
 using sus::construct::Default;
-using sus::mem::relocate_array_by_memcpy;
-using sus::mem::relocate_one_by_memcpy;
+using sus::mem::relocate_by_memcpy;
 using namespace sus::test;
 
 namespace {

--- a/subspace/result/result_types_unittest.cc
+++ b/subspace/result/result_types_unittest.cc
@@ -18,8 +18,7 @@
 #include "subspace/test/behaviour_types.h"
 
 using sus::construct::Default;
-using sus::mem::relocate_array_by_memcpy;
-using sus::mem::relocate_one_by_memcpy;
+using sus::mem::relocate_by_memcpy;
 using sus::result::Result;
 
 namespace default_constructible {
@@ -48,8 +47,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace default_constructible
 
 namespace not_default_constructible {
@@ -78,8 +76,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace not_default_constructible
 
 namespace trivially_copyable {
@@ -108,8 +105,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(!std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_copyable
 
 namespace trivially_moveable_and_relocatable {
@@ -138,8 +134,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_and_relocatable
 
 namespace trivially_copyable_not_destructible {
@@ -168,8 +163,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(!std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_copyable_not_destructible
 
 namespace trivially_moveable_not_destructible {
@@ -198,8 +192,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_not_destructible
 
 namespace not_trivially_relocatable_copyable_or_moveable {
@@ -228,8 +221,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace not_trivially_relocatable_copyable_or_moveable
 
 namespace trivial_abi_relocatable {
@@ -258,6 +250,5 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivial_abi_relocatable

--- a/subspace/test/behaviour_types_unittest.cc
+++ b/subspace/test/behaviour_types_unittest.cc
@@ -18,8 +18,7 @@
 #include "subspace/mem/relocate.h"
 
 using sus::construct::Default;
-using sus::mem::relocate_array_by_memcpy;
-using sus::mem::relocate_one_by_memcpy;
+using sus::mem::relocate_by_memcpy;
 
 namespace default_constructible {
 using T = sus::test::DefaultConstructible;
@@ -47,8 +46,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace default_constructible
 
 namespace not_default_constructible {
@@ -77,8 +75,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace not_default_constructible
 
 namespace trivially_copyable {
@@ -106,8 +103,7 @@ static_assert(!std::is_constructible_v<T, From>);
 static_assert(!std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_copyable
 
 namespace trivially_moveable_and_relocatable {
@@ -136,8 +132,7 @@ static_assert(std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_and_relocatable
 
 namespace trivially_copyable_not_destructible {
@@ -166,8 +161,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(!std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_copyable_not_destructible
 
 namespace trivially_moveable_not_destructible {
@@ -196,8 +190,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace trivially_moveable_not_destructible
 
 namespace not_trivially_relocatable_copyable_or_moveable {
@@ -226,8 +219,7 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(!relocate_one_by_memcpy<T>);
-static_assert(!relocate_array_by_memcpy<T>);
+static_assert(!relocate_by_memcpy<T>);
 }  // namespace not_trivially_relocatable_copyable_or_moveable
 
 namespace trivial_abi_relocatable {
@@ -256,6 +248,5 @@ static_assert(!std::is_trivially_constructible_v<T, From>);
 static_assert(std::is_assignable_v<T, From>);
 static_assert(std::is_nothrow_destructible_v<T>);
 static_assert(!Default<T>);
-static_assert(relocate_one_by_memcpy<T>);
-static_assert(relocate_array_by_memcpy<T>);
+static_assert(relocate_by_memcpy<T>);
 }  // namespace trivial_abi_relocatable


### PR DESCRIPTION
Reading through my references carefully while writing a blog post about these concepts I realized that the distinction is not needed. Trivially relocating a single object that is volatile is already problematic and can cause tearing.

So combine these two into relocate_by_memcpy<T> which does what relocate_array_by_memcpy used to do.