### PR TITLE
Make all of Option constexpr

### DIFF
--- a/subspace/choice/choice.h
+++ b/subspace/choice/choice.h
@@ -145,7 +145,8 @@ class Choice<__private::TypeList<Ts...>, Tags...> final {
     requires(!(std::is_trivially_destructible_v<TagsType> && ... &&
                std::is_trivially_destructible_v<Ts>))
   {
-    if (index_ != kUseAfterMove) storage_.destroy(size_t{index_});
+    if (index_ != kUseAfterMove && index_ != kNeverValue)
+      storage_.destroy(size_t{index_});
   }
 
   constexpr Choice(Choice&& o)
@@ -437,7 +438,8 @@ class Choice<__private::TypeList<Ts...>, Tags...> final {
   IndexType index_;
 
   sus_class_never_value_field(::sus::marker::unsafe_fn, Choice, index_,
-                              kNeverValue);
+                              kNeverValue, kNeverValue);
+  constexpr Choice() = default;  // For the NeverValueField.
 };
 
 /// Used to construct a Choice with the tag and parameters as its values.

--- a/subspace/choice/choice_unittest.cc
+++ b/subspace/choice/choice_unittest.cc
@@ -63,12 +63,11 @@ TEST(Choice, NeverValue) {
   static_assert(std::is_standard_layout_v<One>);
   static_assert(sizeof(sus::Option<One>) == sizeof(One));
 
-  // Two values in a Tuple isn't standard layout at this time. This allows the
-  // Tuple to pack better but, also means we can't use the never-value field
-  // optimization in Option.
+  // It used to be that Option<T> did not support the NeverValueField
+  // optimization for non-Standard-Layout types, but it does now.
   using Two = Choice<sus_choice_types((Order::First, u64, u64))>;
   static_assert(!std::is_standard_layout_v<Two>);
-  static_assert(sizeof(sus::Option<Two>) > sizeof(Two));
+  static_assert(sizeof(sus::Option<Two>) == sizeof(Two));
 }
 
 TEST(Choice, ConstructorFunctionNoValue) {

--- a/subspace/containers/slice.h
+++ b/subspace/containers/slice.h
@@ -38,7 +38,8 @@ namespace sus::containers {
 template <class T>
 class Slice {
  public:
-  static constexpr inline Slice from_raw_parts(T* data, ::sus::usize len) noexcept {
+  static constexpr inline Slice from_raw_parts(T* data,
+                                               ::sus::usize len) noexcept {
     check(len.primitive_value <= PTRDIFF_MAX);
     return Slice(data, len);
   }
@@ -164,7 +165,9 @@ class Slice {
   T* data_;
   ::sus::usize len_;
 
-  sus_class_never_value_field(::sus::marker::unsafe_fn, Slice, data_, nullptr);
+  sus_class_never_value_field(::sus::marker::unsafe_fn, Slice, data_, nullptr,
+                              nullptr);
+  constexpr Slice() = default;  // For the NeverValueField.
 };
 
 // Implicit for-ranged loop iteration via `Slice::iter()`.

--- a/subspace/fn/fn_defn.h
+++ b/subspace/fn/fn_defn.h
@@ -241,10 +241,13 @@ class [[sus_trivial_abi]] FnOnce<R(CallArgs...)> {
 
  private:
   sus_class_trivially_relocatable(::sus::marker::unsafe_fn, decltype(fn_ptr_),
-                                             decltype(storage_),
-                                             decltype(type_));
+                                  decltype(storage_), decltype(type_));
+  // Set the never value field to FnPointer to perform a no-op destruction as
+  // there is nothing cleaned up when holding a function pointer.
   sus_class_never_value_field(::sus::marker::unsafe_fn, FnOnce, type_,
-                              static_cast<__private::FnType>(0));
+                              static_cast<__private::FnType>(0),
+                              __private::FnType::FnPointer);
+  constexpr FnOnce() = default;  // For the NeverValueField.
 };
 
 /// A closure that erases the type of the internal callable object (lambda). A

--- a/subspace/fn/fn_impl.h
+++ b/subspace/fn/fn_impl.h
@@ -83,6 +83,8 @@ void FnOnce<R(CallArgs...)>::make_vtable(
 template <class R, class... CallArgs>
 FnOnce<R(CallArgs...)>::~FnOnce() noexcept {
   switch (type_) {
+    // Note that the FnPointer state is set when destroying from the never value
+    // state.
     case __private::FnPointer: break;
     case __private::Storage: {
       if (auto* s = ::sus::mem::replace_ptr(mref(storage_), nullptr); s)

--- a/subspace/mem/clone.h
+++ b/subspace/mem/clone.h
@@ -58,9 +58,11 @@ concept HasCloneFromMethod = requires(T& self, const T& source) {
 /// copy constructors if the type within is Copy.
 template <class T>
 concept Clone = (Copy<T> &&
-                 !__private::HasCloneMethod<std::remove_reference_t<T>>) ||
+                 !__private::HasCloneMethod<
+                     std::remove_const_t<std::remove_reference_t<T>>>) ||
                 (!Copy<T> && Move<T> &&
-                 __private::HasCloneMethod<std::remove_reference_t<T>>);
+                 __private::HasCloneMethod<
+                     std::remove_const_t<std::remove_reference_t<T>>>);
 
 /// A `CloneOrRef` object or reference of type `T` can be cloned to construct a
 /// new `T`.
@@ -84,8 +86,10 @@ concept CloneOrRef = Clone<T> || std::is_reference_v<T>;
 template <class T>
 concept CloneInto =
     Clone<T> &&
-    ((Copy<T> && !__private::HasCloneFromMethod<std::remove_reference_t<T>>) ||
-     (!Copy<T> && __private::HasCloneFromMethod<std::remove_reference_t<T>>));
+    ((Copy<T> && !__private::HasCloneFromMethod<
+                     std::remove_const_t<std::remove_reference_t<T>>>) ||
+     (!Copy<T> && __private::HasCloneFromMethod<
+                      std::remove_const_t<std::remove_reference_t<T>>>));
 
 /// Clones the input either by copying or cloning. Returns a new object of type
 /// `T`.

--- a/subspace/mem/copy.h
+++ b/subspace/mem/copy.h
@@ -23,7 +23,8 @@ namespace sus::mem {
 ///
 /// Satisfying `Copy` also implies that the type satisfies `Clone`.
 ///
-/// This concept tests the object type of `T`, not a reference type `T&` or `const T&`.
+/// This concept tests the object type of `T`, not a reference type `T&` or
+/// `const T&`.
 ///
 /// Typically types should only be `Copy` when performing a copy is very cheap,
 /// and thus unlikely to cause performance problems. For types that are larger
@@ -41,8 +42,10 @@ namespace sus::mem {
 /// static_assert(sus::mem::Clone<S>);
 /// ```
 template <class T>
-concept Copy = std::is_copy_constructible_v<std::remove_reference_t<T>> &&
-               std::is_copy_assignable_v<std::remove_reference_t<T>>;
+concept Copy =
+    std::is_copy_constructible_v<
+        std::remove_const_t<std::remove_reference_t<T>>> &&
+    std::is_copy_assignable_v<std::remove_const_t<std::remove_reference_t<T>>>;
 
 /// A `CopyOrRef` object or reference of type `T` can be copied to construct a
 /// new `T`.

--- a/subspace/mem/move.h
+++ b/subspace/mem/move.h
@@ -47,9 +47,12 @@ namespace sus::mem {
 /// };
 /// static_assert(sus::mem::Move<S>);
 template <class T>
-concept Move = std::is_move_constructible_v<std::remove_reference_t<T>> &&
-               (std::is_move_assignable_v<std::remove_reference_t<T>> ||
-                !std::is_copy_assignable_v<std::remove_reference_t<T>>);
+concept Move = std::is_move_constructible_v<
+                   std::remove_const_t<std::remove_reference_t<T>>> &&
+               (std::is_move_assignable_v<
+                    std::remove_const_t<std::remove_reference_t<T>>> ||
+                !std::is_copy_assignable_v<
+                    std::remove_const_t<std::remove_reference_t<T>>>);
 
 /// A `MoveOrRef` object or reference of type `T` can be moved to construct a
 /// new `T`.

--- a/subspace/mem/nonnull.h
+++ b/subspace/mem/nonnull.h
@@ -162,7 +162,9 @@ struct [[sus_trivial_abi]] NonNull {
   sus_class_trivially_relocatable_unchecked(::sus::marker::unsafe_fn);
   // Declare that the `ptr_` field is never set to `nullptr` for library
   // optimizations.
-  sus_class_never_value_field(::sus::marker::unsafe_fn, NonNull, ptr_, nullptr);
+  sus_class_never_value_field(::sus::marker::unsafe_fn, NonNull, ptr_, nullptr,
+                              nullptr);
+  constexpr NonNull() = default;  // For the NeverValueField.
 };
 
 /// sus::ops::Eq<NonNull<T>> trait.

--- a/subspace/mem/nonnull_types_unittest.cc
+++ b/subspace/mem/nonnull_types_unittest.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "subspace/construct/default.h"
+#include "subspace/macros/compiler.h"
 #include "subspace/mem/nonnull.h"
 #include "subspace/mem/relocate.h"
 #include "subspace/test/behaviour_types.h"
@@ -24,7 +25,8 @@ using sus::mem::relocate_by_memcpy;
 namespace default_constructible {
 using T = NonNull<sus::test::DefaultConstructible>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);
@@ -53,7 +55,8 @@ static_assert(relocate_by_memcpy<T>);
 namespace not_default_constructible {
 using T = NonNull<sus::test::NotDefaultConstructible>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);
@@ -82,7 +85,8 @@ static_assert(relocate_by_memcpy<T>);
 namespace trivially_copyable {
 using T = NonNull<sus::test::TriviallyCopyable>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);
@@ -110,7 +114,8 @@ static_assert(relocate_by_memcpy<T>);
 namespace trivially_moveable_and_relocatable {
 using T = NonNull<sus::test::TriviallyMoveableAndRelocatable>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);
@@ -139,7 +144,8 @@ static_assert(relocate_by_memcpy<T>);
 namespace trivially_copyable_not_destructible {
 using T = NonNull<sus::test::TriviallyCopyableNotDestructible>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);
@@ -168,7 +174,8 @@ static_assert(relocate_by_memcpy<T>);
 namespace trivially_moveable_not_destructible {
 using T = NonNull<sus::test::TriviallyMoveableNotDestructible>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);
@@ -197,7 +204,8 @@ static_assert(relocate_by_memcpy<T>);
 namespace not_trivially_relocatable_copyable_or_moveable {
 using T = NonNull<sus::test::NotTriviallyRelocatableCopyableOrMoveable>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);
@@ -226,7 +234,8 @@ static_assert(relocate_by_memcpy<T>);
 namespace trivial_abi_relocatable {
 using T = NonNull<sus::test::TrivialAbiRelocatable>;
 using From = T;
-static_assert(!std::is_trivial_v<T>);
+// MSVC does not see private constructors, Clang and GCC do.
+static_assert(sus_if_msvc_else(!std::is_trivial_v<T>, std::is_trivial_v<T>));
 static_assert(!std::is_aggregate_v<T>);
 static_assert(std::is_standard_layout_v<T>);
 static_assert(!std::is_trivially_default_constructible_v<T>);

--- a/subspace/tuple/tuple.h
+++ b/subspace/tuple/tuple.h
@@ -236,15 +236,15 @@ class Tuple final {
 
 // Support for structured binding.
 template <size_t I, class... Ts>
-decltype(auto) get(const Tuple<Ts...>& t) noexcept {
+constexpr decltype(auto) get(const Tuple<Ts...>& t) noexcept {
   return t.template get_ref<I>();
 }
 template <size_t I, class... Ts>
-decltype(auto) get(Tuple<Ts...>& t) noexcept {
+constexpr decltype(auto) get(Tuple<Ts...>& t) noexcept {
   return t.template get_mut<I>();
 }
 template <size_t I, class... Ts>
-decltype(auto) get(Tuple<Ts...>&& t) noexcept {
+constexpr decltype(auto) get(Tuple<Ts...>&& t) noexcept {
   // We explicitly don't move-from `t` to call `t.into_inner()` as this `get()`
   // function will be called for each member of `t` when making structured
   // bindings from an rvalue Tuple.


### PR DESCRIPTION
To do this we have to make the implementation of NeverValueField for
a given type a bit more awkward.

1. The type needs to be trivially default constructible. It can be
   private, since this implies leaving its fields all uninitialized. The
   NeverValueAccess class will still be able to construct it.
2. The macro takes an additional 'destroy value'.
3. The destructor must be a no-op when the never value field is set to
   the destroy value. Most times the never value and destroy value can
   be the same thing but if the destructor branches on the value then it
   can be set to a no-op value.

Once these were done then we introduced the NeverValueAccess as a type
that holds a NeverValueField type T, and when default constructed it
trivially constructs the T. The caller must then set the never value in
the newly constructed T. Default construction is required to be able to
destroy the member in Option and reset it to the never value in a
constexpr way (without in-place new).

The good news is there's no longer any standard-layout requirements.

The bad news is that this probably dooms the NeverValueField concept to
be unstable, or worse, private. Implementing it in user types is just
kind of messy and complicated.

The other bad news is Vec no longer satisfies NeverValueField, since
it has a public, non-trivial default constructor. So it's not possible
to construct it with all its fields uninitialized.