### PR TITLE
Capture the source location for check(), panic(), and unreached()

### DIFF
--- a/subspace/assertions/check.h
+++ b/subspace/assertions/check.h
@@ -15,22 +15,26 @@
 #pragma once
 
 #include <stdlib.h>
+#include <source_location>
 
 #include "subspace/assertions/panic.h"
 #include "subspace/macros/always_inline.h"
 
 namespace sus::assertions {
 
-constexpr sus_always_inline void check(bool cond) {
+constexpr sus_always_inline void check(
+    bool cond,
+    const std::source_location location = std::source_location::current()) {
   if (!cond) [[unlikely]]
-    ::sus::panic();
+    ::sus::panic(location);
 }
 
 constexpr sus_always_inline void check_with_message(
     bool cond,
-    /* TODO: string view type, or format + args */ const char& msg) {
+    /* TODO: string view type, or format + args */ const char& msg,
+    const std::source_location location = std::source_location::current()) {
   if (!cond) [[unlikely]]
-    ::sus::panic_with_message(msg);
+    ::sus::panic_with_message(msg, location);
 }
 
 }  // namespace sus::assertions

--- a/subspace/assertions/panic.cc
+++ b/subspace/assertions/panic.cc
@@ -19,8 +19,17 @@
 namespace sus::assertions::__private {
 
 // Defined outside the header to avoid fprintf in the header.
-void print_panic_message(const char& msg) {
-  fprintf(stderr, "PANIC! %s\n", &msg);
+void print_panic_message(const char& msg,
+                         const std::source_location& location) {
+  fprintf(stderr, "PANIC! at %s:%lu:%lu: %s\n", location.file_name(),
+          static_cast<unsigned long>(location.line()),
+          static_cast<unsigned long>(location.column()), &msg);
+}
+
+void print_panic_location(const std::source_location& location) {
+  fprintf(stderr, "PANIC! at %s:%lu:%lu\n", location.file_name(),
+          static_cast<unsigned long>(location.line()),
+          static_cast<unsigned long>(location.column()));
 }
 
 }  // namespace sus::assertions::__private

--- a/subspace/assertions/panic_unittest.cc
+++ b/subspace/assertions/panic_unittest.cc
@@ -16,18 +16,29 @@
 
 #include "googletest/include/gtest/gtest.h"
 
+// Incredibly, on Posix we can use [0-9] but on Windows we can't. Yet on Windows
+// we can use `\d` and on Posix we can't (or it doesn't match).
+#if GTEST_USES_SIMPLE_RE
+#define DIGIT "\\d"
+#else
+#define DIGIT "[0-9]"
+#endif
+
 namespace sus {
 namespace {
 
-TEST(Panic, Panic) {
+TEST(PanicDeathTest, Panic) {
 #if GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(panic(), "");
+  EXPECT_DEATH(panic(),
+               "^PANIC! at .*panic_unittest.cc:" DIGIT "+:" DIGIT "+\n$");
 #endif
 }
 
-TEST(Panic, WithMessage) {
+TEST(PanicDeathTest, WithMessage) {
 #if GTEST_HAS_DEATH_TEST
-  EXPECT_DEATH(panic_with_message(*"hello world"), "hello world");
+  EXPECT_DEATH(panic_with_message(*"hello world"),
+               "^PANIC! at .*panic_unittest.cc:" DIGIT "+:" DIGIT
+               "+: hello world\n$");
 #endif
 }
 

--- a/subspace/assertions/unreachable.h
+++ b/subspace/assertions/unreachable.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <source_location>
+
 #include "subspace/assertions/panic.h"
 #include "subspace/macros/always_inline.h"
 #include "subspace/macros/builtin.h"
@@ -21,7 +23,10 @@
 
 namespace sus::assertions {
 
-[[noreturn]] sus_always_inline void unreachable() { panic(); }
+[[noreturn]] sus_always_inline void unreachable(
+    const std::source_location location = std::source_location::current()) {
+  panic(location);
+}
 
 [[noreturn]] sus_always_inline void unreachable_unchecked(
     ::sus::marker::UnsafeFnMarker) {


### PR DESCRIPTION
And print the location out when an error occurs.