### PR TITLE
Add cmake notes; make tests optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 
 include(OptionIf)
 
+option_if_not_defined(SUBSPACE_BUILD_TESTS "Build subspace tests" ON)
 option_if_not_defined(SUBSPACE_BUILD_CIR "Build CIR (requires LLVM)" ON)
 option_if_not_defined(SUBSPACE_BUILD_SUBDOC "Build subdoc (requires LLVM)" ON)
 
@@ -67,10 +68,12 @@ function(subspace_test_default_compile_options TARGET)
     target_link_libraries(${TARGET} gtest_main)
 endfunction()
 
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-add_subdirectory(third_party/googletest)
-include(GoogleTest)
-enable_testing()
+if(${SUBSPACE_BUILD_TESTS})
+    set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+    add_subdirectory(third_party/googletest)
+    include(GoogleTest)
+    enable_testing()
+endif()
 
 add_subdirectory(subspace)
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/chromium/subspace/actions/workflows/ci.yml/badge.svg)](https://github.com/chromium/subspace/actions/workflows/ci.yml)
 [![hdoc](https://github.com/chromium/subspace/actions/workflows/hdoc.yml/badge.svg)](https://docs.hdoc.io/danakj/subspace/)
 [![sub-doc](https://github.com/chromium/subspace/actions/workflows/subdoc.yml/badge.svg)](https://danakj.github.io/subspace-docs/sus.html)
-<!--- 
+<!---
 [![clang-doc](https://github.com/chromium/subspace/actions/workflows/clang-doc.yml/badge.svg)](https://danakj.github.io/subspace-docs/sus/#Namespaces)
 -->
 # Subspace Library
@@ -85,6 +85,51 @@ Then use VSCode to choose a build configuration and run the "CMake: Build" and
 
 On windows, set the environment variable `LLVM_DEBUG=1` if the LLVM build was a
 debug build in order for CIR to link the appropriate runtime.
+
+# Using Subspace with CMake
+
+If you're looking to use Subspace in a project, CMake and `git submodules` can be used to help
+integrate the subspace library.
+
+## Add `subspace` as a submodule
+* `git submodule add https://github.com/chromium/subspace third_party/subspace`
+
+## CMakeLists.txt
+
+```
+cmake_minimum_required(VERSION 3.25)
+
+project(subspace-example VERSION 0.1.0)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+SET(SUBSPACE_BUILD_CIR OFF)
+SET(SUBSPACE_BUILD_SUBDOC OFF)
+SET(SUBSPACE_BUILD_TESTS OFF)
+add_subdirectory(third_party/subspace)
+
+add_executable(subspace-example src/main.cc)
+target_link_libraries(subspace-example PRIVATE subspace::lib)
+```
+
+## src/main.cc
+```
+#include "subspace/assertions/check.h"
+
+int main() {
+  sus::assertions::check(false);
+  return 0;
+}
+```
+
+## Building
+```
+mkdir -p out/Debug
+cd out/Debug
+CXX=clang++ cmake -GNinja ../..
+ninja
+```
 
 # Copyright
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ target_link_libraries(subspace-example PRIVATE subspace::lib)
 #include "subspace/assertions/check.h"
 
 int main() {
-  sus::assertions::check(false);
+  sus::check(false);
   return 0;
 }
 ```

--- a/cir/CMakeLists.txt
+++ b/cir/CMakeLists.txt
@@ -35,11 +35,6 @@ add_executable(cir
     "cir_main.cc"
 )
 
-add_executable(cir_unittests
-    "tests/cir_test.h"
-    "tests/smoke_unittest.cc"
-)
-
 # cir_lib
 subspace_default_compile_options(cir_lib)
 
@@ -95,13 +90,20 @@ target_link_libraries(cir_lib
     clangTransformer
 )
 
-# cir_unittests
-subspace_test_default_compile_options(cir_unittests)
-target_link_libraries(cir_unittests cir::lib)
-
-gtest_discover_tests(cir_unittests)
-
 # cir binary
 subspace_default_compile_options(cir)
 target_link_libraries(cir cir::lib)
+
+if(${SUBSPACE_BUILD_TESTS})
+    add_executable(cir_unittests
+        "tests/cir_test.h"
+        "tests/smoke_unittest.cc"
+    )
+
+    # cir_unittests
+    subspace_test_default_compile_options(cir_unittests)
+    target_link_libraries(cir_unittests cir::lib)
+
+    gtest_discover_tests(cir_unittests)
+endif()
 

--- a/subdoc/CMakeLists.txt
+++ b/subdoc/CMakeLists.txt
@@ -46,22 +46,6 @@ add_executable(subdoc
     "subdoc_main.cc"
 )
 
-add_executable(subdoc_unittests
-    "gen_tests/gen_tests.cc"
-    "tests/fields_unittest.cc"
-    "tests/functions_unittest.cc"
-    "tests/include_exclude_unittest.cc"
-    "tests/inherit_unittest.cc"
-    "tests/macros_unittest.cc"
-    "tests/markdown_unittest.cc"
-    "tests/methods_unittest.cc"
-    "tests/records_unittest.cc"
-    "tests/styles_unittest.cc"
-    "tests/types_unittest.cc"
-    "tests/subdoc_gen_test.h"
-    "tests/subdoc_test.h"
-)
-
 # subdoc_lib
 subspace_default_compile_options(subdoc_lib)
 
@@ -117,12 +101,31 @@ target_link_libraries(subdoc_lib
     clangTransformer
 )
 
-# subdoc_unittests
-subspace_test_default_compile_options(subdoc_unittests)
-target_link_libraries(subdoc_unittests subdoc::lib)
-
-gtest_discover_tests(subdoc_unittests)
-
 # subdoc binary
 subspace_default_compile_options(subdoc)
 target_link_libraries(subdoc subdoc::lib)
+
+if(${SUBSPACE_BUILD_TESTS})
+    add_executable(subdoc_unittests
+        "gen_tests/gen_tests.cc"
+        "tests/fields_unittest.cc"
+        "tests/functions_unittest.cc"
+        "tests/include_exclude_unittest.cc"
+        "tests/inherit_unittest.cc"
+        "tests/macros_unittest.cc"
+        "tests/markdown_unittest.cc"
+        "tests/methods_unittest.cc"
+        "tests/records_unittest.cc"
+        "tests/styles_unittest.cc"
+        "tests/types_unittest.cc"
+        "tests/subdoc_gen_test.h"
+        "tests/subdoc_test.h"
+    )
+
+    # subdoc_unittests
+    subspace_test_default_compile_options(subdoc_unittests)
+    target_link_libraries(subdoc_unittests subdoc::lib)
+
+    gtest_discover_tests(subdoc_unittests)
+endif()
+

--- a/subspace/CMakeLists.txt
+++ b/subspace/CMakeLists.txt
@@ -151,73 +151,6 @@ target_sources(subspace PUBLIC
     "lib/lib.cc"
 )
 
-add_library(subspace_test_support STATIC "")
-add_library(subspace::test_support ALIAS subspace_test_support)
-target_sources(subspace_test_support PUBLIC
-    "test/from_i32.h"
-    "test/behaviour_types.h"
-    "test/behaviour_types_unittest.cc"
-    "test/ensure_use.cc"
-    "test/ensure_use.h"
-    "test/no_copy_move.h"
-)
-
-add_executable(subspace_unittests
-    "assertions/check_unittest.cc"
-    "assertions/endian_unittest.cc"
-    "assertions/panic_unittest.cc"
-    "assertions/unreachable_unittest.cc"
-    "choice/choice_types_unittest.cc"
-    "choice/choice_unittest.cc"
-    "convert/subclass_unittest.cc"
-    "containers/array_unittest.cc"
-    "containers/slice_unittest.cc"
-    "containers/vec_unittest.cc"
-    "construct/from_unittest.cc"
-    "construct/into_unittest.cc"
-    "construct/default_unittest.cc"
-    "fn/fn_box_unittest.cc"
-    "fn/fn_concepts_unittest.cc"
-    "fn/fn_ref_unittest.cc"
-    "iter/compat_ranges_unittest.cc"
-    "iter/generator_unittest.cc"
-    "iter/iterator_unittest.cc"
-    "mem/addressof_unittest.cc"
-    "mem/clone_unittest.cc"
-    "mem/move_unittest.cc"
-    "mem/nonnull_unittest.cc"
-    "mem/nonnull_types_unittest.cc"
-    "mem/relocate_unittest.cc"
-    "mem/replace_unittest.cc"
-    "mem/size_of_unittest.cc"
-    "mem/swap_unittest.cc"
-    "mem/take_unittest.cc"
-    "num/__private/literals_unittest.cc"
-    "num/cmath_macros_unittest.cc"
-    "num/f32_unittest.cc"
-    "num/f64_unittest.cc"
-    "num/i8_unittest.cc"
-    "num/i16_unittest.cc"
-    "num/i32_unittest.cc"
-    "num/i64_unittest.cc"
-    "num/isize_unittest.cc"
-    "num/u8_unittest.cc"
-    "num/u16_unittest.cc"
-    "num/u32_unittest.cc"
-    "num/u64_unittest.cc"
-    "num/usize_unittest.cc"
-    "option/option_unittest.cc"
-    "option/option_types_unittest.cc"
-    "ops/eq_unittest.cc"
-    "ops/ord_unittest.cc"
-    "ops/range_unittest.cc"
-    "ptr/swap_unittest.cc"
-    "result/result_unittest.cc"
-    "result/result_types_unittest.cc"
-    "tuple/tuple_types_unittest.cc"
-    "tuple/tuple_unittest.cc"
-)
-
 # Subspace library
 subspace_default_compile_options(subspace)
 
@@ -229,15 +162,85 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND
     target_compile_options(subspace PUBLIC /D_CRT_USE_BUILTIN_OFFSETOF)
 endif()
 
-# Subspace test support
-subspace_test_default_compile_options(subspace_test_support)
-target_link_libraries(subspace_test_support subspace::lib)
+if(${SUBSPACE_BUILD_TESTS})
+    add_library(subspace_test_support STATIC "")
+    add_library(subspace::test_support ALIAS subspace_test_support)
+    target_sources(subspace_test_support PUBLIC
+        "test/from_i32.h"
+        "test/behaviour_types.h"
+        "test/behaviour_types_unittest.cc"
+        "test/ensure_use.cc"
+        "test/ensure_use.h"
+        "test/no_copy_move.h"
+    )
 
-# Subspace unittests
-subspace_test_default_compile_options(subspace_unittests)
-target_link_libraries(subspace_unittests
-    subspace::lib
-    subspace::test_support
-)
+    add_executable(subspace_unittests
+        "assertions/check_unittest.cc"
+        "assertions/endian_unittest.cc"
+        "assertions/panic_unittest.cc"
+        "assertions/unreachable_unittest.cc"
+        "choice/choice_types_unittest.cc"
+        "choice/choice_unittest.cc"
+        "convert/subclass_unittest.cc"
+        "containers/array_unittest.cc"
+        "containers/slice_unittest.cc"
+        "containers/vec_unittest.cc"
+        "construct/from_unittest.cc"
+        "construct/into_unittest.cc"
+        "construct/default_unittest.cc"
+        "fn/fn_box_unittest.cc"
+        "fn/fn_concepts_unittest.cc"
+        "fn/fn_ref_unittest.cc"
+        "iter/compat_ranges_unittest.cc"
+        "iter/generator_unittest.cc"
+        "iter/iterator_unittest.cc"
+        "mem/addressof_unittest.cc"
+        "mem/clone_unittest.cc"
+        "mem/move_unittest.cc"
+        "mem/nonnull_unittest.cc"
+        "mem/nonnull_types_unittest.cc"
+        "mem/relocate_unittest.cc"
+        "mem/replace_unittest.cc"
+        "mem/size_of_unittest.cc"
+        "mem/swap_unittest.cc"
+        "mem/take_unittest.cc"
+        "num/__private/literals_unittest.cc"
+        "num/cmath_macros_unittest.cc"
+        "num/f32_unittest.cc"
+        "num/f64_unittest.cc"
+        "num/i8_unittest.cc"
+        "num/i16_unittest.cc"
+        "num/i32_unittest.cc"
+        "num/i64_unittest.cc"
+        "num/isize_unittest.cc"
+        "num/u8_unittest.cc"
+        "num/u16_unittest.cc"
+        "num/u32_unittest.cc"
+        "num/u64_unittest.cc"
+        "num/usize_unittest.cc"
+        "option/option_unittest.cc"
+        "option/option_types_unittest.cc"
+        "ops/eq_unittest.cc"
+        "ops/ord_unittest.cc"
+        "ops/range_unittest.cc"
+        "ptr/swap_unittest.cc"
+        "result/result_unittest.cc"
+        "result/result_types_unittest.cc"
+        "tuple/tuple_types_unittest.cc"
+        "tuple/tuple_unittest.cc"
+    )
 
-gtest_discover_tests(subspace_unittests)
+    # Subspace test support
+    subspace_test_default_compile_options(subspace_test_support)
+    target_link_libraries(subspace_test_support subspace::lib)
+
+    # Subspace unittests
+    subspace_test_default_compile_options(subspace_unittests)
+    target_link_libraries(subspace_unittests
+        subspace::lib
+        subspace::test_support
+    )
+
+    gtest_discover_tests(subspace_unittests)
+endif()
+


### PR DESCRIPTION
This CL adds some documentation on integrating subspace with CMake. In order to make the integration simpler the test files have been moved inside a `SUBSPACE_BUILD_TESTS` cmake option. This allows disabling the subspace tests when integrating.

Issue #226