### PR TITLE
Support any streamable type for Array, Choice, Tuple

### DIFF
--- a/subspace/choice/choice.h
+++ b/subspace/choice/choice.h
@@ -708,9 +708,10 @@ struct fmt::formatter<
 
 // Stream support (written out manually due to use of template specialization).
 namespace sus::choice_type {
-template <class... Ts, auto... Tags>
-inline std::basic_ostream<char>& operator<<(
-    std::basic_ostream<char>& stream,
+template <class... Ts, auto... Tags,
+          ::sus::string::__private::StreamCanReceiveString<char> StreamType>
+inline StreamType& operator<<(
+    StreamType& stream,
     const Choice<__private::TypeList<Ts...>, Tags...>& value) {
   return ::sus::string::__private::format_to_stream(stream,
                                                     fmt::format("{}", value));

--- a/subspace/containers/array.h
+++ b/subspace/containers/array.h
@@ -501,9 +501,9 @@ struct fmt::formatter<::sus::containers::Array<T, N>, Char> {
 
 // Stream support (written out manually due to size_t template param).
 namespace sus::containers {
-template <class T, size_t N>
-inline std::basic_ostream<char>& operator<<(std::basic_ostream<char>& stream,
-                                            const Array<T, N>& value) {
+template <class T, size_t N,
+          ::sus::string::__private::StreamCanReceiveString<char> StreamType>
+inline StreamType& operator<<(StreamType& stream, const Array<T, N>& value) {
   return ::sus::string::__private::format_to_stream(stream,
                                                     fmt::format("{}", value));
 }

--- a/subspace/string/__private/format_to_stream_unittest.cc
+++ b/subspace/string/__private/format_to_stream_unittest.cc
@@ -19,7 +19,10 @@
 
 #include "fmt/core.h"
 #include "googletest/include/gtest/gtest.h"
+#include "subspace/choice/choice.h"
+#include "subspace/containers/array.h"
 #include "subspace/prelude.h"
+#include "subspace/tuple/tuple.h"
 
 namespace {
 struct Streamable {};
@@ -75,6 +78,30 @@ TEST(FormatToStream, ToStreamWithADL) {
   StreamWithADL s;
   EXPECT_EQ(s.called, false);
   s << Streamable();
+  EXPECT_EQ(s.called, true);
+}
+
+// Array has a manually written stream impl, instead of using the macro.
+TEST(FormatToStream, Array) {
+  StreamWithADL s;
+  EXPECT_EQ(s.called, false);
+  s << sus::Array<i32, 3>::with_values(1, 2, 3);
+  EXPECT_EQ(s.called, true);
+}
+
+// Choice has a manually written stream impl, instead of using the macro.
+TEST(FormatToStream, Choice) {
+  StreamWithADL s;
+  EXPECT_EQ(s.called, false);
+  s << sus::Choice<sus_choice_types((1_i32, i32))>::with<1>(1);
+  EXPECT_EQ(s.called, true);
+}
+
+// Tuple has a manually written stream impl, instead of using the macro.
+TEST(FormatToStream, Tuple) {
+  StreamWithADL s;
+  EXPECT_EQ(s.called, false);
+  s << sus::Tuple<i32>::with(1);
   EXPECT_EQ(s.called, true);
 }
 

--- a/subspace/tuple/tuple.h
+++ b/subspace/tuple/tuple.h
@@ -339,9 +339,10 @@ struct fmt::formatter<::sus::tuple_type::Tuple<Types...>, Char> {
 
 // Stream support (written out manually due to use of template pack).
 namespace sus::tuple_type {
-template <class... Types>
-inline std::basic_ostream<char>& operator<<(std::basic_ostream<char>& stream,
-                                            const Tuple<Types...>& value) {
+template <class... Types,
+          ::sus::string::__private::StreamCanReceiveString<char> StreamType>
+inline StreamType& operator<<(StreamType& stream,
+                              const Tuple<Types...>& value) {
   return ::sus::string::__private::format_to_stream(stream,
                                                     fmt::format("{}", value));
 }


### PR DESCRIPTION
These three types manually write out their format-to-stream support due to template complications. Add unit tests for each one and update their implementation to support streaming to any stream sink, not just std::ostream.