### PR TITLE
Remove the requires clause on array

### DIFF
--- a/subspace/containers/array.h
+++ b/subspace/containers/array.h
@@ -39,6 +39,7 @@
 #include "subspace/mem/move.h"
 #include "subspace/mem/relocate.h"
 #include "subspace/num/num_concepts.h"
+#include "subspace/num/signed_integer.h"
 #include "subspace/num/unsigned_integer.h"
 #include "subspace/ops/eq.h"
 #include "subspace/ops/ord.h"
@@ -67,8 +68,8 @@ struct Storage<T, 0> final {};
 /// An Array can not be larger than `isize::MAX`, as subtracting a pointer at a
 /// greater distance results in Undefined Behaviour.
 template <class T, size_t N>
-  requires(N <= size_t{PTRDIFF_MAX})
 class Array final {
+  static_assert(N <= usize::from(isize::MAX));
   static_assert(!std::is_reference_v<T>,
                 "Array<T&, N> is invalid as Array must hold value types. Use "
                 "Array<T*, N> instead.");

--- a/subspace/containers/iterators/chunks.h
+++ b/subspace/containers/iterators/chunks.h
@@ -114,7 +114,6 @@ struct [[nodiscard]] [[sus_trivial_abi]] Chunks final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
   friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
@@ -229,8 +228,7 @@ struct [[nodiscard]] [[sus_trivial_abi]] ChunksMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const SliceMut<ItemT>& values,
@@ -332,8 +330,7 @@ struct [[nodiscard]] [[sus_trivial_abi]] ChunksExact final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const Slice<ItemT>& values,
@@ -445,8 +442,7 @@ struct [[nodiscard]] [[sus_trivial_abi]] ChunksExactMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const SliceMut<ItemT>& values,
@@ -570,8 +566,7 @@ struct [[nodiscard]] [[sus_trivial_abi]] RChunks final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const Slice<ItemT>& values,
@@ -674,8 +669,7 @@ struct [[nodiscard]] [[sus_trivial_abi]] RChunksMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const SliceMut<ItemT>& values,
@@ -777,8 +771,7 @@ struct [[nodiscard]] [[sus_trivial_abi]] RChunksExact final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const Slice<ItemT>& values,
@@ -888,8 +881,7 @@ struct [[nodiscard]] [[sus_trivial_abi]] RChunksExactMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const SliceMut<ItemT>& values,

--- a/subspace/containers/iterators/split.h
+++ b/subspace/containers/iterators/split.h
@@ -169,8 +169,7 @@ class [[nodiscard]] [[sus_trivial_abi]] Split final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -298,8 +297,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -435,8 +433,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusive final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(
       ::sus::iter::IterRef ref, const Slice<ItemT>& values,
@@ -561,8 +558,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusiveMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(
       ::sus::iter::IterRef ref, const SliceMut<ItemT>& values,
@@ -624,8 +620,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplit final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -681,8 +676,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplitMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -735,8 +729,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitN final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(Split<ItemT>&& split, usize n) noexcept {
     return SplitN(::sus::move(split), n);
@@ -783,8 +776,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitNMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(SplitMut<ItemT>&& split, usize n) noexcept {
     return SplitNMut(::sus::move(split), n);
@@ -832,8 +824,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplitN final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(RSplit<ItemT>&& split, usize n) noexcept {
     return RSplitN(::sus::move(split), n);
@@ -881,8 +872,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplitNMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(RSplitMut<ItemT>&& split, usize n) noexcept {
     return RSplitNMut(::sus::move(split), n);

--- a/subspace/containers/iterators/windows.h
+++ b/subspace/containers/iterators/windows.h
@@ -96,8 +96,7 @@ class [[nodiscard]] [[sus_trivial_abi]] Windows final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const Slice<ItemT>& values,
@@ -185,8 +184,7 @@ class [[nodiscard]] [[sus_trivial_abi]] WindowsMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    requires(N <= size_t{PTRDIFF_MAX})
-  friend class Array;
+    friend class Array;
 
   static constexpr auto with(::sus::iter::IterRef ref,
                              const SliceMut<ItemT>& values,

--- a/subspace/lib/__private/forward_decl.h
+++ b/subspace/lib/__private/forward_decl.h
@@ -28,7 +28,6 @@ class Choice;
 
 namespace sus::containers {
 template <class T, size_t N>
-  requires(N <= size_t{PTRDIFF_MAX})
 class Array;
 }
 


### PR DESCRIPTION
This fails to compile on clang 16, with it claiming that the forward declaration differs from the friend declaration, even though they have the same clause.

https://github.com/llvm/llvm-project/issues/58859#issuecomment-1638529533

It also makes things very noisy with little benefit - code won't need to branch based on Array<T, N> being a type, the way it can for an overload existing. So change it to a static_assert as we have done for other class-level requirements.

Avoid requires on types, keep it for functions/methods.