### PR TITLE
Prevent implicit temporary binding to const& in const&-holding types

### DIFF
--- a/subspace/option/option_unittest.cc
+++ b/subspace/option/option_unittest.cc
@@ -81,27 +81,45 @@ static_assert(sizeof(Option<LargerThanAPointer&>) ==
               sizeof(LargerThanAPointer*));
 
 template <class T, class = void, class... Args>
-struct is_some_callable : std::false_type {};
+struct is_with_callable : std::false_type {};
 
 template <class T, class... Args>
-struct is_some_callable<
+struct is_with_callable<
     T, std::void_t<decltype(T::with(std::declval<Args>()...))>, Args...>
     : std::true_type {};
 
 template <class T, class... Args>
-inline constexpr bool is_some_callable_v =
-    is_some_callable<T, void, Args...>::value;
+inline constexpr bool is_with_callable_v =
+    is_with_callable<T, void, Args...>::value;
 
-static_assert(is_some_callable_v<Option<int>, int>);
-static_assert(is_some_callable_v<Option<int>, const int>);
-static_assert(is_some_callable_v<Option<int>, int&>);
-static_assert(is_some_callable_v<Option<int>, int&&>);
-static_assert(is_some_callable_v<Option<int>, const int&>);
+static_assert(is_with_callable_v<Option<i32>, i32>);
+static_assert(is_with_callable_v<Option<i32>, const i32>);
+static_assert(is_with_callable_v<Option<i32>, i32&>);
+static_assert(is_with_callable_v<Option<i32>, i32&&>);
+static_assert(is_with_callable_v<Option<i32>, const i32&>);
 
-static_assert(!is_some_callable_v<Option<int&>, int>);
-static_assert(!is_some_callable_v<Option<int&>, const int>);
-static_assert(is_some_callable_v<Option<int&>, int&>);
-static_assert(!is_some_callable_v<Option<int&>, const int&>);
+static_assert(!is_with_callable_v<Option<i32&>, i32>);
+static_assert(!is_with_callable_v<Option<i32&>, const i32>);
+static_assert(is_with_callable_v<Option<i32&>, i32&>);
+static_assert(!is_with_callable_v<Option<i32&>, const i32&>);
+
+static_assert(is_with_callable_v<Option<const i32&>, i32>);
+static_assert(is_with_callable_v<Option<const i32&>, const i32&>);
+static_assert(is_with_callable_v<Option<const i32&>, i32&>);
+static_assert(is_with_callable_v<Option<const i32&>, i32&&>);
+static_assert(is_with_callable_v<Option<const i32&>, const i32&&>);
+
+// No conversion to a temporary.
+static_assert(is_with_callable_v<Option<i32>, i16>);
+static_assert(is_with_callable_v<Option<i32>, const i16&>);
+static_assert(is_with_callable_v<Option<i32>, i16&>);
+static_assert(is_with_callable_v<Option<i32>, i16&&>);
+static_assert(is_with_callable_v<Option<i32>, const i16&&>);
+static_assert(!is_with_callable_v<Option<const i32&>, i16>);
+static_assert(!is_with_callable_v<Option<const i32&>, const i16&>);
+static_assert(!is_with_callable_v<Option<const i32&>, i16&>);
+static_assert(!is_with_callable_v<Option<const i32&>, i16&&>);
+static_assert(!is_with_callable_v<Option<const i32&>, const i16&&>);
 
 TEST(Option, Construct) {
   {
@@ -1218,7 +1236,8 @@ TEST(Option, And) {
   auto iy = Option<NoCopyMove&>::with(mref(i2)).and_that(Option<NoCopyMove&>());
   IS_NONE(iy);
 
-  auto inx = Option<NoCopyMove&>().and_that(Option<NoCopyMove&>::with(mref(i3)));
+  auto inx =
+      Option<NoCopyMove&>().and_that(Option<NoCopyMove&>::with(mref(i3)));
   IS_NONE(inx);
 
   auto iny = Option<NoCopyMove&>().and_that(Option<NoCopyMove&>());

--- a/subspace/tuple/tuple_unittest.cc
+++ b/subspace/tuple/tuple_unittest.cc
@@ -119,6 +119,59 @@ TEST(Tuple, TailPadding) {
   static_assert(sizeof(ExampleFromDocs) == (16 + sus_if_msvc_else(8, 0)));
 }
 
+template <class T, class = void, class... Args>
+struct is_with_callable : std::false_type {};
+
+template <class T, class... Args>
+struct is_with_callable<
+    T, std::void_t<decltype(T::with(std::declval<Args>()...))>, Args...>
+    : std::true_type {};
+
+template <class T, class... Args>
+inline constexpr bool is_with_callable_v =
+    is_with_callable<T, void, Args...>::value;
+
+static_assert(is_with_callable_v<Tuple<i32>, i32>);
+static_assert(is_with_callable_v<Tuple<i32>, const i32>);
+static_assert(is_with_callable_v<Tuple<i32>, i32&>);
+static_assert(is_with_callable_v<Tuple<i32>, i32&&>);
+static_assert(is_with_callable_v<Tuple<i32>, const i32&>);
+
+static_assert(!is_with_callable_v<Tuple<i32&>, i32>);
+static_assert(!is_with_callable_v<Tuple<i32&>, const i32>);
+static_assert(is_with_callable_v<Tuple<i32&>, i32&>);
+static_assert(!is_with_callable_v<Tuple<i32&>, const i32&>);
+
+static_assert(is_with_callable_v<Tuple<const i32&>, i32>);
+static_assert(is_with_callable_v<Tuple<const i32&>, const i32&>);
+static_assert(is_with_callable_v<Tuple<const i32&>, i32&>);
+static_assert(is_with_callable_v<Tuple<const i32&>, i32&&>);
+static_assert(is_with_callable_v<Tuple<const i32&>, const i32&&>);
+
+// No conversion to a temporary.
+static_assert(is_with_callable_v<Tuple<i32>, i16>);
+static_assert(is_with_callable_v<Tuple<i32>, const i16&>);
+static_assert(is_with_callable_v<Tuple<i32>, i16&>);
+static_assert(is_with_callable_v<Tuple<i32>, i16&&>);
+static_assert(is_with_callable_v<Tuple<i32>, const i16&&>);
+static_assert(!is_with_callable_v<Tuple<const i32&>, i16>);
+static_assert(!is_with_callable_v<Tuple<const i32&>, const i16&>);
+static_assert(!is_with_callable_v<Tuple<const i32&>, i16&>);
+static_assert(!is_with_callable_v<Tuple<const i32&>, i16&&>);
+static_assert(!is_with_callable_v<Tuple<const i32&>, const i16&&>);
+// clang-format off
+static_assert(is_with_callable_v<Tuple<i32, i32>, i16, i16>);
+static_assert(is_with_callable_v<Tuple<i32, i32>, const i16&, const i16&>);
+static_assert(is_with_callable_v<Tuple<i32, i32>, i16&, i16&>);
+static_assert(is_with_callable_v<Tuple<i32, i32>, i16&&, i16&&>);
+static_assert(is_with_callable_v<Tuple<i32, i32>, const i16&, const i16&&>);
+static_assert(!is_with_callable_v<Tuple<i32, const i32&>, i16, i16>);
+static_assert(!is_with_callable_v<Tuple<i32, const i32&>, const i16&, const i16&>);
+static_assert(!is_with_callable_v<Tuple<i32, const i32&>, i16&, i16&>);
+static_assert(!is_with_callable_v<Tuple<i32, const i32&>, i16&&, i16&&>);
+static_assert(!is_with_callable_v<Tuple<i32, const i32&>, const i16&, const i16&&>);
+// clang-format on
+
 TEST(Tuple, With) {
   auto t1 = Tuple<i32>::with(2);
   auto t2 = Tuple<i32, f32>::with(2, 3.f);


### PR DESCRIPTION
A function receiving const T& and passed a U that is convertible to T will implicitly create a temporary T and pass the reference to that.

But if the function is going to store the reference, then this means it holds a pointer to a temporary. The Google style guide just forbids passing a const& at all in this case.

We use `sus::construct::SafelyConstructibleFromReference` to prevent implicit conversions at the caller, and apply this to the `with()` constructor methods on the three types that hold references: Option, Result, and Tuple.