### PR TITLE
Update Clang and fmtlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
           endif()
 
           execute_process(
-            COMMAND cmake --build out
+            COMMAND cmake --build out -j 10
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Install LLVM+Clang
         if: startsWith(matrix.config.os, 'ubuntu-')
         run: |
+          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 16 all

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,31 +29,45 @@ jobs:
           #    build_type: "Release", cc: "gcc", cxx: "g++"
           #  }
 
-          - {
-              name: "Ubuntu Clang Debug",
-              artifact: "Linux-Clang.tar.xz",
-              os: ubuntu-latest,
-              build_type: "Debug",
-              cc: "clang-16",
-              cxx: "clang++-16",
-            }
+        - {
+            name: "Ubuntu Clang-16 Debug",
+            os: ubuntu-latest,
+            build_type: "Debug",
+            cc: "clang-16",
+            cxx: "clang++-16",
+            clang_version: 16,
+            installed_clang_version: 14
+          }
 
-          - {
-              name: "Ubuntu Clang Sanitizer",
-              os: ubuntu-latest,
-              build_type: "Release",
-              cc: "clang-16",
-              cxx: "clang++-16",
-            }
+        - {
+            name: "Ubuntu Clang-17 Debug",
+            os: ubuntu-latest,
+            build_type: "Debug",
+            cc: "clang-17",
+            cxx: "clang++-17",
+            clang_version: 17,
+            installed_clang_version: 14
+          }
 
-          - {
-              name: "Ubuntu GCC",
-              artifact: "Linux-GCC.tar.xz",
-              os: ubuntu-latest,
-              build_type: "Release",
-              cc: "gcc-13",
-              cxx: "g++-13",
-            }
+        - {
+            name: "Ubuntu Clang-17 Sanitizer",
+            os: ubuntu-latest,
+            build_type: "Release",
+            cc: "clang-17",
+            cxx: "clang++-17",
+            clang_version: 17,
+            installed_clang_version: 14
+          }
+
+        - {
+            name: "Ubuntu GCC",
+            os: ubuntu-latest,
+            build_type: "Release",
+            cc: "gcc-13",
+            cxx: "g++-13",
+            clang_version: 17,
+            installed_clang_version: 14
+          }
 
           # Clang doesn't have good enough C++20 support to compile this library
           # yet.
@@ -72,10 +86,27 @@ jobs:
       - name: Install LLVM+Clang
         if: startsWith(matrix.config.os, 'ubuntu-')
         run: |
-          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
+          sudo apt-get remove clang-${{matrix.config.installed_clang_version}} \
+            lldb-${{matrix.config.installed_clang_version}} \
+            lld-${{matrix.config.installed_clang_version}} \
+            clangd-${{matrix.config.installed_clang_version}} \
+            clang-tidy-${{matrix.config.installed_clang_version}} \
+            clang-format-${{matrix.config.installed_clang_version}} \
+            clang-tools-${{matrix.config.installed_clang_version}} \
+            llvm-${{matrix.config.installed_clang_version}}-dev \
+            lld-${{matrix.config.installed_clang_version}} \
+            lldb-${{matrix.config.installed_clang_version}} \
+            llvm-${{matrix.config.installed_clang_version}}-tools \
+            libomp-${{matrix.config.installed_clang_version}}-dev \
+            libc++-${{matrix.config.installed_clang_version}}-dev \
+            libc++abi-${{matrix.config.installed_clang_version}}-dev \
+            libclang-common-${{matrix.config.installed_clang_version}}-dev \
+            libclang-${{matrix.config.installed_clang_version}}-dev \
+            libclang-cpp${{matrix.config.installed_clang_version}}-dev \
+            libunwind-${{matrix.config.installed_clang_version}}-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16 all
+          sudo ./llvm.sh ${{matrix.config.clang_version}} all
 
       - name: Install GCC 13
         if: matrix.config.name == 'Ubuntu GCC'
@@ -142,8 +173,8 @@ jobs:
           set(HAS_LLVM ON)
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             # Path to LLVM+Clang nightly that we have installed.
-            set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
-            set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
+            set(ENV{LLVM_DIR} "/usr/lib/llvm-${{matrix.config.clang_version}}/lib/cmake/llvm")
+            set(ENV{Clang_DIR} "/usr/lib/llvm-${{matrix.config.clang_version}}/lib/cmake/clang")
           else()
             # We don't have a copy of LLVM+Clang on the Windows bot.
             set(HAS_LLVM OFF)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,7 @@ jobs:
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
           sudo apt update
           sudo apt-get install g++-13
-          # GCC 13 and fmtlib error: https://github.com/fmtlib/fmt/issues/3533
-          echo "CXXFLAGS=$CXXFLAGS -Wno-stringop-overflow" >> $GITHUB_ENV
+          echo "CXXFLAGS=$CXXFLAGS" >> $GITHUB_ENV
 
       - name: Install Python3
         if: startsWith(matrix.config.os, 'ubuntu-')

--- a/.github/workflows/subdoc.yml
+++ b/.github/workflows/subdoc.yml
@@ -111,7 +111,7 @@ jobs:
           set(ENV{NINJA_STATUS} "[%f/%t %o/sec] ")
 
           execute_process(
-            COMMAND cmake --build out
+            COMMAND cmake --build out -j 10
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/.github/workflows/subdoc.yml
+++ b/.github/workflows/subdoc.yml
@@ -9,6 +9,9 @@ jobs:
     name: Generate documentation with subdoc
     if: github.repository == 'chromium/subspace'
     runs-on: ubuntu-latest
+    env:
+      clang_version: 17
+      installed_clang_version: 14
 
     steps:
       - uses: actions/checkout@v1
@@ -19,10 +22,27 @@ jobs:
 
       - name: Install LLVM+Clang
         run: |
-          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
+          sudo apt-get remove clang-${installed_clang_version} \
+            lldb-${installed_clang_version} \
+            lld-${installed_clang_version} \
+            clangd-${installed_clang_version} \
+            clang-tidy-${installed_clang_version} \
+            clang-format-${installed_clang_version} \
+            clang-tools-${installed_clang_version} \
+            llvm-${installed_clang_version}-dev \
+            lld-${installed_clang_version} \
+            lldb-${installed_clang_version} \
+            llvm-${installed_clang_version}-tools \
+            libomp-${installed_clang_version}-dev \
+            libc++-${installed_clang_version}-dev \
+            libc++abi-${installed_clang_version}-dev \
+            libclang-common-${installed_clang_version}-dev \
+            libclang-${installed_clang_version}-dev \
+            libclang-cpp${installed_clang_version}-dev \
+            libunwind-${installed_clang_version}-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16 all
+          sudo ./llvm.sh ${clang_version} all
 
       - name: Install Python3
         run: |
@@ -60,12 +80,12 @@ jobs:
       - name: Configure
         shell: cmake -P {0}
         run: |
-          set(ENV{CC} clang-16)
-          set(ENV{CXX} clang++-16)
+          set(ENV{CC} clang-$ENV{clang_version})
+          set(ENV{CXX} clang++-$ENV{clang_version})
 
           # Path to LLVM+Clang nightly that we have installed.
-          set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
-          set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
+          set(ENV{LLVM_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/llvm")
+          set(ENV{Clang_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/clang")
 
           file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 
@@ -103,12 +123,12 @@ jobs:
       - name: Reconfigure with tests
         shell: cmake -P {0}
         run: |
-          set(ENV{CC} clang-16)
-          set(ENV{CXX} clang++-16)
+          set(ENV{CC} clang-$ENV{clang_version})
+          set(ENV{CXX} clang++-$ENV{clang_version})
 
           # Path to LLVM+Clang nightly that we have installed.
-          set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
-          set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
+          set(ENV{LLVM_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/llvm")
+          set(ENV{Clang_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/clang")
 
           file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 
@@ -140,7 +160,7 @@ jobs:
       - name: Generate
         run: |
           # For crash dumps.
-          export LLVM_SYMBOLIZER_PATH="/usr/lib/llvm-16/bin/llvm-symbolizer"
+          export LLVM_SYMBOLIZER_PATH="/usr/lib/llvm-${clang_version}/bin/llvm-symbolizer"
 
           out/subdoc/subdoc \
             -p out \

--- a/.github/workflows/subdoc.yml
+++ b/.github/workflows/subdoc.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Install LLVM+Clang
         run: |
+          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 16 all

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -73,6 +73,7 @@ jobs:
       - name: Install LLVM+Clang
         if: startsWith(matrix.config.os, 'ubuntu-')
         run: |
+          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 16 all
@@ -226,6 +227,7 @@ jobs:
 
       - name: Install LLVM+Clang
         run: |
+          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 16 all

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -84,8 +84,7 @@ jobs:
           sudo add-apt-repository ppa:ubuntu-toolchain-r/ppa
           sudo apt update
           sudo apt-get install g++-13
-          # GCC 13 and fmtlib error: https://github.com/fmtlib/fmt/issues/3533
-          echo "CXXFLAGS=$CXXFLAGS -Wno-stringop-overflow" >> $GITHUB_ENV
+          echo "CXXFLAGS=$CXXFLAGS" >> $GITHUB_ENV
   
       - name: Install Python3
         if: startsWith(matrix.config.os, 'ubuntu-')

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -33,19 +33,33 @@ jobs:
           #  }
 
           - {
-              name: "Ubuntu Clang Debug",
+              name: "Ubuntu Clang-16 Debug",
               os: ubuntu-latest,
               build_type: "Debug",
               cc: "clang-16",
               cxx: "clang++-16",
+              clang_version: 16,
+              installed_clang_version: 14
             }
 
           - {
-              name: "Ubuntu Clang Sanitizer",
+              name: "Ubuntu Clang-17 Debug",
+              os: ubuntu-latest,
+              build_type: "Debug",
+              cc: "clang-17",
+              cxx: "clang++-17",
+              clang_version: 17,
+              installed_clang_version: 14
+            }
+
+          - {
+              name: "Ubuntu Clang-17 Sanitizer",
               os: ubuntu-latest,
               build_type: "Release",
-              cc: "clang-16",
-              cxx: "clang++-16",
+              cc: "clang-17",
+              cxx: "clang++-17",
+              clang_version: 17,
+              installed_clang_version: 14
             }
 
           - {
@@ -54,6 +68,8 @@ jobs:
               build_type: "Release",
               cc: "gcc-13",
               cxx: "g++-13",
+              clang_version: 17,
+              installed_clang_version: 14
             }
 
           # Clang doesn't have good enough C++20 support to compile this library
@@ -73,10 +89,27 @@ jobs:
       - name: Install LLVM+Clang
         if: startsWith(matrix.config.os, 'ubuntu-')
         run: |
-          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
+          sudo apt-get remove clang-${{matrix.config.installed_clang_version}} \
+            lldb-${{matrix.config.installed_clang_version}} \
+            lld-${{matrix.config.installed_clang_version}} \
+            clangd-${{matrix.config.installed_clang_version}} \
+            clang-tidy-${{matrix.config.installed_clang_version}} \
+            clang-format-${{matrix.config.installed_clang_version}} \
+            clang-tools-${{matrix.config.installed_clang_version}} \
+            llvm-${{matrix.config.installed_clang_version}}-dev \
+            lld-${{matrix.config.installed_clang_version}} \
+            lldb-${{matrix.config.installed_clang_version}} \
+            llvm-${{matrix.config.installed_clang_version}}-tools \
+            libomp-${{matrix.config.installed_clang_version}}-dev \
+            libc++-${{matrix.config.installed_clang_version}}-dev \
+            libc++abi-${{matrix.config.installed_clang_version}}-dev \
+            libclang-common-${{matrix.config.installed_clang_version}}-dev \
+            libclang-${{matrix.config.installed_clang_version}}-dev \
+            libclang-cpp${{matrix.config.installed_clang_version}}-dev \
+            libunwind-${{matrix.config.installed_clang_version}}-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16 all
+          sudo ./llvm.sh ${{matrix.config.clang_version}} all
 
       - name: Install GCC 13
         if: matrix.config.name == 'Ubuntu GCC'
@@ -143,8 +176,8 @@ jobs:
           set(HAS_LLVM ON)
           if (NOT "${{ runner.os }}" STREQUAL "Windows")
             # Path to LLVM+Clang nightly that we have installed.
-            set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
-            set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
+            set(ENV{LLVM_DIR} "/usr/lib/llvm-${{matrix.config.clang_version}}/lib/cmake/llvm")
+            set(ENV{Clang_DIR} "/usr/lib/llvm-${{matrix.config.clang_version}}/lib/cmake/clang")
           else()
             # We don't have a copy of LLVM+Clang on the Windows bot.
             set(HAS_LLVM OFF)
@@ -220,16 +253,36 @@ jobs:
   docs:
     name: Generate Subdoc
     runs-on: ubuntu-latest
+    env:
+      clang_version: 17
+      installed_clang_version: 14
 
     steps:
       - uses: actions/checkout@v1
 
       - name: Install LLVM+Clang
         run: |
-          sudo apt-get remove clang-14 lldb-14 lld-14 clangd-14 clang-tidy-14 clang-format-14 clang-tools-14 llvm-14-dev lld-14 lldb-14 llvm-14-tools libomp-14-dev libc++-14-dev libc++abi-14-dev libclang-common-14-dev libclang-14-dev libclang-cpp14-dev libunwind-14-dev
+          sudo apt-get remove clang-${installed_clang_version} \
+            lldb-${installed_clang_version} \
+            lld-${installed_clang_version} \
+            clangd-${installed_clang_version} \
+            clang-tidy-${installed_clang_version} \
+            clang-format-${installed_clang_version} \
+            clang-tools-${installed_clang_version} \
+            llvm-${installed_clang_version}-dev \
+            lld-${installed_clang_version} \
+            lldb-${installed_clang_version} \
+            llvm-${installed_clang_version}-tools \
+            libomp-${installed_clang_version}-dev \
+            libc++-${installed_clang_version}-dev \
+            libc++abi-${installed_clang_version}-dev \
+            libclang-common-${installed_clang_version}-dev \
+            libclang-${installed_clang_version}-dev \
+            libclang-cpp${installed_clang_version}-dev \
+            libunwind-${installed_clang_version}-dev
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
-          sudo ./llvm.sh 16 all
+          sudo ./llvm.sh ${clang_version} all
 
       - name: Install Python3
         run: |
@@ -267,12 +320,12 @@ jobs:
       - name: Configure
         shell: cmake -P {0}
         run: |
-          set(ENV{CC} clang-16)
-          set(ENV{CXX} clang++-16)
+          set(ENV{CC} clang-$ENV{clang_version})
+          set(ENV{CXX} clang++-$ENV{clang_version})
 
           # Path to LLVM+Clang nightly that we have installed.
-          set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
-          set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
+          set(ENV{LLVM_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/llvm")
+          set(ENV{Clang_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/clang")
 
           file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 
@@ -310,12 +363,12 @@ jobs:
       - name: Reconfigure with tests
         shell: cmake -P {0}
         run: |
-          set(ENV{CC} clang-16)
-          set(ENV{CXX} clang++-16)
+          set(ENV{CC} clang-$ENV{clang_version})
+          set(ENV{CXX} clang++-$ENV{clang_version})
 
           # Path to LLVM+Clang nightly that we have installed.
-          set(ENV{LLVM_DIR} "/usr/lib/llvm-16/lib/cmake/llvm")
-          set(ENV{Clang_DIR} "/usr/lib/llvm-16/lib/cmake/clang")
+          set(ENV{LLVM_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/llvm")
+          set(ENV{Clang_DIR} "/usr/lib/llvm-$ENV{clang_version}/lib/cmake/clang")
 
           file(TO_CMAKE_PATH "$ENV{GITHUB_WORKSPACE}/ninja" ninja_program)
 
@@ -341,7 +394,7 @@ jobs:
       - name: Generate
         run: |
           # For crash dumps.
-          export LLVM_SYMBOLIZER_PATH="/usr/lib/llvm-16/bin/llvm-symbolizer"
+          export LLVM_SYMBOLIZER_PATH="/usr/lib/llvm-${clang_version}/bin/llvm-symbolizer"
 
           out/subdoc/subdoc \
             -p out \

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -228,7 +228,7 @@ jobs:
           endif()
 
           execute_process(
-            COMMAND cmake --build build
+            COMMAND cmake --build build -j 10
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)
@@ -351,7 +351,7 @@ jobs:
           set(ENV{NINJA_STATUS} "[%f/%t %o/sec] ")
 
           execute_process(
-            COMMAND cmake --build out
+            COMMAND cmake --build out -j 10
             RESULT_VARIABLE result
           )
           if (NOT result EQUAL 0)

--- a/DEPS
+++ b/DEPS
@@ -7,7 +7,7 @@ vars = {
 
   'buildtools_revision': 'edbefcee3d2cc45cdb0c60c2b01b673f8ba728bc',
   'googletest_revision': 'ec25eea8f8237cf86c30703f59747e42f34b6f75',
-  'fmt_revision': '8e87d3a8bead3f37eb513af093f58a4222f45038',
+  'fmt_revision': '757564f5cd2fa78b634dd698c63dbf069818e6fd',
 }
 
 deps = {

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ check out which compiler versions are used by the
 | Compiler   | Version |
 |------------|---------|
 | **Clang:** | 16 and up |
-| **GCC**:   | 13 and up (with [-Wno-stringop-overflow](https://github.com/fmtlib/fmt/issues/3533)) |
+| **GCC**:   | 13 and up |
 | **MSVC**:   | 17.4.2 (not [newer versions](https://github.com/chromium/subspace/issues/267)) |
 
 We attempt to work around bugs when reasonable, to widen compiler version


### PR DESCRIPTION
Clang has branched for 17 and is now tracking HEAD as 18. For some reason part of that change has the clang-16 packages now conflicting with the clang-14 ones.

So remove the clang-14 packages before installing clang-16.

Roll fmtlib to pick up https://github.com/fmtlib/fmt/commit/fb97cb2318dd14b5c791699232e1e73782be7e57 and remove the GCC warning suppression.

Move the clang bots to 17, but keep a 16 bot around too.