### PR TITLE
Support method pointers for Fn concepts and Fn*Ref types

### DIFF
--- a/subdoc/lib/visit.cc
+++ b/subdoc/lib/visit.cc
@@ -528,7 +528,7 @@ class AstConsumer : public clang::ASTConsumer {
 
   void HandleTranslationUnit(clang::ASTContext& ast_cx) noexcept final {
     if (cx_.options.on_tu_complete.is_some()) {
-      (*cx_.options.on_tu_complete)(ast_cx);
+      ::sus::fn::call(*cx_.options.on_tu_complete, ast_cx);
     }
   }
 

--- a/subspace/construct/__private/into_ref.h
+++ b/subspace/construct/__private/into_ref.h
@@ -23,13 +23,13 @@ struct IntoRef final {
   [[nodiscard]] constexpr IntoRef(FromType&& from) noexcept
       : from_(static_cast<FromType&&>(from)) {}
 
-  template <std::same_as<std::remove_reference_t<FromType>> ToType>
+  template <std::same_as<std::decay_t<FromType>> ToType>
   constexpr operator ToType() && noexcept {
     return static_cast<ToType&&>(from_);
   }
 
   template <::sus::construct::From<FromType> ToType>
-    requires(!std::same_as<FromType, ToType>)
+    requires(!std::same_as<std::decay_t<FromType>, ToType>)
   constexpr operator ToType() && noexcept {
     return ToType::from(static_cast<FromType&&>(from_));
   }

--- a/subspace/containers/__private/slice_methods.inc
+++ b/subspace/containers/__private/slice_methods.inc
@@ -129,7 +129,8 @@ binary_search_by(
     // `size/2 < size`.  Thus `left + size/2 < left + size`, which coupled
     // with the `left + size <= len()` invariant means we have
     // `left + size/2 < len()`, and this is in-bounds.
-    auto cmp = f(get_unchecked(::sus::marker::unsafe_fn, mid));
+    auto cmp =
+        ::sus::fn::call_mut(f, get_unchecked(::sus::marker::unsafe_fn, mid));
 
     // The order of these comparisons comes from the Rust stdlib and is
     // performance sensitive.
@@ -172,8 +173,9 @@ template <::sus::ops::Ord Key>
     Result<::sus::num::usize, ::sus::num::usize> constexpr binary_search_by_key(
         const Key& key,
         ::sus::fn::FnMut<Key(const T&)> auto&& f) const& noexcept {
-  return binary_search_by(
-      [&key, &f](const T& p) -> std::strong_ordering { return f(p) <=> key; });
+  return binary_search_by([&key, &f](const T& p) -> std::strong_ordering {
+    return ::sus::fn::call_mut(f, p) <=> key;
+  });
 }
 
 /// Returns an iterator over `chunk_size` elements of the slice at a time,
@@ -519,7 +521,7 @@ constexpr ::sus::Option<const T&> last() && = delete;
 constexpr ::sus::num::usize partition_point(
     ::sus::fn::FnMutRef<bool(const T&)> pred) const& noexcept {
   return binary_search_by([pred = ::sus::move(pred)](const T& x) {
-           if (pred(x)) {
+           if (::sus::fn::call_mut(pred, x)) {
              return std::strong_ordering::less;
            } else {
              return std::strong_ordering::greater;

--- a/subspace/containers/__private/slice_mut_methods.inc
+++ b/subspace/containers/__private/slice_mut_methods.inc
@@ -236,7 +236,7 @@ constexpr void fill_with(::sus::fn::FnMutRef<T()> f) NO_RETURN_REF noexcept {
   T* ptr = as_mut_ptr();
   T* const end_ptr = ptr + len();
   while (ptr != end_ptr) {
-    *ptr = f();
+    *ptr = ::sus::fn::call_mut(f);
     ptr += 1u;
   }
 }
@@ -622,7 +622,7 @@ template <::sus::fn::FnMut<::sus::fn::NonVoid(const T&)> KeyFn, int&...,
 ::sus::Tuple<SliceMut<T>, T&, SliceMut<T>> select_nth_unstable_by_key(
     usize index, KeyFn f) RETURN_REF noexcept {
   return select_nth_unstable_by(
-      index, [&f](const T& a, const T& b) { return f(a) <=> f(b); });
+      index, [&f](const T& a, const T& b) { return ::sus::fn::call_mut(f, a) <=> ::sus::fn::call_mut(f, b); });
 }
 #endif
 
@@ -665,9 +665,10 @@ void sort() NO_RETURN_REF noexcept
 void sort_by(::sus::fn::FnMutRef<std::strong_ordering(const T&, const T&)>
                  compare) NO_RETURN_REF noexcept {
   if (len() > ::sus::num::usize(0u)) {
-    std::stable_sort(
-        as_mut_ptr(), as_mut_ptr() + len(),
-        [&compare](const T& l, const T& r) { return compare(l, r) < 0; });
+    std::stable_sort(as_mut_ptr(), as_mut_ptr() + len(),
+                     [&compare](const T& l, const T& r) {
+                       return ::sus::fn::call_mut(compare, l, r) < 0;
+                     });
   }
 }
 
@@ -693,7 +694,9 @@ template <::sus::fn::FnMut<::sus::fn::NonVoid(const T&)> KeyFn, int&...,
           class Key = std::invoke_result_t<KeyFn&, const T&>>
   requires(::sus::ops::Ord<Key>)
 void sort_by_key(KeyFn f) NO_RETURN_REF noexcept {
-  return sort_by([&f](const T& a, const T& b) { return f(a) <=> f(b); });
+  return sort_by([&f](const T& a, const T& b) {
+    return ::sus::fn::call_mut(f, a) <=> ::sus::fn::call_mut(f, b);
+  });
 }
 
 template <::sus::fn::FnMut<::sus::fn::NonVoid(const T&)> KeyFn, int&...,
@@ -764,7 +767,9 @@ constexpr void sort_unstable_by(
     NO_RETURN_REF noexcept {
   if (len() > 0u) {
     std::sort(as_mut_ptr(), as_mut_ptr() + len(),
-              [&compare](const T& l, const T& r) { return compare(l, r) < 0; });
+              [&compare](const T& l, const T& r) {
+                return ::sus::fn::call_mut(compare, l, r) < 0;
+              });
   }
 }
 
@@ -781,8 +786,9 @@ template <::sus::fn::FnMut<::sus::fn::NonVoid(const T&)> KeyFn, int&...,
           class Key = std::invoke_result_t<KeyFn&, const T&>>
   requires(::sus::ops::Ord<Key>)
 void sort_unstable_by_key(KeyFn f) NO_RETURN_REF noexcept {
-  return sort_unstable_by(
-      [&f](const T& a, const T& b) { return f(a) <=> f(b); });
+  return sort_unstable_by([&f](const T& a, const T& b) {
+    return ::sus::fn::call_mut(f, a) <=> ::sus::fn::call_mut(f, b);
+  });
 }
 
 /// Returns an iterator over mutable subslices separated by elements that match

--- a/subspace/containers/array.h
+++ b/subspace/containers/array.h
@@ -358,7 +358,7 @@ class Array final {
   constexpr Array(WithInitializer, ::sus::fn::FnMut<T()> auto&& f,
                   std::index_sequence<Is...>) noexcept
       : storage_(::sus::iter::IterRefCounter::for_owner(),
-                 {((void)Is, f())...}) {}
+                 {((void)Is, ::sus::fn::call_mut(f))...}) {}
 
   enum WithValue { kWithValue };
   template <size_t... Is>

--- a/subspace/containers/iterators/split.h
+++ b/subspace/containers/iterators/split.h
@@ -115,7 +115,7 @@ class [[nodiscard]] [[sus_trivial_abi]] Split final
       if (o.is_none()) {
         return finish();
       }
-      if (pred_(*o)) {
+      if (::sus::fn::call_mut(pred_, *o)) {
         ret = Option<Item>::with(v_[::sus::ops::RangeTo(idx)]);
         v_ = v_[::sus::ops::RangeFrom(idx + 1u)];
         return ret;
@@ -141,7 +141,7 @@ class [[nodiscard]] [[sus_trivial_abi]] Split final
         return finish();
       }
       idx -= 1u;
-      if (pred_(*o)) {
+      if (::sus::fn::call_mut(pred_, *o)) {
         ret = Option<Item>::with(v_[::sus::ops::RangeFrom(idx + 1u)]);
         v_ = v_[::sus::ops::RangeTo(idx)];
         return ret;
@@ -169,7 +169,7 @@ class [[nodiscard]] [[sus_trivial_abi]] Split final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -243,7 +243,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitMut final
       if (o.is_none()) {
         return finish();
       }
-      if (pred_(*o)) {
+      if (::sus::fn::call_mut(pred_, *o)) {
         ret = Option<Item>::with(v_[::sus::ops::RangeTo(idx)]);
         v_ = v_[::sus::ops::RangeFrom(idx + 1u)];
         return ret;
@@ -269,7 +269,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitMut final
         return finish();
       }
       idx -= 1u;
-      if (pred_(*o)) {
+      if (::sus::fn::call_mut(pred_, *o)) {
         ret = Option<Item>::with(v_[::sus::ops::RangeFrom(idx + 1u)]);
         v_ = v_[::sus::ops::RangeTo(idx)];
         return ret;
@@ -297,7 +297,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -370,7 +370,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusive final
     auto it = v_.iter();
     while (true) {
       Option<const ItemT&> o = it.next();
-      if (o.is_none() || pred_(*o)) {
+      if (o.is_none() || ::sus::fn::call_mut(pred_, *o)) {
         if (idx >= last) {
           finished_ = true;
           idx = last;
@@ -401,7 +401,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusive final
     auto it = remainder.iter().rev();
     while (true) {
       Option<const ItemT&> o = it.next();
-      if (o.is_none() || pred_(*o)) {
+      if (o.is_none() || ::sus::fn::call_mut(pred_, *o)) {
         if (idx == 0u) {
           finished_ = true;
         }
@@ -433,7 +433,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusive final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   static constexpr auto with(
       ::sus::iter::IterRef ref, const Slice<ItemT>& values,
@@ -494,7 +494,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusiveMut final
     auto it = v_.iter();
     while (true) {
       Option<const ItemT&> o = it.next();
-      if (o.is_none() || pred_(*o)) {
+      if (o.is_none() || ::sus::fn::call_mut(pred_, *o)) {
         if (idx >= last) {
           finished_ = true;
           idx = last;
@@ -526,7 +526,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusiveMut final
     auto it = remainder.iter().rev();
     while (true) {
       Option<const ItemT&> o = it.next();
-      if (o.is_none() || pred_(*o)) {
+      if (o.is_none() || ::sus::fn::call_mut(pred_, *o)) {
         if (idx == 0u) {
           finished_ = true;
         }
@@ -558,7 +558,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitInclusiveMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   static constexpr auto with(
       ::sus::iter::IterRef ref, const SliceMut<ItemT>& values,
@@ -620,7 +620,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplit final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -676,7 +676,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplitMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   // Access to finish().
   template <class A, ::sus::iter::Iterator<A> B>
@@ -729,7 +729,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitN final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   static constexpr auto with(Split<ItemT>&& split, usize n) noexcept {
     return SplitN(::sus::move(split), n);
@@ -776,7 +776,7 @@ class [[nodiscard]] [[sus_trivial_abi]] SplitNMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   static constexpr auto with(SplitMut<ItemT>&& split, usize n) noexcept {
     return SplitNMut(::sus::move(split), n);
@@ -824,7 +824,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplitN final
   friend class Slice<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   static constexpr auto with(RSplit<ItemT>&& split, usize n) noexcept {
     return RSplitN(::sus::move(split), n);
@@ -872,7 +872,7 @@ class [[nodiscard]] [[sus_trivial_abi]] RSplitNMut final
   friend class SliceMut<ItemT>;
   friend class Vec<ItemT>;
   template <class ArrayItemT, size_t N>
-    friend class Array;
+  friend class Array;
 
   static constexpr auto with(RSplitMut<ItemT>&& split, usize n) noexcept {
     return RSplitNMut(::sus::move(split), n);

--- a/subspace/fn/__private/callable_types.h
+++ b/subspace/fn/__private/callable_types.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <concepts>
+#include <functional>
 #include <type_traits>
 
 #include "subspace/mem/forward.h"
@@ -27,7 +28,7 @@ namespace sus::fn::__private {
 template <class F, class R, class... Args>
 concept FunctionPointer =
     std::is_pointer_v<std::decay_t<F>> && requires(F f, Args... args) {
-      { (*f)(args...) } -> std::convertible_to<R>;
+      { std::invoke(*f, args...) } -> std::convertible_to<R>;
     };
 
 /// Whether a functor `T` is a function pointer.
@@ -49,7 +50,7 @@ template <class F, class R, class... Args>
 concept CallableOnceMut =
     !FunctionPointer<F, R, Args...> && requires(F&& f, Args... args) {
       {
-        ::sus::move(f)(::sus::forward<Args>(args)...)
+        std::invoke(::sus::move(f), ::sus::forward<Args>(args)...)
       } -> std::convertible_to<R>;
     };
 
@@ -59,7 +60,9 @@ concept CallableOnceMut =
 template <class F, class R, class... Args>
 concept CallableMut =
     !FunctionPointer<F, R, Args...> && requires(F& f, Args... args) {
-      { f(::sus::forward<Args>(args)...) } -> std::convertible_to<R>;
+      {
+        std::invoke(f, ::sus::forward<Args>(args)...)
+      } -> std::convertible_to<R>;
     };
 
 /// Whether a functor `F` is a callable object (with an `operator()`) that is
@@ -68,7 +71,9 @@ concept CallableMut =
 template <class F, class R, class... Args>
 concept CallableConst =
     !FunctionPointer<F, R, Args...> && requires(const F& f, Args... args) {
-      { f(::sus::forward<Args>(args)...) } -> std::convertible_to<R>;
+      {
+        std::invoke(f, ::sus::forward<Args>(args)...)
+      } -> std::convertible_to<R>;
     };
 
 }  // namespace sus::fn::__private

--- a/subspace/fn/__private/fn_ref_invoker.h
+++ b/subspace/fn/__private/fn_ref_invoker.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <functional>
+
 #include "subspace/mem/forward.h"
 #include "subspace/mem/move.h"
 
@@ -33,21 +35,21 @@ struct Invoker {
   template <class R, class... Args>
   static R fnptr_call_mut(const union Storage& s, Args... args) {
     F f = reinterpret_cast<F>(s.fnptr);
-    return (*f)(::sus::forward<Args>(args)...);
+    return std::invoke(*f, ::sus::forward<Args>(args)...);
   }
 
   /// Calls the `F` in `Storage`, as an lvalue, when it is a callable object.
   template <class R, class... Args>
   static R object_call_mut(const union Storage& s, Args... args) {
     F& f = *static_cast<F*>(s.object);
-    return f(::sus::forward<Args>(args)...);
+    return std::invoke(f, ::sus::forward<Args>(args)...);
   }
 
   /// Calls the `F` in `Storage`, as an rvalue, when it is a callable object.
   template <class R, class... Args>
   static R object_call_once(const union Storage& s, Args... args) {
     F& f = *static_cast<F*>(s.object);
-    return ::sus::move(f)(::sus::forward<Args>(args)...);
+    return std::invoke(::sus::move(f), ::sus::forward<Args>(args)...);
   }
 
   /// Calls the `F` in `Storage`, allowing only const overloads, when it is a
@@ -55,7 +57,7 @@ struct Invoker {
   template <class R, class... Args>
   static R fnptr_call_const(const union Storage& s, Args... args) {
     const F f = reinterpret_cast<const F>(s.fnptr);
-    return (*f)(::sus::forward<Args>(args)...);
+    return std::invoke(*f, ::sus::forward<Args>(args)...);
   }
 
   /// Calls the `F` in `Storage`, as a const object, when it is a callable
@@ -63,7 +65,7 @@ struct Invoker {
   template <class R, class... Args>
   static R object_call_const(const union Storage& s, Args... args) {
     const F& f = *static_cast<const F*>(s.object);
-    return f(::sus::forward<Args>(args)...);
+    return std::invoke(f, ::sus::forward<Args>(args)...);
   }
 };
 

--- a/subspace/fn/__private/signature.h
+++ b/subspace/fn/__private/signature.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <concepts>
+#include <functional>
 
 #include "subspace/mem/forward.h"
 
@@ -67,10 +68,10 @@ struct InvokedFnOnce {
 
 template <class F, class... Ts>
   requires requires(F&& f) {
-    { ::sus::forward<F>(f)(std::declval<Ts>()...) };
+    { std::invoke(::sus::forward<F>(f), std::declval<Ts>()...) };
   }
 struct InvokedFnOnce<F, ArgsPack<Ts...>> {
-  static decltype(std::declval<F&&>()(std::declval<Ts>()...)) returns();
+  static std::invoke_result_t<F&&, Ts...> returns();
 };
 
 /// Unpacks an `ArgsPack` of function argument types, and determines if a
@@ -86,10 +87,10 @@ struct InvokedFnMut {
 
 template <class F, class... Ts>
   requires requires(F f) {
-    { f(std::declval<Ts>()...) };
+    { std::invoke(f, std::declval<Ts>()...) };
   }
 struct InvokedFnMut<F, ArgsPack<Ts...>> {
-  static decltype(std::declval<F>()(std::declval<Ts>()...)) returns();
+  static std::invoke_result_t<F, Ts...> returns();
 };
 
 /// Unpacks an `ArgsPack` of function argument types, and determines if a
@@ -105,10 +106,10 @@ struct InvokedFn {
 
 template <class F, class... Ts>
   requires requires(const F& f) {
-    { f(std::declval<Ts>()...) };
+    { std::invoke(f, std::declval<Ts>()...) };
   }
 struct InvokedFn<F, ArgsPack<Ts...>> {
-  static decltype(std::declval<const F&>()(std::declval<Ts>()...)) returns();
+  static std::invoke_result_t<const F&, Ts...> returns();
 };
 
 /// Whether the `ReturnType` of a functor is compatible with receiving it as

--- a/subspace/fn/fn_concepts.h
+++ b/subspace/fn/fn_concepts.h
@@ -125,6 +125,21 @@ struct Anything {
 /// auto c = Class(42);
 /// sus::check(map_class_once(c, &Class::value) == 42);
 /// ```
+///
+/// Using a method pointer as the parameter for `Option::map()` will call that
+/// method on the object inside the Option:
+/// ```
+/// struct Class {
+///   Class(i32 value) : value_(value) {}
+///   i32 value() const { return value_; }
+///
+///  private:
+///   i32 value_;
+/// };
+///
+/// auto o = sus::Option<Class>::with(Class(42));
+/// sus::check(o.map(&Class::value) == sus::some(42));
+/// ```
 template <class F, class... S>
 concept FnOnce = requires {
   // Receives and passes along the signature as a pack instead of a single
@@ -222,6 +237,21 @@ concept FnOnce = requires {
 /// auto c = Class(42);
 /// sus::check(map_class_mut(c, &Class::value) == 42);
 /// ```
+///
+/// Using a method pointer as the parameter for `Option::map()` will call that
+/// method on the object inside the Option:
+/// ```
+/// struct Class {
+///   Class(i32 value) : value_(value) {}
+///   i32 value() const { return value_; }
+///
+///  private:
+///   i32 value_;
+/// };
+///
+/// auto o = sus::Option<Class>::with(Class(42));
+/// sus::check(o.map(&Class::value) == sus::some(42));
+/// ```
 template <class F, class... S>
 concept FnMut = requires {
   // Receives and passes along the signature as a pack instead of a single
@@ -318,6 +348,21 @@ concept FnMut = requires {
 /// // Map the class C to its value().
 /// auto c = Class(42);
 /// sus::check(map_class(c, &Class::value) == 42);
+/// ```
+///
+/// Using a method pointer as the parameter for `Option::map()` will call that
+/// method on the object inside the Option:
+/// ```
+/// struct Class {
+///   Class(i32 value) : value_(value) {}
+///   i32 value() const { return value_; }
+///
+///  private:
+///   i32 value_;
+/// };
+///
+/// auto o = sus::Option<Class>::with(Class(42));
+/// sus::check(o.map(&Class::value) == sus::some(42));
 /// ```
 template <class F, class... S>
 concept Fn = requires {

--- a/subspace/fn/fn_concepts.h
+++ b/subspace/fn/fn_concepts.h
@@ -89,7 +89,8 @@ struct Anything {
 /// `FnOnceRef`. And `FnBox` is convertible to `FnMutBox` is convertible to
 /// `FnOnceBox`.
 ///
-/// # Example
+/// # Examples
+/// A function that receives a `FnOnce` matching type and calls it:
 /// ```
 /// // Accepts any type that can be called once with (Option<i32>) and returns
 /// // i32.
@@ -101,6 +102,28 @@ struct Anything {
 ///   return sus::move(o).unwrap_or_default() + 4;
 /// });
 ///  sus::check(x == 400 + 4);
+/// ```
+///
+/// A `FnOnce` whose first parameter is a class can be matched with a method
+/// from that same class if the remaining parameters match the method's
+/// signature:
+/// ```
+/// struct Class {
+///   Class(i32 value) : value_(value) {}
+///   i32 value() const { return value_; }
+///
+///  private:
+///   i32 value_;
+/// };
+///
+/// i32 map_class_once(const Class& c,
+///                    sus::fn::FnOnce<i32(const Class&)> auto&& f) {
+///   return sus::fn::call_once(sus::move(f), c);
+/// }
+///
+/// // Map the class C to its value().
+/// auto c = Class(42);
+/// sus::check(map_class_once(c, &Class::value) == 42);
 /// ```
 template <class F, class... S>
 concept FnOnce = requires {
@@ -162,7 +185,8 @@ concept FnOnce = requires {
 /// `FnOnceRef`. And `FnBox` is convertible to `FnMutBox` is convertible to
 /// `FnOnceBox`.
 ///
-/// # Example
+/// # Examples
+/// A function that receives a `FnMut` matching type and calls it:
 /// ```
 /// // Accepts any type that can be called once with (Option<i32>) and returns
 /// // i32.
@@ -176,6 +200,27 @@ concept FnOnce = requires {
 ///   return sus::move(o).unwrap_or_default() + i;
 /// });
 /// sus::check(x == 401 + 102);
+/// ```
+///
+/// A `FnMut` whose first parameter is a class can be matched with a method from
+/// that same class if the remaining parameters match the method's signature:
+/// ```
+/// struct Class {
+///   Class(i32 value) : value_(value) {}
+///   i32 value() const { return value_; }
+///
+///  private:
+///   i32 value_;
+/// };
+///
+/// i32 map_class_mut(const Class& c,
+///                   sus::fn::FnMut<i32(const Class&)> auto&& f) {
+///   return sus::fn::call_mut(f, c);
+/// }
+///
+/// // Map the class C to its value().
+/// auto c = Class(42);
+/// sus::check(map_class_mut(c, &Class::value) == 42);
 /// ```
 template <class F, class... S>
 concept FnMut = requires {
@@ -238,7 +283,8 @@ concept FnMut = requires {
 /// `FnOnceRef`. And `FnBox` is convertible to `FnMutBox` is convertible to
 /// `FnOnceBox`.
 ///
-/// # Example
+/// # Examples
+/// A function that receives a `Fn` matching type and calls it:
 /// ```
 /// // Accepts any type that can be called once with (Option<i32>) and returns
 /// // i32.
@@ -251,6 +297,27 @@ concept FnMut = requires {
 ///   return sus::move(o).unwrap_or_default() + i;
 /// });
 /// sus::check(x == 401 + 101);
+/// ```
+///
+/// A `Fn` whose first parameter is a class can be matched with a method from
+/// that same class if the remaining parameters match the method's signature:
+/// ```
+/// struct Class {
+///   Class(i32 value) : value_(value) {}
+///   i32 value() const { return value_; }
+///
+///  private:
+///   i32 value_;
+/// };
+///
+/// i32 map_class(const Class& c,
+///               sus::fn::Fn<i32(const Class&)> auto const& f) {
+///   return sus::fn::call(f, c);
+/// }
+///
+/// // Map the class C to its value().
+/// auto c = Class(42);
+/// sus::check(map_class(c, &Class::value) == 42);
 /// ```
 template <class F, class... S>
 concept Fn = requires {

--- a/subspace/fn/fn_concepts_unittest.cc
+++ b/subspace/fn/fn_concepts_unittest.cc
@@ -449,6 +449,9 @@ TEST(FnConcepts, Example_Method) {
   sus::check(map_class_once(c, &Class::value) == 42);
   sus::check(map_class_mut(c, &Class::value) == 42);
   sus::check(map_class(c, &Class::value) == 42);
+
+  auto o = sus::Option<Class>::with(Class(42));
+  sus::check(o.map(&Class::value) == sus::some(42));
 }
 
 }  // namespace

--- a/subspace/fn/fn_concepts_unittest.cc
+++ b/subspace/fn/fn_concepts_unittest.cc
@@ -422,4 +422,33 @@ TEST(Fn, Methods) {
   }
 }
 
+struct Class {
+  Class(i32 value) : value_(value) {}
+  i32 value() const { return value_; }
+
+ private:
+  i32 value_;
+};
+
+i32 map_class_once(const Class& c,
+                   sus::fn::FnOnce<i32(const Class&)> auto&& f) {
+  return sus::fn::call_once(sus::move(f), c);
+}
+
+i32 map_class_mut(const Class& c, sus::fn::FnMut<i32(const Class&)> auto&& f) {
+  return sus::fn::call_mut(f, c);
+}
+
+i32 map_class(const Class& c, sus::fn::Fn<i32(const Class&)> auto const& f) {
+  return sus::fn::call(f, c);
+}
+
+TEST(FnConcepts, Example_Method) {
+  // Map the class C to its value().
+  auto c = Class(42);
+  sus::check(map_class_once(c, &Class::value) == 42);
+  sus::check(map_class_mut(c, &Class::value) == 42);
+  sus::check(map_class(c, &Class::value) == 42);
+}
+
 }  // namespace

--- a/subspace/iter/__private/iter_compare.h
+++ b/subspace/iter/__private/iter_compare.h
@@ -44,7 +44,7 @@ inline Ordering iter_compare(
       value = Ordering::greater;
       return value;
     } else {
-      value = f(item_a.as_value(), item_b.as_value());
+      value = ::sus::fn::call_mut(f, item_a.as_value(), item_b.as_value());
       if (!(value == 0)) return value;
       // Otherwise, try the next pair of elements.
     }
@@ -71,7 +71,7 @@ inline bool iter_compare_eq(
       value = false;
       return value;
     } else {
-      value = f(item_a.as_value(), item_b.as_value());
+      value = ::sus::fn::call_mut(f, item_a.as_value(), item_b.as_value());
       if (!value) return value;
       // Otherwise, try the next pair of elements.
     }

--- a/subspace/iter/chain.h
+++ b/subspace/iter/chain.h
@@ -29,7 +29,7 @@ constexpr inline Option<U> and_then_or_clear(
   if (opt.is_none()) {
     return Option<U>();
   } else {
-    return f(*opt).or_else([&opt]() {
+    return ::sus::fn::call_once(::sus::move(f), *opt).or_else([&opt]() {
       opt = Option<T>();
       return Option<U>();
     });

--- a/subspace/iter/filter.h
+++ b/subspace/iter/filter.h
@@ -40,12 +40,10 @@ class [[nodiscard]] [[sus_trivial_abi]] Filter final
 
   // sus::iter::Iterator trait.
   Option<Item> next() noexcept {
-    InnerSizedIter& iter = next_iter_;
-    Pred& pred = pred_;
-
     while (true) {
-      Option<Item> item = iter.next();
-      if (item.is_none() || pred(item.as_value())) return item;
+      Option<Item> item = next_iter_.next();
+      if (item.is_none() || ::sus::fn::call_mut(pred_, item.as_value()))
+        return item;
     }
   }
   /// sus::iter::Iterator trait.
@@ -58,13 +56,11 @@ class [[nodiscard]] [[sus_trivial_abi]] Filter final
   Option<Item> next_back() noexcept
     requires(InnerSizedIter::DoubleEnded)
   {
-    InnerSizedIter& iter = next_iter_;
-    Pred& pred = pred_;
-
     // TODO: Just call find(pred) on itself?
     while (true) {
-      Option<Item> item = iter.next_back();
-      if (item.is_none() || pred(item.as_value())) return item;
+      Option<Item> item = next_iter_.next_back();
+      if (item.is_none() || ::sus::fn::call_mut(pred_, item.as_value()))
+        return item;
     }
   }
 
@@ -72,11 +68,11 @@ class [[nodiscard]] [[sus_trivial_abi]] Filter final
   template <class U, class V>
   friend class IteratorBase;
 
-  static Filter with(Pred && pred, InnerSizedIter && next_iter) noexcept {
+  static Filter with(Pred&& pred, InnerSizedIter&& next_iter) noexcept {
     return Filter(::sus::move(pred), ::sus::move(next_iter));
   }
 
-  Filter(Pred && pred, InnerSizedIter && next_iter) noexcept
+  Filter(Pred&& pred, InnerSizedIter&& next_iter) noexcept
       : pred_(::sus::move(pred)), next_iter_(::sus::move(next_iter)) {}
 
   Pred pred_;

--- a/subspace/iter/filter_map.h
+++ b/subspace/iter/filter_map.h
@@ -46,14 +46,11 @@ class [[nodiscard]] [[sus_trivial_abi]] FilterMap final
 
   // sus::iter::Iterator trait.
   Option<Item> next() noexcept {
-    InnerSizedIter& iter = next_iter_;
-    FilterMapFn& fn = fn_;
-
     while (true) {
-      Option<FromItem> in = iter.next();
+      Option<FromItem> in = next_iter_.next();
       Option<ToItem> out;
       if (in.is_none()) return out;
-      out = fn_(sus::move(in).unwrap());
+      out = ::sus::fn::call_mut(fn_, sus::move(in).unwrap());
       if (out.is_some()) return out;
     }
   }
@@ -68,14 +65,11 @@ class [[nodiscard]] [[sus_trivial_abi]] FilterMap final
   Option<Item> next_back() noexcept
     requires(InnerSizedIter::DoubleEnded)
   {
-    InnerSizedIter& iter = next_iter_;
-    FilterMapFn& fn = fn_;
-
     while (true) {
-      Option<FromItem> in = iter.next_back();
+      Option<FromItem> in = next_iter_.next_back();
       Option<ToItem> out;
       if (in.is_none()) return out;
-      out = fn_(sus::move(in).unwrap());
+      out = ::sus::fn::call_mut(fn_, sus::move(in).unwrap());
       if (out.is_some()) return out;
     }
   }
@@ -84,12 +78,11 @@ class [[nodiscard]] [[sus_trivial_abi]] FilterMap final
   template <class U, class V>
   friend class IteratorBase;
 
-  static FilterMap with(FilterMapFn && fn,
-                        InnerSizedIter && next_iter) noexcept {
+  static FilterMap with(FilterMapFn&& fn, InnerSizedIter&& next_iter) noexcept {
     return FilterMap(::sus::move(fn), ::sus::move(next_iter));
   }
 
-  FilterMap(FilterMapFn && fn, InnerSizedIter && next_iter) noexcept
+  FilterMap(FilterMapFn&& fn, InnerSizedIter&& next_iter) noexcept
       : fn_(::sus::move(fn)), next_iter_(::sus::move(next_iter)) {}
 
   FilterMapFn fn_;

--- a/subspace/iter/flat_map.h
+++ b/subspace/iter/flat_map.h
@@ -52,8 +52,9 @@ class [[nodiscard]] FlatMap final
         front_iter_ = Option<EachIter>();
       }
       // Otherwise grab the next iterator into front_iter_.
-      front_iter_ = iters_.next().map(
-          [this](auto&& i) { return map_fn_(::sus::move(i)).into_iter(); });
+      front_iter_ = iters_.next().map([this](auto&& i) {
+        return ::sus::fn::call_mut(map_fn_, ::sus::move(i)).into_iter();
+      });
       if (front_iter_.is_none()) break;
     }
     // There's no more iterator to place in front_iter_. Take an item off
@@ -96,8 +97,9 @@ class [[nodiscard]] FlatMap final
         back_iter_ = Option<EachIter>();
       }
       // Otherwise grab the next iterator into back_iter_.
-      back_iter_ = iters_.next_back().map(
-          [this](auto&& i) { return map_fn_(::sus::move(i)).into_iter(); });
+      back_iter_ = iters_.next_back().map([this](auto&& i) {
+        return ::sus::fn::call_mut(map_fn_, ::sus::move(i)).into_iter();
+      });
       if (back_iter_.is_none()) break;
     }
     // There's no more iterator to place in back_iter_. Take an item off

--- a/subspace/iter/inspect.h
+++ b/subspace/iter/inspect.h
@@ -46,7 +46,7 @@ class [[nodiscard]] [[sus_trivial_abi]] Inspect final
   // sus::iter::Iterator trait.
   Option<Item> next() noexcept {
     Option<Item> item = next_iter_.next();
-    if (item.is_some()) inspect_(item.as_value());
+    if (item.is_some()) ::sus::fn::call_mut(inspect_, item.as_value());
     return item;
   }
 
@@ -60,7 +60,7 @@ class [[nodiscard]] [[sus_trivial_abi]] Inspect final
     requires(InnerSizedIter::DoubleEnded)
   {
     Option<Item> item = next_iter_.next_back();
-    if (item.is_some()) inspect_(item.as_value());
+    if (item.is_some()) ::sus::fn::call_mut(inspect_, item.as_value());
     return item;
   }
 
@@ -75,11 +75,11 @@ class [[nodiscard]] [[sus_trivial_abi]] Inspect final
   template <class U, class V>
   friend class IteratorBase;
 
-  static Inspect with(InspectFn fn, InnerSizedIter && next_iter) noexcept {
+  static Inspect with(InspectFn fn, InnerSizedIter&& next_iter) noexcept {
     return Inspect(::sus::move(fn), ::sus::move(next_iter));
   }
 
-  Inspect(InspectFn && fn, InnerSizedIter && next_iter)
+  Inspect(InspectFn&& fn, InnerSizedIter&& next_iter)
       : inspect_(::sus::move(fn)), next_iter_(::sus::move(next_iter)) {}
 
   InspectFn inspect_;

--- a/subspace/iter/map.h
+++ b/subspace/iter/map.h
@@ -40,8 +40,8 @@ class [[nodiscard]] [[sus_trivial_abi]] Map final
     if (item.is_none()) {
       return sus::none();
     } else {
-      return sus::some(
-          fn_(sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn)));
+      return sus::some(::sus::fn::call_mut(
+          fn_, sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn)));
     }
   }
 
@@ -58,8 +58,8 @@ class [[nodiscard]] [[sus_trivial_abi]] Map final
     if (item.is_none()) {
       return sus::none();
     } else {
-      return sus::some(
-          fn_(sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn)));
+      return sus::some(::sus::fn::call_mut(
+          fn_, sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn)));
     }
   }
 

--- a/subspace/iter/map_while.h
+++ b/subspace/iter/map_while.h
@@ -47,7 +47,8 @@ class [[nodiscard]] [[sus_trivial_abi]] MapWhile final
     if (item.is_none()) {
       return sus::none();
     } else {
-      return fn_(sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn));
+      return ::sus::fn::call_mut(
+          fn_, sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn));
     }
   }
 
@@ -65,7 +66,8 @@ class [[nodiscard]] [[sus_trivial_abi]] MapWhile final
     if (item.is_none()) {
       return sus::none();
     } else {
-      return fn_(sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn));
+      return ::sus::fn::call_mut(
+          fn_, sus::move(item).unwrap_unchecked(::sus::marker::unsafe_fn));
     }
   }
 
@@ -73,11 +75,11 @@ class [[nodiscard]] [[sus_trivial_abi]] MapWhile final
   template <class U, class V>
   friend class IteratorBase;
 
-  static MapWhile with(MapFn fn, InnerSizedIter && next_iter) noexcept {
+  static MapWhile with(MapFn fn, InnerSizedIter&& next_iter) noexcept {
     return MapWhile(::sus::move(fn), ::sus::move(next_iter));
   }
 
-  MapWhile(MapFn fn, InnerSizedIter && next_iter)
+  MapWhile(MapFn fn, InnerSizedIter&& next_iter)
       : fn_(::sus::move(fn)), next_iter_(::sus::move(next_iter)) {}
 
   MapFn fn_;

--- a/subspace/iter/once_with.h
+++ b/subspace/iter/once_with.h
@@ -55,7 +55,7 @@ class [[nodiscard]] [[sus_trivial_abi]] OnceWith final
 
   // sus::iter::Iterator trait.
   Option<Item> next() noexcept {
-    return gen_.take().map([](auto&& gen) { return ::sus::move(gen)(); });
+    return gen_.take().map([](auto&& gen) { return ::sus::fn::call_mut(gen); });
   }
   /// sus::iter::Iterator trait.
   ::sus::iter::SizeHint size_hint() const noexcept {
@@ -64,7 +64,7 @@ class [[nodiscard]] [[sus_trivial_abi]] OnceWith final
   }
   // sus::iter::DoubleEndedIterator trait.
   Option<Item> next_back() noexcept {
-    return gen_.take().map([](auto&& gen) { return ::sus::move(gen)(); });
+    return gen_.take().map([](auto&& gen) { return ::sus::fn::call_mut(gen); });
   }
   // sus::iter::ExactSizeIterator trait.
   usize exact_size_hint() const noexcept { return gen_.is_some() ? 1u : 0u; }

--- a/subspace/iter/peekable.h
+++ b/subspace/iter/peekable.h
@@ -70,7 +70,7 @@ class [[nodiscard]] Peekable final
       ::sus::fn::FnOnceRef<bool(const std::remove_reference_t<Item>&)>
           pred) noexcept {
     Option<Item> o = next();
-    if (o.is_some() && ::sus::move(pred)(o.as_value())) {
+    if (o.is_some() && ::sus::fn::call_once(::sus::move(pred), o.as_value())) {
       return o;
     } else {
       // Since we called `next()`, we consumed `peeked_`, so we can insert

--- a/subspace/iter/repeat_with.h
+++ b/subspace/iter/repeat_with.h
@@ -59,13 +59,17 @@ class [[nodiscard]] [[sus_trivial_abi]] RepeatWith final
   using Item = ItemT;
 
   // sus::iter::Iterator trait.
-  Option<Item> next() noexcept { return ::sus::some(gen_()); }
+  Option<Item> next() noexcept {
+    return ::sus::some(::sus::fn::call_mut(gen_));
+  }
   /// sus::iter::Iterator trait.
   ::sus::iter::SizeHint size_hint() const noexcept {
     return SizeHint(usize::MAX, ::sus::Option<::sus::num::usize>());
   }
   // sus::iter::DoubleEndedIterator trait.
-  Option<Item> next_back() noexcept { return ::sus::some(gen_()); }
+  Option<Item> next_back() noexcept {
+    return ::sus::some(::sus::fn::call_mut(gen_));
+  }
 
  private:
   friend RepeatWith<Item> sus::iter::repeat_with<Item>(

--- a/subspace/iter/scan.h
+++ b/subspace/iter/scan.h
@@ -51,8 +51,9 @@ class [[nodiscard]] Scan final
     Option<Item> out;
     if (Option<typename InnerSizedIter::Item> o = next_iter_.next();
         o.is_some()) {
-      out = fn_(state_,
-                ::sus::move(o).unwrap_unchecked(::sus::marker::unsafe_fn));
+      out = ::sus::fn::call_mut(
+          fn_, state_,
+          ::sus::move(o).unwrap_unchecked(::sus::marker::unsafe_fn));
     }
     return out;
   }

--- a/subspace/iter/skip_while.h
+++ b/subspace/iter/skip_while.h
@@ -52,7 +52,8 @@ class [[nodiscard]] [[sus_trivial_abi]] SkipWhile final
       Option<Item> out = next_iter_.next();
       if (out.is_none() || pred_.is_none()) return out;
       // SAFETY: `out` and `pred_` are both checked for None above.
-      if (!pred_.as_value_unchecked_mut(::sus::marker::unsafe_fn)(
+      if (!::sus::fn::call_mut(
+              pred_.as_value_unchecked_mut(::sus::marker::unsafe_fn),
               out.as_value_unchecked(::sus::marker::unsafe_fn))) {
         pred_ = Option<Pred>();
         return out;
@@ -71,11 +72,11 @@ class [[nodiscard]] [[sus_trivial_abi]] SkipWhile final
   template <class U, class V>
   friend class IteratorBase;
 
-  static SkipWhile with(Pred && pred, InnerSizedIter && next_iter) noexcept {
+  static SkipWhile with(Pred&& pred, InnerSizedIter&& next_iter) noexcept {
     return SkipWhile(::sus::move(pred), ::sus::move(next_iter));
   }
 
-  SkipWhile(Pred && pred, InnerSizedIter && next_iter) noexcept
+  SkipWhile(Pred&& pred, InnerSizedIter&& next_iter) noexcept
       : pred_(Option<Pred>::with(::sus::move(pred))),
         next_iter_(::sus::move(next_iter)) {}
 

--- a/subspace/iter/successors.h
+++ b/subspace/iter/successors.h
@@ -61,7 +61,7 @@ class [[nodiscard]] Successors final
   // sus::iter::Iterator trait.
   Option<Item> next() noexcept {
     Option<Item> item = next_.take();
-    if (item.is_some()) next_ = func_(item.as_value());
+    if (item.is_some()) next_ = ::sus::fn::call_mut(func_, item.as_value());
     return item;
   }
 

--- a/subspace/iter/take_while.h
+++ b/subspace/iter/take_while.h
@@ -51,7 +51,8 @@ class [[nodiscard]] [[sus_trivial_abi]] TakeWhile final
     out = next_iter_.next();
     if (out.is_none()) return out;
     // SAFETY: `pred_` and `out` have each been checked for None already.
-    if (!pred_.as_value_unchecked_mut(::sus::marker::unsafe_fn)(
+    if (!::sus::fn::call_mut(
+            pred_.as_value_unchecked_mut(::sus::marker::unsafe_fn),
             out.as_value_unchecked(::sus::marker::unsafe_fn))) {
       pred_ = Option<Pred>();
       out = Option<Item>();
@@ -70,11 +71,11 @@ class [[nodiscard]] [[sus_trivial_abi]] TakeWhile final
   template <class U, class V>
   friend class IteratorBase;
 
-  static TakeWhile with(Pred && pred, InnerSizedIter && next_iter) noexcept {
+  static TakeWhile with(Pred&& pred, InnerSizedIter&& next_iter) noexcept {
     return TakeWhile(::sus::move(pred), ::sus::move(next_iter));
   }
 
-  TakeWhile(Pred && pred, InnerSizedIter && next_iter) noexcept
+  TakeWhile(Pred&& pred, InnerSizedIter&& next_iter) noexcept
       : pred_(::sus::some(::sus::move(pred))),
         next_iter_(::sus::move(next_iter)) {}
 

--- a/subspace/ops/ord.h
+++ b/subspace/ops/ord.h
@@ -140,7 +140,8 @@ constexpr T min_by(
     ::sus::fn::FnOnce<std::strong_ordering(
         const std::remove_reference_t<T>&,
         const std::remove_reference_t<T>&)> auto&& compare) noexcept {
-  return ::sus::move(compare)(a, b) == std::strong_ordering::greater
+  return ::sus::fn::call_once(::sus::move(compare), a, b) ==
+                 std::strong_ordering::greater
              ? ::sus::forward<T>(b)
              : ::sus::forward<T>(a);
 }
@@ -165,7 +166,9 @@ template <
   requires(::sus::ops::Ord<Key>)
 constexpr T min_by_key(T a sus_lifetimebound, T b sus_lifetimebound,
                        KeyFn f) noexcept {
-  return f(a) > f(b) ? ::sus::forward<T>(b) : ::sus::forward<T>(a);
+  return ::sus::fn::call_mut(f, a) > ::sus::fn::call_mut(f, b)
+             ? ::sus::forward<T>(b)
+             : ::sus::forward<T>(a);
 }
 
 /// Compares and returns the maximum of two values.
@@ -201,7 +204,8 @@ constexpr T max_by(
     ::sus::fn::FnOnce<std::strong_ordering(
         const std::remove_reference_t<T>&,
         const std::remove_reference_t<T>&)> auto&& compare) noexcept {
-  return ::sus::move(compare)(a, b) == std::strong_ordering::greater
+  return ::sus::fn::call_once(::sus::move(compare), a, b) ==
+                 std::strong_ordering::greater
              ? ::sus::forward<T>(a)
              : ::sus::forward<T>(b);
 }

--- a/subspace/result/result.h
+++ b/subspace/result/result.h
@@ -718,10 +718,11 @@ class [[nodiscard]] Result final {
   template <::sus::fn::FnOnce<T(E&&)> F>
   constexpr T unwrap_or_else(F&& op) && noexcept {
     if (is_ok()) {
-      return sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
+      return ::sus::move(*this).unwrap_unchecked(::sus::marker::unsafe_fn);
     } else {
-      return ::sus::move(op)(
-          sus::move(*this).unwrap_err_unchecked(::sus::marker::unsafe_fn));
+      return ::sus::fn::call_once(
+          ::sus::move(op),
+          ::sus::move(*this).unwrap_err_unchecked(::sus::marker::unsafe_fn));
     }
   }
 


### PR DESCRIPTION
A class method pointer acts like a function that receives a reference to the class as its first parameter.

So a Fn concept that receives a type const T& as its first parameter can be satisfied by any const method on T.