### PR TITLE
Rename Ord to StrongOrd, and WeakOrd to Ord

### DIFF
--- a/sus/choice/__private/ops_concepts.h
+++ b/sus/choice/__private/ops_concepts.h
@@ -44,8 +44,8 @@ struct ChoiceIsOrdHelper;
 template <class TagType1, class... Types1, class TagType2, class... Types2>
 struct ChoiceIsOrdHelper<TagType1, TypeList<Types1...>, TagType2,
                          TypeList<Types2...>> {
-  static constexpr bool value = (::sus::ops::Ord<TagType1, TagType2> && ... &&
-                                 ::sus::ops::Ord<Types1, Types2>);
+  static constexpr bool value = (::sus::ops::StrongOrd<TagType1, TagType2> && ... &&
+                                 ::sus::ops::StrongOrd<Types1, Types2>);
 };
 
 // Out of line from the requires clause, and in a struct, to work around
@@ -62,11 +62,11 @@ struct ChoiceIsWeakOrdHelper<TagType1, TypeList<Types1...>, TagType2,
                              TypeList<Types2...>> {
   // clang-format off
   static constexpr bool value =
-      ((!::sus::ops::Ord<TagType1, TagType2> || ... ||
-        !::sus::ops::Ord<Types1, Types2>)
+      ((!::sus::ops::StrongOrd<TagType1, TagType2> || ... ||
+        !::sus::ops::StrongOrd<Types1, Types2>)
         &&
-       (::sus::ops::WeakOrd<TagType1, TagType2> && ... &&
-        ::sus::ops::WeakOrd<Types1, Types2>));
+       (::sus::ops::Ord<TagType1, TagType2> && ... &&
+        ::sus::ops::Ord<Types1, Types2>));
   // clang-format on
 };
 
@@ -84,8 +84,8 @@ struct ChoiceIsPartialOrdHelper<TagType1, TypeList<Types1...>, TagType2,
                                 TypeList<Types2...>> {
   // clang-format off
   static constexpr bool value =
-      (!::sus::ops::WeakOrd<TagType1, TagType2> || ... ||
-       !::sus::ops::WeakOrd<Types1, Types2>)
+      (!::sus::ops::Ord<TagType1, TagType2> || ... ||
+       !::sus::ops::Ord<Types1, Types2>)
       &&
       (::sus::ops::PartialOrd<TagType1, TagType2> && ... &&
        ::sus::ops::PartialOrd<Types1, Types2>);

--- a/sus/choice/choice.h
+++ b/sus/choice/choice.h
@@ -532,7 +532,7 @@ class Choice<__private::TypeList<Ts...>, Tags...> final {
       const Choice& l,
       const Choice<__private::TypeList<Us...>, V, Vs...>& r) noexcept = delete;
 
-  /// sus::ops::Ord<Choice<Ts...>, Choice<Us...>> trait.
+  /// sus::ops::StrongOrd<Choice<Ts...>, Choice<Us...>> trait.
   ///
   /// #[doc.overloads=ord]
   template <class... Us, auto V, auto... Vs>
@@ -550,7 +550,7 @@ class Choice<__private::TypeList<Ts...>, Tags...> final {
     }
   }
 
-  /// sus::ops::WeakOrd<Choice<Ts...>, Choice<Us...>> trait.
+  /// sus::ops::Ord<Choice<Ts...>, Choice<Us...>> trait.
   ///
   /// #[doc.overloads=weakord]
   template <class... Us, auto V, auto... Vs>

--- a/sus/choice/choice_unittest.cc
+++ b/sus/choice/choice_unittest.cc
@@ -671,7 +671,7 @@ TEST(Choice, Eq) {
   EXPECT_EQ(double_storage, sus::choice<Order::First>(2u, 3u));
 }
 
-TEST(Choice, Ord) {
+TEST(Choice, StrongOrd) {
   using OrderChoice =
       Choice<sus_choice_types((Order::First, u32), (Order::Second, u8))>;
   auto u1 = OrderChoice::with<Order::First>(4u);
@@ -726,8 +726,8 @@ struct Weak {
 TEST(Choice, WeakOrder) {
   using ChoiceWeak =
       Choice<sus_choice_types((Order::First, Weak), (Order::Second, Weak))>;
-  static_assert(!sus::ops::Ord<ChoiceWeak>);
-  static_assert(sus::ops::WeakOrd<ChoiceWeak>);
+  static_assert(!sus::ops::StrongOrd<ChoiceWeak>);
+  static_assert(sus::ops::Ord<ChoiceWeak>);
 
   // Same enum value and inner value.
   auto u1 = ChoiceWeak::with<Order::First>(Weak(1, 1));
@@ -787,13 +787,13 @@ TEST(Choice, PartialOrder) {
 struct NotCmp {};
 static_assert(!sus::ops::PartialOrd<NotCmp>);
 
-static_assert(::sus::ops::Ord<Choice<sus_choice_types((1, int))>,
+static_assert(::sus::ops::StrongOrd<Choice<sus_choice_types((1, int))>,
                               Choice<sus_choice_types((1, int))>>);
-static_assert(!::sus::ops::Ord<Choice<sus_choice_types((1, Weak))>,
+static_assert(!::sus::ops::StrongOrd<Choice<sus_choice_types((1, Weak))>,
                                Choice<sus_choice_types((1, Weak))>>);
-static_assert(::sus::ops::WeakOrd<Choice<sus_choice_types((1, Weak))>,
+static_assert(::sus::ops::Ord<Choice<sus_choice_types((1, Weak))>,
                                   Choice<sus_choice_types((1, Weak))>>);
-static_assert(!::sus::ops::WeakOrd<Choice<sus_choice_types((1, float))>,
+static_assert(!::sus::ops::Ord<Choice<sus_choice_types((1, float))>,
                                    Choice<sus_choice_types((1, float))>>);
 static_assert(::sus::ops::PartialOrd<Choice<sus_choice_types((1, float))>,
                                      Choice<sus_choice_types((1, float))>>);
@@ -814,8 +814,8 @@ TEST(Choice, VoidValues) {
   static_assert(sus::mem::Copy<decltype(u3)>);
   static_assert(sus::ops::Eq<decltype(u1)>);
   static_assert(sus::ops::Eq<decltype(u3)>);
-  static_assert(sus::ops::Ord<decltype(u1)>);
-  static_assert(sus::ops::Ord<decltype(u3)>);
+  static_assert(sus::ops::StrongOrd<decltype(u1)>);
+  static_assert(sus::ops::StrongOrd<decltype(u3)>);
 
   static_assert(CanGetRef<decltype(u1), Order::First>);
   static_assert(!CanGetRef<decltype(u1), Order::Second>);

--- a/sus/containers/__private/slice_methods.inc
+++ b/sus/containers/__private/slice_methods.inc
@@ -93,8 +93,7 @@ constexpr ::sus::result::Result<::sus::num::usize, ::sus::num::usize>
 binary_search(const T& x) const& noexcept
   requires(::sus::ops::Ord<T>)
 {
-  return binary_search_by(
-      [&x](const T& p) -> std::strong_ordering { return p <=> x; });
+  return binary_search_by([&x](const T& p) { return p <=> x; });
 }
 
 /// Binary searches this slice with a comparator function. This behaves
@@ -113,9 +112,7 @@ binary_search(const T& x) const& noexcept
 /// element could be inserted while maintaining sorted order.
 constexpr ::sus::result::Result<::sus::num::usize, ::sus::num::usize>
 binary_search_by(
-    ::sus::fn::FnMutRef<std::strong_ordering(const T&)> f) const& noexcept
-  requires(::sus::ops::Ord<T>)
-{
+    ::sus::fn::FnMutRef<std::weak_ordering(const T&)> f) const& noexcept {
   using Result = ::sus::result::Result<::sus::num::usize, ::sus::num::usize>;
 
   // INVARIANTS:
@@ -171,7 +168,7 @@ binary_search_by(
 /// found then `sus::Err` is returned, with the index where a matching
 /// element could be inserted while maintaining sorted order.
 ///
-template <::sus::ops::Ord Key>
+template <::sus::ops::StrongOrd Key>
 ::sus::result::
     Result<::sus::num::usize, ::sus::num::usize> constexpr binary_search_by_key(
         const Key& key,

--- a/sus/containers/array.h
+++ b/sus/containers/array.h
@@ -435,17 +435,17 @@ constexpr inline auto array_cmp(auto equal, const Array<T, N>& l,
 
 /// Compares two Arrays.
 ///
-/// Satisfies sus::ops::Ord<Array<T, N>> if sus::ops::Ord<T>.
+/// Satisfies sus::ops::StrongOrd<Array<T, N>> if sus::ops::StrongOrd<T>.
 ///
-/// Satisfies sus::ops::WeakOrd<Array<T, N>> if sus::ops::WeakOrd<T>.
+/// Satisfies sus::ops::Ord<Array<T, N>> if sus::ops::Ord<T>.
 ///
 /// Satisfies sus::ops::PartialOrd<Array<T, N>> if sus::ops::PartialOrd<T>.
 //
+// sus::ops::StrongOrd<Array<T, N>> trait.
 // sus::ops::Ord<Array<T, N>> trait.
-// sus::ops::WeakOrd<Array<T, N>> trait.
 // sus::ops::PartialOrd<Array<T, N>> trait.
 template <class T, class U, size_t N>
-  requires(::sus::ops::ExclusiveOrd<T, U>)
+  requires(::sus::ops::ExclusiveStrongOrd<T, U>)
 constexpr inline auto operator<=>(const Array<T, N>& l,
                                   const Array<U, N>& r) noexcept {
   return __private::array_cmp(std::strong_ordering::equivalent, l, r,
@@ -453,7 +453,7 @@ constexpr inline auto operator<=>(const Array<T, N>& l,
 }
 
 template <class T, class U, size_t N>
-  requires(::sus::ops::ExclusiveWeakOrd<T, U>)
+  requires(::sus::ops::ExclusiveOrd<T, U>)
 constexpr inline auto operator<=>(const Array<T, N>& l,
                                   const Array<U, N>& r) noexcept {
   return __private::array_cmp(std::weak_ordering::equivalent, l, r,

--- a/sus/containers/array_unittest.cc
+++ b/sus/containers/array_unittest.cc
@@ -338,7 +338,7 @@ TEST(Array, Eq) {
   EXPECT_NE(a, b);
 }
 
-TEST(Array, Ord) {
+TEST(Array, StrongOrd) {
   auto a = Array<int, 5>::with_initializer([i = 0]() mutable { return ++i; });
   auto b = Array<int, 5>::with_initializer([i = 0]() mutable { return ++i; });
   EXPECT_LE(a, b);
@@ -393,15 +393,15 @@ TEST(Array, PartialOrder) {
 struct NotCmp {};
 static_assert(!sus::ops::PartialOrd<NotCmp>);
 
+static_assert(!sus::ops::StrongOrd<Array<int, 3>, Array<int, 4>>);
 static_assert(!sus::ops::Ord<Array<int, 3>, Array<int, 4>>);
-static_assert(!sus::ops::WeakOrd<Array<int, 3>, Array<int, 4>>);
 static_assert(!sus::ops::PartialOrd<Array<int, 3>, Array<int, 4>>);
 
-static_assert(sus::ops::Ord<Array<int, 3>>);
-static_assert(!sus::ops::Ord<Array<Weak, 3>>);
-static_assert(sus::ops::WeakOrd<Array<Weak, 3>>);
-static_assert(!sus::ops::WeakOrd<Array<float, 3>>);
-static_assert(!sus::ops::WeakOrd<Array<float, 3>>);
+static_assert(sus::ops::StrongOrd<Array<int, 3>>);
+static_assert(!sus::ops::StrongOrd<Array<Weak, 3>>);
+static_assert(sus::ops::Ord<Array<Weak, 3>>);
+static_assert(!sus::ops::Ord<Array<float, 3>>);
+static_assert(!sus::ops::Ord<Array<float, 3>>);
 static_assert(!sus::ops::PartialOrd<Array<NotCmp, 3>>);
 
 TEST(Array, Iter) {

--- a/sus/iter/iterator_defn.h
+++ b/sus/iter/iterator_defn.h
@@ -139,23 +139,23 @@ class IteratorBase {
   Iterator<std::remove_cvref_t<Item>> auto cloned() && noexcept
     requires(::sus::mem::Clone<Item>);
 
-  /// [Lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) compares
+  /// [Lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) compares
   /// the elements of this `Iterator` with those of another.
   template <IntoIteratorAny Other, int&...,
             class OtherItem = typename IntoIteratorOutputType<Other>::Item>
     requires(::sus::ops::Ord<ItemT, OtherItem>)
-  std::strong_ordering cmp(Other&& other) && noexcept;
+  constexpr std::weak_ordering cmp(Other&& other) && noexcept;
 
-  /// [Lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) compares
+  /// [Lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) compares
   /// the elements of this `Iterator` with those of another with respect to the
   /// specified comparison function.
   template <IntoIteratorAny Other, int&...,
             class OtherItem = typename IntoIteratorOutputType<Other>::Item>
-  std::strong_ordering cmp_by(Other&& other,
-                              ::sus::fn::FnMutBox<std::strong_ordering(
-                                  const std::remove_reference_t<Item>&,
-                                  const std::remove_reference_t<OtherItem>&)>
-                                  cmp) && noexcept;
+  constexpr std::weak_ordering cmp_by(
+      Other&& other,
+      ::sus::fn::FnMut<std::weak_ordering(
+          const std::remove_reference_t<Item>&,
+          const std::remove_reference_t<OtherItem>&)> auto cmp) && noexcept;
 
   /// Creates an iterator which copies all of its elements.
   ///
@@ -388,7 +388,7 @@ class IteratorBase {
   Iterator<GenR> auto generate(GenFn generator_fn) && noexcept;
 
   /// Determines if the elements of this Iterator are
-  /// [lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) greater than
+  /// [lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) greater than
   /// or equal to those of another.
   template <IntoIteratorAny Other, int&...,
             class OtherItem = typename IntoIteratorOutputType<Other>::Item>
@@ -396,7 +396,7 @@ class IteratorBase {
   constexpr bool ge(Other&& other) && noexcept;
 
   /// Determines if the elements of this Iterator are
-  /// [lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) greater than
+  /// [lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) greater than
   /// those of another.
   template <IntoIteratorAny Other, int&...,
             class OtherItem = typename IntoIteratorOutputType<Other>::Item>
@@ -431,12 +431,12 @@ class IteratorBase {
   /// true. If the iterator yields exactly zero or one element, true is
   /// returned.
   constexpr bool is_sorted_by(
-      ::sus::fn::FnMut<std::strong_ordering(
+      ::sus::fn::FnMut<std::weak_ordering(
           const std::remove_reference_t<Item>&,
           const std::remove_reference_t<Item>&)> auto compare) noexcept;
 
   /// Determines if the elements of this Iterator are
-  /// [lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) less than or
+  /// [lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) less than or
   /// equal to those of another.
   template <IntoIteratorAny Other, int&...,
             class OtherItem = typename IntoIteratorOutputType<Other>::Item>
@@ -444,7 +444,7 @@ class IteratorBase {
   constexpr bool le(Other&& other) && noexcept;
 
   /// Determines if the elements of this Iterator are
-  /// [lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) less than
+  /// [lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) less than
   /// those of another.
   template <IntoIteratorAny Other, int&...,
             class OtherItem = typename IntoIteratorOutputType<Other>::Item>
@@ -484,7 +484,7 @@ class IteratorBase {
   /// If several elements are equally maximum, the last element is returned. If
   /// the iterator is empty, None is returned.
   ///
-  /// Note that `f32`/`f64` doesn’t implement `Ord` due to NaN being
+  /// Note that `f32`/`f64` doesn’t implement `StrongOrd` due to NaN being
   /// incomparable. You can work around this by using [`Iterator::reduce`](
   /// sus::iter::IteratorBase::reduce):
   ///
@@ -506,7 +506,7 @@ class IteratorBase {
   /// If several elements are equally maximum, the last element is returned. If
   /// the iterator is empty, None is returned.
   constexpr Option<Item> max_by(
-      sus::fn::FnMut<std::strong_ordering(
+      sus::fn::FnMut<std::weak_ordering(
           const std::remove_reference_t<Item>&,
           const std::remove_reference_t<Item>&)> auto compare) && noexcept;
 
@@ -530,7 +530,7 @@ class IteratorBase {
   /// If several elements are equally minimum, the first element is returned. If
   /// the iterator is empty, None is returned.
   ///
-  /// Note that `f32`/`f64` doesn’t implement `Ord` due to NaN being
+  /// Note that `f32`/`f64` doesn’t implement `StrongOrd` due to NaN being
   /// incomparable. You can work around this by using [`Iterator::reduce`](
   /// sus::iter::IteratorBase::reduce):
   ///
@@ -552,7 +552,7 @@ class IteratorBase {
   /// If several elements are equally minimum, the first element is returned. If
   /// the iterator is empty, None is returned.
   constexpr Option<Item> min_by(
-      sus::fn::FnMut<std::strong_ordering(
+      sus::fn::FnMut<std::weak_ordering(
           const std::remove_reference_t<Item>&,
           const std::remove_reference_t<Item>&)> auto compare) && noexcept;
 
@@ -610,7 +610,7 @@ class IteratorBase {
   constexpr Option<Item> nth_back(usize n) noexcept
     requires(DoubleEndedIterator<Iter, Item>);
 
-  /// [Lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) compares
+  /// [Lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) compares
   /// the elements of this `Iterator` with those of another.
   ///
   /// The comparison works like short-circuit evaluation, returning a result
@@ -624,7 +624,7 @@ class IteratorBase {
     requires(::sus::ops::PartialOrd<ItemT, OtherItem>)
   constexpr std::partial_ordering partial_cmp(Other&& other) && noexcept;
 
-  /// [Lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) compares
+  /// [Lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) compares
   /// the elements of this `Iterator` with those of another with respect to the
   /// specified comparison function.
   template <IntoIteratorAny Other, int&...,
@@ -885,6 +885,33 @@ class IteratorBase {
   /// of 1 returns every element.
   constexpr Iterator<Item> auto step_by(usize step) && noexcept;
 
+  /// [Lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) compares
+  /// the elements of this `Iterator` with those of another.
+  ///
+  /// Strong ordering requires each item being compared that compares equal to
+  /// share the same identity (be replaceable). Typically `Ord` is
+  /// sufficient, which is required for `cmp()` and `cmp_by()`, where items that
+  /// compare equivalent may still have different internal state.
+  ///
+  /// The comparison works like short-circuit evaluation, returning a result
+  /// without comparing the remaining elements. As soon as an order can be
+  /// determined, the evaluation stops and a result is returned.
+  template <IntoIteratorAny Other, int&...,
+            class OtherItem = typename IntoIteratorOutputType<Other>::Item>
+    requires(::sus::ops::StrongOrd<ItemT, OtherItem>)
+  constexpr std::strong_ordering strong_cmp(Other&& other) && noexcept;
+
+  /// [Lexicographically](sus::ops::StrongOrd#How-can-I-implement-StrongOrd?) compares
+  /// the elements of this `Iterator` with those of another with respect to the
+  /// specified comparison function.
+  template <IntoIteratorAny Other, int&...,
+            class OtherItem = typename IntoIteratorOutputType<Other>::Item>
+  constexpr std::strong_ordering strong_cmp_by(
+      Other&& other,
+      ::sus::fn::FnMut<std::strong_ordering(
+          const std::remove_reference_t<Item>&,
+          const std::remove_reference_t<OtherItem>&)> auto cmp) && noexcept;
+
   /// Sums the elements of an iterator.
   ///
   /// Takes each element, adds them together, and returns the result.
@@ -1065,28 +1092,6 @@ class IteratorBase {
   constexpr Iterator<sus::Tuple<ItemT, OtherItem>> auto zip(
       Other&& other) && noexcept;
 
-  /// [Lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) compares
-  /// the elements of this `Iterator` with those of another.
-  ///
-  /// The comparison works like short-circuit evaluation, returning a result
-  /// without comparing the remaining elements. As soon as an order can be
-  /// determined, the evaluation stops and a result is returned.
-  template <IntoIteratorAny Other, int&...,
-            class OtherItem = typename IntoIteratorOutputType<Other>::Item>
-    requires(::sus::ops::WeakOrd<ItemT, OtherItem>)
-  constexpr std::weak_ordering weak_cmp(Other&& other) && noexcept;
-
-  /// [Lexicographically](sus::ops::Ord#How-can-I-implement-Ord?) compares
-  /// the elements of this `Iterator` with those of another with respect to the
-  /// specified comparison function.
-  template <IntoIteratorAny Other, int&...,
-            class OtherItem = typename IntoIteratorOutputType<Other>::Item>
-  constexpr std::weak_ordering weak_cmp_by(
-      Other&& other,
-      ::sus::fn::FnMut<std::weak_ordering(
-          const std::remove_reference_t<Item>&,
-          const std::remove_reference_t<OtherItem>&)> auto cmp) && noexcept;
-
   /// Transforms an iterator into a collection.
   ///
   /// collect() can turn anything iterable into a relevant collection. If this
@@ -1176,23 +1181,21 @@ IteratorBase<Iter, Item>::cloned() && noexcept
 template <class Iter, class Item>
 template <IntoIteratorAny Other, int&..., class OtherItem>
   requires(::sus::ops::Ord<Item, OtherItem>)
-std::strong_ordering IteratorBase<Iter, Item>::cmp(Other&& other) && noexcept {
+constexpr std::weak_ordering IteratorBase<Iter, Item>::cmp(Other&& other) && noexcept {
   return static_cast<Iter&&>(*this).cmp_by(
       ::sus::move(other),
       [](const std::remove_reference_t<Item>& x,
-         const std::remove_reference_t<OtherItem>& y) -> std::strong_ordering {
-        return x <=> y;
-      });
+         const std::remove_reference_t<OtherItem>& y) { return x <=> y; });
 }
 
 template <class Iter, class Item>
 template <IntoIteratorAny Other, int&..., class OtherItem>
-std::strong_ordering IteratorBase<Iter, Item>::cmp_by(
-    Other&& other, ::sus::fn::FnMutBox<std::strong_ordering(
-                       const std::remove_reference_t<Item>&,
-                       const std::remove_reference_t<OtherItem>&)>
-                       cmp) && noexcept {
-  return __private::iter_compare<std::strong_ordering, Item, OtherItem>(
+constexpr std::weak_ordering IteratorBase<Iter, Item>::cmp_by(
+    Other&& other,
+    ::sus::fn::FnMut<std::weak_ordering(
+        const std::remove_reference_t<Item>&,
+        const std::remove_reference_t<OtherItem>&)> auto cmp) && noexcept {
+  return __private::iter_compare<std::weak_ordering, Item, OtherItem>(
       static_cast<Iter&&>(*this), ::sus::move(other).into_iter(),
       ::sus::move(cmp));
 }
@@ -1392,7 +1395,7 @@ constexpr bool IteratorBase<Iter, Item>::is_sorted() noexcept
 
 template <class Iter, class Item>
 constexpr bool IteratorBase<Iter, Item>::is_sorted_by(
-    ::sus::fn::FnMut<std::strong_ordering(
+    ::sus::fn::FnMut<std::weak_ordering(
         const std::remove_reference_t<Item>&,
         const std::remove_reference_t<Item>&)> auto compare) noexcept {
   Option<Item> o = as_subclass_mut().next();
@@ -1468,7 +1471,7 @@ constexpr Option<Item> IteratorBase<Iter, Item>::max() && noexcept
 
 template <class Iter, class Item>
 constexpr Option<Item> IteratorBase<Iter, Item>::max_by(
-    sus::fn::FnMut<std::strong_ordering(
+    sus::fn::FnMut<std::weak_ordering(
         const std::remove_reference_t<Item>&,
         const std::remove_reference_t<Item>&)> auto compare) && noexcept {
   return static_cast<Iter&&>(*this).reduce(
@@ -1526,7 +1529,7 @@ constexpr Option<Item> IteratorBase<Iter, Item>::min() && noexcept
 
 template <class Iter, class Item>
 constexpr Option<Item> IteratorBase<Iter, Item>::min_by(
-    sus::fn::FnMut<std::strong_ordering(
+    sus::fn::FnMut<std::weak_ordering(
         const std::remove_reference_t<Item>&,
         const std::remove_reference_t<Item>&)> auto compare) && noexcept {
   return static_cast<Iter&&>(*this).reduce(
@@ -1786,6 +1789,29 @@ constexpr Iterator<Item> auto IteratorBase<Iter, Item>::step_by(
 }
 
 template <class Iter, class Item>
+template <IntoIteratorAny Other, int&..., class OtherItem>
+  requires(::sus::ops::StrongOrd<Item, OtherItem>)
+constexpr std::strong_ordering IteratorBase<Iter, Item>::strong_cmp(
+    Other&& other) && noexcept {
+  return static_cast<Iter&&>(*this).strong_cmp_by(
+      ::sus::move(other),
+      [](const std::remove_reference_t<Item>& x,
+         const std::remove_reference_t<OtherItem>& y) { return x <=> y; });
+}
+
+template <class Iter, class Item>
+template <IntoIteratorAny Other, int&..., class OtherItem>
+constexpr std::strong_ordering IteratorBase<Iter, Item>::strong_cmp_by(
+    Other&& other,
+    ::sus::fn::FnMut<std::strong_ordering(
+        const std::remove_reference_t<Item>&,
+        const std::remove_reference_t<OtherItem>&)> auto cmp) && noexcept {
+  return __private::iter_compare<std::strong_ordering, Item, OtherItem>(
+      static_cast<Iter&&>(*this), ::sus::move(other).into_iter(),
+      ::sus::move(cmp));
+}
+
+template <class Iter, class Item>
 template <class P>
   requires(Sum<P, Item>)
 constexpr P IteratorBase<Iter, Item>::sum() && noexcept {
@@ -1884,31 +1910,6 @@ IteratorBase<Iter, Item>::zip(Other&& other) && noexcept {
   using Zip = Zip<Iter, IntoIteratorOutputType<Other>>;
   return Zip::with(
       sus::tuple(static_cast<Iter&&>(*this), sus::move(other).into_iter()));
-}
-
-template <class Iter, class Item>
-template <IntoIteratorAny Other, int&..., class OtherItem>
-  requires(::sus::ops::WeakOrd<Item, OtherItem>)
-constexpr std::weak_ordering IteratorBase<Iter, Item>::weak_cmp(
-    Other&& other) && noexcept {
-  return static_cast<Iter&&>(*this).weak_cmp_by(
-      ::sus::move(other),
-      [](const std::remove_reference_t<Item>& x,
-         const std::remove_reference_t<OtherItem>& y) -> std::weak_ordering {
-        return x <=> y;
-      });
-}
-
-template <class Iter, class Item>
-template <IntoIteratorAny Other, int&..., class OtherItem>
-constexpr std::weak_ordering IteratorBase<Iter, Item>::weak_cmp_by(
-    Other&& other,
-    ::sus::fn::FnMut<std::weak_ordering(
-        const std::remove_reference_t<Item>&,
-        const std::remove_reference_t<OtherItem>&)> auto cmp) && noexcept {
-  return __private::iter_compare<std::weak_ordering, Item, OtherItem>(
-      static_cast<Iter&&>(*this), ::sus::move(other).into_iter(),
-      ::sus::move(cmp));
 }
 
 template <class Iter, class Item>

--- a/sus/macros/__private/compiler_bugs.h
+++ b/sus/macros/__private/compiler_bugs.h
@@ -70,7 +70,7 @@
 #define sus_clang_bug_54050_else(...) __VA_ARGS__
 #endif
 
-// GCC internal compiler error when Ord fails.
+// GCC internal compiler error when StrongOrd fails.
 // TODO: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=107542
 // Fixed in GCC 12.3 and 13.x.
 #if defined(__GNUC__) && \

--- a/sus/num/__private/signed_integer_methods.inc
+++ b/sus/num/__private/signed_integer_methods.inc
@@ -478,21 +478,21 @@ template <Signed S>
     const _self& l, const S& r) noexcept {
   return l.primitive_value == r.primitive_value;
 }
-/** sus::ops::Ord<##_self##> trait.
+/** sus::ops::StrongOrd<##_self##> trait.
  * #[doc.overloads=int.ord.self] */
 template <UnsignedPrimitiveInteger P>
 [[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(
     const _self& l, const _self& r) noexcept {
   return l.primitive_value <=> r.primitive_value;
 }
-/** sus::ops::Ord<##_self##, SignedPrimitiveInteger> trait.
+/** sus::ops::StrongOrd<##_self##, SignedPrimitiveInteger> trait.
  * #[doc.overloads=int.ord.signedprimitive] */
 template <SignedPrimitiveInteger P>
 [[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(
     const _self& l, const P& r) noexcept {
   return l.primitive_value <=> r;
 }
-/** sus::ops::Ord<##_self##, Signed> trait.
+/** sus::ops::StrongOrd<##_self##, Signed> trait.
  * #[doc.overloads=int.ord.signed] */
 template <Signed S>
 [[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(

--- a/sus/num/__private/unsigned_integer_methods.inc
+++ b/sus/num/__private/unsigned_integer_methods.inc
@@ -514,21 +514,21 @@ template <Unsigned U>
     const _self& l, const U& r) noexcept {
   return l.primitive_value == r.primitive_value;
 }
-/// sus::ops::Ord<##_self##> trait.
+/// sus::ops::StrongOrd<##_self##> trait.
 /// #[doc.overloads=uint.ord.self]
 template <UnsignedPrimitiveInteger P>
 [[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(
     const _self& l, const _self& r) noexcept {
   return l.primitive_value <=> r.primitive_value;
 }
-/// sus::ops::Ord<##_self##, UnsignedPrimitiveInteger> trait.
+/// sus::ops::StrongOrd<##_self##, UnsignedPrimitiveInteger> trait.
 /// #[doc.overloads=uint.ord.unsignedprimitive]
 template <UnsignedPrimitiveInteger P>
 [[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(
     const _self& l, const P& r) noexcept {
   return l.primitive_value <=> r;
 }
-/// sus::ops::Ord<##_self##, Unsigned> trait.
+/// sus::ops::StrongOrd<##_self##, Unsigned> trait.
 /// #[doc.overloads=uint.ord.unsigned]
 template <Unsigned U>
 [[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(

--- a/sus/num/f32_unittest.cc
+++ b/sus/num/f32_unittest.cc
@@ -69,8 +69,8 @@ TEST(f32, Traits) {
   static_assert(!sus::num::Shr<f32>);
   static_assert(!sus::num::ShrAssign<f32>);
 
+  static_assert(!sus::ops::StrongOrd<f32>);
   static_assert(!sus::ops::Ord<f32>);
-  static_assert(!sus::ops::WeakOrd<f32>);
   static_assert(sus::ops::PartialOrd<f32>);
   static_assert(sus::ops::PartialOrd<f32, f64>);
   static_assert(sus::ops::PartialOrd<f32, float>);

--- a/sus/num/f64_unittest.cc
+++ b/sus/num/f64_unittest.cc
@@ -66,8 +66,8 @@ TEST(f64, Traits) {
   static_assert(!sus::num::Shr<f64>);
   static_assert(!sus::num::ShrAssign<f64>);
 
+  static_assert(!sus::ops::StrongOrd<f64>);
   static_assert(!sus::ops::Ord<f64>);
-  static_assert(!sus::ops::WeakOrd<f64>);
   static_assert(sus::ops::PartialOrd<f64>);
   static_assert(sus::ops::PartialOrd<f64, f32>);
   static_assert(sus::ops::PartialOrd<f64, float>);

--- a/sus/num/i16_unittest.cc
+++ b/sus/num/i16_unittest.cc
@@ -113,15 +113,15 @@ TEST(i16, Traits) {
   static_assert(sus::num::Shr<i16>);
   static_assert(sus::num::ShrAssign<i16>);
 
-  static_assert(sus::ops::Ord<i16, int8_t>);
-  static_assert(sus::ops::Ord<i16, int16_t>);
-  static_assert(sus::ops::Ord<i16, int32_t>);
-  static_assert(sus::ops::Ord<i16, int64_t>);
-  static_assert(sus::ops::Ord<i16, i8>);
-  static_assert(sus::ops::Ord<i16, i16>);
-  static_assert(sus::ops::Ord<i16, i32>);
-  static_assert(sus::ops::Ord<i16, i64>);
-  static_assert(sus::ops::Ord<i16, isize>);
+  static_assert(sus::ops::StrongOrd<i16, int8_t>);
+  static_assert(sus::ops::StrongOrd<i16, int16_t>);
+  static_assert(sus::ops::StrongOrd<i16, int32_t>);
+  static_assert(sus::ops::StrongOrd<i16, int64_t>);
+  static_assert(sus::ops::StrongOrd<i16, i8>);
+  static_assert(sus::ops::StrongOrd<i16, i16>);
+  static_assert(sus::ops::StrongOrd<i16, i32>);
+  static_assert(sus::ops::StrongOrd<i16, i64>);
+  static_assert(sus::ops::StrongOrd<i16, isize>);
   static_assert(1_i16 >= 1_i16);
   static_assert(2_i16 > 1_i16);
   static_assert(1_i16 <= 1_i16);

--- a/sus/num/i32_unittest.cc
+++ b/sus/num/i32_unittest.cc
@@ -117,15 +117,15 @@ TEST(i32, Traits) {
   static_assert(sus::num::Shr<i32>);
   static_assert(sus::num::ShrAssign<i32>);
 
-  static_assert(sus::ops::Ord<i32, int8_t>);
-  static_assert(sus::ops::Ord<i32, int16_t>);
-  static_assert(sus::ops::Ord<i32, int32_t>);
-  static_assert(sus::ops::Ord<i32, int64_t>);
-  static_assert(sus::ops::Ord<i32, i8>);
-  static_assert(sus::ops::Ord<i32, i16>);
-  static_assert(sus::ops::Ord<i32, i32>);
-  static_assert(sus::ops::Ord<i32, i64>);
-  static_assert(sus::ops::Ord<i32, isize>);
+  static_assert(sus::ops::StrongOrd<i32, int8_t>);
+  static_assert(sus::ops::StrongOrd<i32, int16_t>);
+  static_assert(sus::ops::StrongOrd<i32, int32_t>);
+  static_assert(sus::ops::StrongOrd<i32, int64_t>);
+  static_assert(sus::ops::StrongOrd<i32, i8>);
+  static_assert(sus::ops::StrongOrd<i32, i16>);
+  static_assert(sus::ops::StrongOrd<i32, i32>);
+  static_assert(sus::ops::StrongOrd<i32, i64>);
+  static_assert(sus::ops::StrongOrd<i32, isize>);
   static_assert(1_i32 >= 1_i32);
   static_assert(2_i32 > 1_i32);
   static_assert(1_i32 <= 1_i32);

--- a/sus/num/i64_unittest.cc
+++ b/sus/num/i64_unittest.cc
@@ -114,15 +114,15 @@ TEST(i64, Traits) {
   static_assert(sus::num::Shr<i64>);
   static_assert(sus::num::ShrAssign<i64>);
 
-  static_assert(sus::ops::Ord<i64, int8_t>);
-  static_assert(sus::ops::Ord<i64, int16_t>);
-  static_assert(sus::ops::Ord<i64, int32_t>);
-  static_assert(sus::ops::Ord<i64, int64_t>);
-  static_assert(sus::ops::Ord<i64, i8>);
-  static_assert(sus::ops::Ord<i64, i16>);
-  static_assert(sus::ops::Ord<i64, i32>);
-  static_assert(sus::ops::Ord<i64, i64>);
-  static_assert(sus::ops::Ord<i64, isize>);
+  static_assert(sus::ops::StrongOrd<i64, int8_t>);
+  static_assert(sus::ops::StrongOrd<i64, int16_t>);
+  static_assert(sus::ops::StrongOrd<i64, int32_t>);
+  static_assert(sus::ops::StrongOrd<i64, int64_t>);
+  static_assert(sus::ops::StrongOrd<i64, i8>);
+  static_assert(sus::ops::StrongOrd<i64, i16>);
+  static_assert(sus::ops::StrongOrd<i64, i32>);
+  static_assert(sus::ops::StrongOrd<i64, i64>);
+  static_assert(sus::ops::StrongOrd<i64, isize>);
   static_assert(1_i64 >= 1_i64);
   static_assert(2_i64 > 1_i64);
   static_assert(1_i64 <= 1_i64);

--- a/sus/num/i8_unittest.cc
+++ b/sus/num/i8_unittest.cc
@@ -113,15 +113,15 @@ TEST(i8, Traits) {
   static_assert(sus::num::Shr<i8>);
   static_assert(sus::num::ShrAssign<i8>);
 
-  static_assert(sus::ops::Ord<i8, int8_t>);
-  static_assert(sus::ops::Ord<i8, int16_t>);
-  static_assert(sus::ops::Ord<i8, int32_t>);
-  static_assert(sus::ops::Ord<i8, int64_t>);
-  static_assert(sus::ops::Ord<i8, i8>);
-  static_assert(sus::ops::Ord<i8, i16>);
-  static_assert(sus::ops::Ord<i8, i32>);
-  static_assert(sus::ops::Ord<i8, i64>);
-  static_assert(sus::ops::Ord<i8, isize>);
+  static_assert(sus::ops::StrongOrd<i8, int8_t>);
+  static_assert(sus::ops::StrongOrd<i8, int16_t>);
+  static_assert(sus::ops::StrongOrd<i8, int32_t>);
+  static_assert(sus::ops::StrongOrd<i8, int64_t>);
+  static_assert(sus::ops::StrongOrd<i8, i8>);
+  static_assert(sus::ops::StrongOrd<i8, i16>);
+  static_assert(sus::ops::StrongOrd<i8, i32>);
+  static_assert(sus::ops::StrongOrd<i8, i64>);
+  static_assert(sus::ops::StrongOrd<i8, isize>);
   static_assert(1_i8 >= 1_i8);
   static_assert(2_i8 > 1_i8);
   static_assert(1_i8 <= 1_i8);

--- a/sus/num/isize_unittest.cc
+++ b/sus/num/isize_unittest.cc
@@ -128,15 +128,15 @@ TEST(isize, Traits) {
   static_assert(sus::num::Shr<isize>);
   static_assert(sus::num::ShrAssign<isize>);
 
-  static_assert(sus::ops::Ord<isize, int8_t>);
-  static_assert(sus::ops::Ord<isize, int16_t>);
-  static_assert(sus::ops::Ord<isize, int32_t>);
-  static_assert(sus::ops::Ord<isize, int64_t>);
-  static_assert(sus::ops::Ord<isize, i8>);
-  static_assert(sus::ops::Ord<isize, i16>);
-  static_assert(sus::ops::Ord<isize, i32>);
-  static_assert(sus::ops::Ord<isize, i64>);
-  static_assert(sus::ops::Ord<isize, isize>);
+  static_assert(sus::ops::StrongOrd<isize, int8_t>);
+  static_assert(sus::ops::StrongOrd<isize, int16_t>);
+  static_assert(sus::ops::StrongOrd<isize, int32_t>);
+  static_assert(sus::ops::StrongOrd<isize, int64_t>);
+  static_assert(sus::ops::StrongOrd<isize, i8>);
+  static_assert(sus::ops::StrongOrd<isize, i16>);
+  static_assert(sus::ops::StrongOrd<isize, i32>);
+  static_assert(sus::ops::StrongOrd<isize, i64>);
+  static_assert(sus::ops::StrongOrd<isize, isize>);
   static_assert(1_isize >= 1_isize);
   static_assert(2_isize > 1_isize);
   static_assert(1_isize <= 1_isize);

--- a/sus/num/overflow_integer_unittest.cc
+++ b/sus/num/overflow_integer_unittest.cc
@@ -450,10 +450,10 @@ TEST(OverflowInteger, Eq) {
             OverflowInteger<i32>::with(5));
 }
 
-TEST(OverflowInteger, Ord) {
-  static_assert(::sus::ops::Ord<OverflowInteger<i32>>);
-  static_assert(::sus::ops::Ord<OverflowInteger<i32>, i32>);
-  static_assert(::sus::ops::Ord<i32, OverflowInteger<i32>>);
+TEST(OverflowInteger, StrongOrd) {
+  static_assert(::sus::ops::StrongOrd<OverflowInteger<i32>>);
+  static_assert(::sus::ops::StrongOrd<OverflowInteger<i32>, i32>);
+  static_assert(::sus::ops::StrongOrd<i32, OverflowInteger<i32>>);
 
   EXPECT_EQ(OverflowInteger<i32>::with(5) <=> 4_i32,
             std::strong_ordering::greater);

--- a/sus/num/u16_unittest.cc
+++ b/sus/num/u16_unittest.cc
@@ -113,16 +113,16 @@ TEST(u16, Traits) {
   static_assert(sus::num::Shr<u16>);
   static_assert(sus::num::ShrAssign<u16>);
 
-  static_assert(sus::ops::Ord<u16, uint8_t>);
-  static_assert(sus::ops::Ord<u16, uint16_t>);
-  static_assert(sus::ops::Ord<u16, uint32_t>);
-  static_assert(sus::ops::Ord<u16, uint64_t>);
-  static_assert(sus::ops::Ord<u16, size_t>);
-  static_assert(sus::ops::Ord<u16, u8>);
-  static_assert(sus::ops::Ord<u16, u16>);
-  static_assert(sus::ops::Ord<u16, u32>);
-  static_assert(sus::ops::Ord<u16, u64>);
-  static_assert(sus::ops::Ord<u16, usize>);
+  static_assert(sus::ops::StrongOrd<u16, uint8_t>);
+  static_assert(sus::ops::StrongOrd<u16, uint16_t>);
+  static_assert(sus::ops::StrongOrd<u16, uint32_t>);
+  static_assert(sus::ops::StrongOrd<u16, uint64_t>);
+  static_assert(sus::ops::StrongOrd<u16, size_t>);
+  static_assert(sus::ops::StrongOrd<u16, u8>);
+  static_assert(sus::ops::StrongOrd<u16, u16>);
+  static_assert(sus::ops::StrongOrd<u16, u32>);
+  static_assert(sus::ops::StrongOrd<u16, u64>);
+  static_assert(sus::ops::StrongOrd<u16, usize>);
   static_assert(1_u16 >= 1_u16);
   static_assert(2_u16 > 1_u16);
   static_assert(1_u16 <= 1_u16);

--- a/sus/num/u32_unittest.cc
+++ b/sus/num/u32_unittest.cc
@@ -117,16 +117,16 @@ TEST(u32, Traits) {
   static_assert(sus::num::Shr<u32>);
   static_assert(sus::num::ShrAssign<u32>);
 
-  static_assert(sus::ops::Ord<u32, uint8_t>);
-  static_assert(sus::ops::Ord<u32, uint16_t>);
-  static_assert(sus::ops::Ord<u32, uint32_t>);
-  static_assert(sus::ops::Ord<u32, uint64_t>);
-  static_assert(sus::ops::Ord<u32, size_t>);
-  static_assert(sus::ops::Ord<u32, u8>);
-  static_assert(sus::ops::Ord<u32, u16>);
-  static_assert(sus::ops::Ord<u32, u32>);
-  static_assert(sus::ops::Ord<u32, u64>);
-  static_assert(sus::ops::Ord<u32, usize>);
+  static_assert(sus::ops::StrongOrd<u32, uint8_t>);
+  static_assert(sus::ops::StrongOrd<u32, uint16_t>);
+  static_assert(sus::ops::StrongOrd<u32, uint32_t>);
+  static_assert(sus::ops::StrongOrd<u32, uint64_t>);
+  static_assert(sus::ops::StrongOrd<u32, size_t>);
+  static_assert(sus::ops::StrongOrd<u32, u8>);
+  static_assert(sus::ops::StrongOrd<u32, u16>);
+  static_assert(sus::ops::StrongOrd<u32, u32>);
+  static_assert(sus::ops::StrongOrd<u32, u64>);
+  static_assert(sus::ops::StrongOrd<u32, usize>);
   static_assert(1_u32 >= 1_u32);
   static_assert(2_u32 > 1_u32);
   static_assert(1_u32 <= 1_u32);

--- a/sus/num/u64_unittest.cc
+++ b/sus/num/u64_unittest.cc
@@ -113,16 +113,16 @@ TEST(u64, Traits) {
   static_assert(sus::num::Shr<u64>);
   static_assert(sus::num::ShrAssign<u64>);
 
-  static_assert(sus::ops::Ord<u64, uint8_t>);
-  static_assert(sus::ops::Ord<u64, uint16_t>);
-  static_assert(sus::ops::Ord<u64, uint32_t>);
-  static_assert(sus::ops::Ord<u64, uint64_t>);
-  static_assert(sus::ops::Ord<u64, size_t>);
-  static_assert(sus::ops::Ord<u64, u8>);
-  static_assert(sus::ops::Ord<u64, u16>);
-  static_assert(sus::ops::Ord<u64, u32>);
-  static_assert(sus::ops::Ord<u64, u64>);
-  static_assert(sus::ops::Ord<u64, usize>);
+  static_assert(sus::ops::StrongOrd<u64, uint8_t>);
+  static_assert(sus::ops::StrongOrd<u64, uint16_t>);
+  static_assert(sus::ops::StrongOrd<u64, uint32_t>);
+  static_assert(sus::ops::StrongOrd<u64, uint64_t>);
+  static_assert(sus::ops::StrongOrd<u64, size_t>);
+  static_assert(sus::ops::StrongOrd<u64, u8>);
+  static_assert(sus::ops::StrongOrd<u64, u16>);
+  static_assert(sus::ops::StrongOrd<u64, u32>);
+  static_assert(sus::ops::StrongOrd<u64, u64>);
+  static_assert(sus::ops::StrongOrd<u64, usize>);
   static_assert(1_u64 >= 1_u64);
   static_assert(2_u64 > 1_u64);
   static_assert(1_u64 <= 1_u64);

--- a/sus/num/u8_unittest.cc
+++ b/sus/num/u8_unittest.cc
@@ -113,16 +113,16 @@ TEST(u8, Traits) {
   static_assert(sus::num::Shr<u8>);
   static_assert(sus::num::ShrAssign<u8>);
 
-  static_assert(sus::ops::Ord<u8, uint8_t>);
-  static_assert(sus::ops::Ord<u8, uint16_t>);
-  static_assert(sus::ops::Ord<u8, uint32_t>);
-  static_assert(sus::ops::Ord<u8, uint64_t>);
-  static_assert(sus::ops::Ord<u8, size_t>);
-  static_assert(sus::ops::Ord<u8, u8>);
-  static_assert(sus::ops::Ord<u8, u16>);
-  static_assert(sus::ops::Ord<u8, u32>);
-  static_assert(sus::ops::Ord<u8, u64>);
-  static_assert(sus::ops::Ord<u8, usize>);
+  static_assert(sus::ops::StrongOrd<u8, uint8_t>);
+  static_assert(sus::ops::StrongOrd<u8, uint16_t>);
+  static_assert(sus::ops::StrongOrd<u8, uint32_t>);
+  static_assert(sus::ops::StrongOrd<u8, uint64_t>);
+  static_assert(sus::ops::StrongOrd<u8, size_t>);
+  static_assert(sus::ops::StrongOrd<u8, u8>);
+  static_assert(sus::ops::StrongOrd<u8, u16>);
+  static_assert(sus::ops::StrongOrd<u8, u32>);
+  static_assert(sus::ops::StrongOrd<u8, u64>);
+  static_assert(sus::ops::StrongOrd<u8, usize>);
   static_assert(1_u8 >= 1_u8);
   static_assert(2_u8 > 1_u8);
   static_assert(1_u8 <= 1_u8);

--- a/sus/num/uptr_unittest.cc
+++ b/sus/num/uptr_unittest.cc
@@ -113,16 +113,16 @@ TEST(uptr, Traits) {
   static_assert(sus::num::Shr<uptr>);
   static_assert(sus::num::ShrAssign<uptr>);
 
-  static_assert(sus::ops::Ord<uptr, uint8_t>);
-  static_assert(sus::ops::Ord<uptr, uint16_t>);
-  static_assert(sus::ops::Ord<uptr, uint64_t>);
-  static_assert(sus::ops::Ord<uptr, uint64_t>);
-  static_assert(sus::ops::Ord<uptr, size_t>);
-  static_assert(sus::ops::Ord<uptr, u8>);
-  static_assert(sus::ops::Ord<uptr, u16>);
-  static_assert(sus::ops::Ord<uptr, u32>);
-  static_assert(sus::ops::Ord<uptr, u64>);
-  static_assert(sus::ops::Ord<uptr, uptr>);
+  static_assert(sus::ops::StrongOrd<uptr, uint8_t>);
+  static_assert(sus::ops::StrongOrd<uptr, uint16_t>);
+  static_assert(sus::ops::StrongOrd<uptr, uint64_t>);
+  static_assert(sus::ops::StrongOrd<uptr, uint64_t>);
+  static_assert(sus::ops::StrongOrd<uptr, size_t>);
+  static_assert(sus::ops::StrongOrd<uptr, u8>);
+  static_assert(sus::ops::StrongOrd<uptr, u16>);
+  static_assert(sus::ops::StrongOrd<uptr, u32>);
+  static_assert(sus::ops::StrongOrd<uptr, u64>);
+  static_assert(sus::ops::StrongOrd<uptr, uptr>);
   static_assert(uptr(uintptr_t{1}) >= uptr(uintptr_t{1}));
   static_assert(uptr(uintptr_t{2}) > uptr(uintptr_t{1}));
   static_assert(uptr(uintptr_t{1}) <= uptr(uintptr_t{1}));

--- a/sus/num/usize_unittest.cc
+++ b/sus/num/usize_unittest.cc
@@ -120,16 +120,16 @@ TEST(usize, Traits) {
   static_assert(sus::num::Shr<usize>);
   static_assert(sus::num::ShrAssign<usize>);
 
-  static_assert(sus::ops::Ord<usize, uint8_t>);
-  static_assert(sus::ops::Ord<usize, uint16_t>);
-  static_assert(sus::ops::Ord<usize, uint64_t>);
-  static_assert(sus::ops::Ord<usize, uint64_t>);
-  static_assert(sus::ops::Ord<usize, size_t>);
-  static_assert(sus::ops::Ord<usize, u8>);
-  static_assert(sus::ops::Ord<usize, u16>);
-  static_assert(sus::ops::Ord<usize, u32>);
-  static_assert(sus::ops::Ord<usize, u64>);
-  static_assert(sus::ops::Ord<usize, usize>);
+  static_assert(sus::ops::StrongOrd<usize, uint8_t>);
+  static_assert(sus::ops::StrongOrd<usize, uint16_t>);
+  static_assert(sus::ops::StrongOrd<usize, uint64_t>);
+  static_assert(sus::ops::StrongOrd<usize, uint64_t>);
+  static_assert(sus::ops::StrongOrd<usize, size_t>);
+  static_assert(sus::ops::StrongOrd<usize, u8>);
+  static_assert(sus::ops::StrongOrd<usize, u16>);
+  static_assert(sus::ops::StrongOrd<usize, u32>);
+  static_assert(sus::ops::StrongOrd<usize, u64>);
+  static_assert(sus::ops::StrongOrd<usize, usize>);
   static_assert(1_usize >= 1_usize);
   static_assert(2_usize > 1_usize);
   static_assert(1_usize <= 1_usize);

--- a/sus/ops/__private/void_concepts.h
+++ b/sus/ops/__private/void_concepts.h
@@ -29,11 +29,11 @@ concept VoidOrEq =
 
 template <class T, class U = T>
 concept VoidOrOrd =
-    (std::is_void_v<T> && std::is_void_v<U>) || ::sus::ops::Ord<T, U>;
+    (std::is_void_v<T> && std::is_void_v<U>) || ::sus::ops::StrongOrd<T, U>;
 
 template <class T, class U = T>
 concept VoidOrWeakOrd =
-    (std::is_void_v<T> && std::is_void_v<U>) || ::sus::ops::WeakOrd<T, U>;
+    (std::is_void_v<T> && std::is_void_v<U>) || ::sus::ops::Ord<T, U>;
 
 template <class T, class U = T>
 concept VoidOrPartialOrd =

--- a/sus/ops/eq.h
+++ b/sus/ops/eq.h
@@ -36,7 +36,7 @@ namespace sus::ops {
 /// they can still be compared with `==` and `!=`. Unlike Rust, C++ does not
 /// understand partial equivalence so we are unable to differentiate.
 ///
-/// TODO: How do we do PartialEq? Can we even? Should we require Ord to be Eq?
+/// TODO: How do we do PartialEq? Can we even? Should we require StrongOrd to be Eq?
 template <class T, class U = T>
 concept Eq = requires(const std::remove_reference_t<T>& lhs,
                       const std::remove_reference_t<U>& rhs) {

--- a/sus/ops/ord_unittest.cc
+++ b/sus/ops/ord_unittest.cc
@@ -39,7 +39,7 @@ struct Strong {
     return a.i <=> b.i;
   }
 };
-static_assert(sus::ops::Ord<Strong>);
+static_assert(sus::ops::StrongOrd<Strong>);
 
 struct NoCmp {
   sus_clang_bug_54040(NoCmp(i32 i, i32 id) : i(i), id(id){});
@@ -47,9 +47,9 @@ struct NoCmp {
   i32 i;
   i32 id;
 };
-static_assert(!sus::ops::Ord<NoCmp>);
+static_assert(!sus::ops::StrongOrd<NoCmp>);
 
-TEST(Ord, Min) {
+TEST(StrongOrd, Min) {
   auto low1 = Strong(1, 1);
   auto low2 = Strong(1, 2);
   auto high = Strong(3, 3);
@@ -62,14 +62,14 @@ TEST(Ord, Min) {
   EXPECT_EQ(min(low2, low1).id, 2_i32);
 }
 
-TEST(Ord, MinBy) {
+TEST(StrongOrd, MinBy) {
   auto cmp = [](const NoCmp& a, const NoCmp& b) { return a.i <=> b.i; };
 
   auto low1 = NoCmp(1, 1);
   auto low2 = NoCmp(1, 2);
   auto high = NoCmp(3, 3);
 
-  // NoCmp is not Ord, but the comparator returns a strong_ordering, so they can
+  // NoCmp is not StrongOrd, but the comparator returns a strong_ordering, so they can
   // be compared through it.
   EXPECT_EQ(min_by(low1, high, cmp).id, 1_i32);
   EXPECT_EQ(min_by(high, low1, cmp).id, 1_i32);
@@ -79,14 +79,14 @@ TEST(Ord, MinBy) {
   EXPECT_EQ(min_by(low2, low1, cmp).id, 2_i32);
 }
 
-TEST(Ord, MinByKey) {
+TEST(StrongOrd, MinByKey) {
   auto get_i = [](const NoCmp& a) { return a.i; };
 
   auto low1 = NoCmp(1, 1);
   auto low2 = NoCmp(1, 2);
   auto high = NoCmp(3, 3);
 
-  // NoCmp is not Ord, but the key function returns a type that is Ord.
+  // NoCmp is not StrongOrd, but the key function returns a type that is StrongOrd.
   EXPECT_EQ(min_by_key(low1, high, get_i).id, 1_i32);
   EXPECT_EQ(min_by_key(high, low1, get_i).id, 1_i32);
 
@@ -95,7 +95,7 @@ TEST(Ord, MinByKey) {
   EXPECT_EQ(min_by_key(low2, low1, get_i).id, 2_i32);
 }
 
-TEST(Ord, Max) {
+TEST(StrongOrd, Max) {
   auto low1 = Strong(1, 1);
   auto low2 = Strong(1, 2);
   auto high = Strong(3, 3);
@@ -108,14 +108,14 @@ TEST(Ord, Max) {
   EXPECT_EQ(max(low2, low1).id, 1_i32);
 }
 
-TEST(Ord, MaxBy) {
+TEST(StrongOrd, MaxBy) {
   auto cmp = [](const NoCmp& a, const NoCmp& b) { return a.i <=> b.i; };
 
   auto low1 = NoCmp(1, 1);
   auto low2 = NoCmp(1, 2);
   auto high = NoCmp(3, 3);
 
-  // NoCmp is not Ord, but the comparator returns a strong_ordering, so they can
+  // NoCmp is not StrongOrd, but the comparator returns a strong_ordering, so they can
   // be compared through it.
   EXPECT_EQ(max_by(low1, high, cmp).id, 3_i32);
   EXPECT_EQ(max_by(high, low1, cmp).id, 3_i32);
@@ -125,14 +125,14 @@ TEST(Ord, MaxBy) {
   EXPECT_EQ(max_by(low2, low1, cmp).id, 1_i32);
 }
 
-TEST(Ord, MaxByKey) {
+TEST(StrongOrd, MaxByKey) {
   auto get_i = [](const NoCmp& a) { return a.i; };
 
   auto low1 = NoCmp(1, 1);
   auto low2 = NoCmp(1, 2);
   auto high = NoCmp(3, 3);
 
-  // NoCmp is not Ord, but the key function returns a type that is Ord.
+  // NoCmp is not StrongOrd, but the key function returns a type that is StrongOrd.
   EXPECT_EQ(max_by_key(low1, high, get_i).id, 3_i32);
   EXPECT_EQ(max_by_key(high, low1, get_i).id, 3_i32);
 

--- a/sus/ops/range_unittest.cc
+++ b/sus/ops/range_unittest.cc
@@ -300,7 +300,7 @@ TEST(Range, fmt) {
     i32 a = 0x16ae3cf2;
     auto operator<=>(const NoFormat& rhs) const noexcept { return a <=> rhs.a; }
   };
-  static_assert(sus::ops::Ord<NoFormat>);
+  static_assert(sus::ops::StrongOrd<NoFormat>);
   static_assert(!fmt::is_formattable<NoFormat, char>::value);
   static_assert(fmt::is_formattable<sus::ops::Range<NoFormat>, char>::value);
   static_assert(

--- a/sus/option/option.h
+++ b/sus/option/option.h
@@ -1214,19 +1214,19 @@ class Option final {
 
   /// Compares two Options.
   ///
-  /// Satisfies sus::ops::Ord<Option<U>> if sus::ops::Ord<U>.
+  /// Satisfies sus::ops::StrongOrd<Option<U>> if sus::ops::StrongOrd<U>.
   ///
-  /// Satisfies sus::ops::WeakOrd<Option<U>> if sus::ops::WeakOrd<U>.
+  /// Satisfies sus::ops::Ord<Option<U>> if sus::ops::Ord<U>.
   ///
   /// Satisfies sus::ops::PartialOrd<Option<U>> if sus::ops::PartialOrd<U>.
   ///
   /// The non-template overloads allow some/none marker types to convert to
   /// Option for comparison.
   //
-  // sus::ops::Ord<Option<U>> trait.
+  // sus::ops::StrongOrd<Option<U>> trait.
   friend constexpr inline auto operator<=>(const Option& l,
                                            const Option& r) noexcept
-    requires(::sus::ops::ExclusiveOrd<T>)
+    requires(::sus::ops::ExclusiveStrongOrd<T>)
   {
     switch (l) {
       case Some:
@@ -1245,7 +1245,7 @@ class Option final {
     ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
   template <class U>
-    requires(::sus::ops::ExclusiveOrd<T, U>)
+    requires(::sus::ops::ExclusiveStrongOrd<T, U>)
   friend constexpr inline auto operator<=>(const Option<T>& l,
                                            const Option<U>& r) noexcept {
     switch (l) {
@@ -1265,10 +1265,10 @@ class Option final {
     ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
 
-  // sus::ops::WeakOrd<Option<U>> trait.
+  // sus::ops::Ord<Option<U>> trait.
   friend constexpr inline auto operator<=>(const Option& l,
                                            const Option& r) noexcept
-    requires(::sus::ops::ExclusiveWeakOrd<T>)
+    requires(::sus::ops::ExclusiveOrd<T>)
   {
     switch (l) {
       case Some:
@@ -1287,7 +1287,7 @@ class Option final {
     ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
   template <class U>
-    requires(::sus::ops::ExclusiveWeakOrd<T, U>)
+    requires(::sus::ops::ExclusiveOrd<T, U>)
   friend constexpr inline auto operator<=>(const Option<T>& l,
                                            const Option<U>& r) noexcept {
     switch (l) {

--- a/sus/option/option_unittest.cc
+++ b/sus/option/option_unittest.cc
@@ -2378,7 +2378,7 @@ TEST(Option, Eq) {
   EXPECT_EQ(Option<i32>(), sus::none());
 }
 
-TEST(Option, Ord) {
+TEST(Option, StrongOrd) {
   EXPECT_LT(Option<int>::with(1), Option<int>::with(2));
   EXPECT_GT(Option<int>::with(3), Option<int>::with(2));
 
@@ -2390,7 +2390,7 @@ TEST(Option, Ord) {
 }
 
 TEST(Option, StrongOrder) {
-  static_assert(::sus::ops::Ord<Option<int>>);
+  static_assert(::sus::ops::StrongOrd<Option<int>>);
 
   EXPECT_EQ(std::strong_order(Option<int>::with(12), Option<int>::with(12)),
             std::strong_ordering::equal);
@@ -2420,8 +2420,8 @@ struct Weak {
 };
 
 TEST(Option, WeakOrder) {
-  static_assert(!::sus::ops::Ord<Option<Weak>>);
-  static_assert(::sus::ops::WeakOrd<Option<Weak>>);
+  static_assert(!::sus::ops::StrongOrd<Option<Weak>>);
+  static_assert(::sus::ops::Ord<Option<Weak>>);
 
   auto x = std::weak_order(Option<Weak>::with(Weak(1, 2)),
                            Option<Weak>::with(Weak(1, 2)));
@@ -2438,7 +2438,7 @@ TEST(Option, WeakOrder) {
 }
 
 TEST(Option, PartialOrder) {
-  static_assert(!::sus::ops::WeakOrd<Option<float>>);
+  static_assert(!::sus::ops::Ord<Option<float>>);
   static_assert(::sus::ops::PartialOrd<Option<float>>);
 
   EXPECT_EQ(

--- a/sus/ptr/nonnull.h
+++ b/sus/ptr/nonnull.h
@@ -195,9 +195,9 @@ constexpr inline bool operator==(const NonNull<T>& l,
   return l.as_ptr() == r.as_ptr();
 }
 
-/// sus::ops::Ord<NonNull<T>> trait.
+/// sus::ops::StrongOrd<NonNull<T>> trait.
 template <class T, class U>
-  requires(::sus::ops::Ord<const T*, const U*>)
+  requires(::sus::ops::StrongOrd<const T*, const U*>)
 constexpr inline auto operator<=>(const NonNull<T>& l,
                                   const NonNull<U>& r) noexcept {
   return l.as_ptr() <=> r.as_ptr();

--- a/sus/ptr/nonnull_unittest.cc
+++ b/sus/ptr/nonnull_unittest.cc
@@ -263,11 +263,11 @@ TEST(NonNull, Eq) {
   EXPECT_NE(NonNull<Sub>::with(s), NonNull<Base>::with(static_cast<Base&>(s2)));
 }
 
-TEST(NonNull, Ord) {
+TEST(NonNull, StrongOrd) {
   struct NotCmp {};
-  static_assert(sus::ops::Ord<NonNull<int>>);
+  static_assert(sus::ops::StrongOrd<NonNull<int>>);
   sus_gcc_bug_107542_else(
-      static_assert(!sus::ops::Ord<NonNull<int>, NonNull<NotCmp>>));
+      static_assert(!sus::ops::StrongOrd<NonNull<int>, NonNull<NotCmp>>));
 
   int a[] = {1, 2};
   EXPECT_LE(NonNull<int>::with(a[0]), NonNull<int>::with(a[0]));

--- a/sus/result/result.h
+++ b/sus/result/result.h
@@ -876,11 +876,11 @@ class [[nodiscard]] Result final {
 
   /// Compares two Result.
   ///
+  /// Satisfies sus::ops::StrongOrd<Result<T, E>> if sus::ops::StrongOrd<T> and
+  /// sus::ops::StrongOrd<E>.
+  ///
   /// Satisfies sus::ops::Ord<Result<T, E>> if sus::ops::Ord<T> and
   /// sus::ops::Ord<E>.
-  ///
-  /// Satisfies sus::ops::WeakOrd<Result<T, E>> if sus::ops::WeakOrd<T> and
-  /// sus::ops::WeakOrd<E>.
   ///
   /// Satisfies sus::ops::PartialOrd<Result<T, E>> if sus::ops::PartialOrd<T>
   /// and sus::ops::PartialOrd<E>.
@@ -888,9 +888,9 @@ class [[nodiscard]] Result final {
   /// The non-template overloads allow ok/err marker types to convert to
   /// Option for comparison.
   //
-  // sus::ops::Ord<Result<T, E>> trait.
+  // sus::ops::StrongOrd<Result<T, E>> trait.
   friend constexpr auto operator<=>(const Result& l, const Result& r) noexcept
-    requires(VoidOrOrd<T> && ::sus::ops::Ord<E>)
+    requires(VoidOrOrd<T> && ::sus::ops::StrongOrd<E>)
   {
     ::sus::check(l.state_ != ResultState::IsMoved);
     switch (l.state_) {
@@ -913,7 +913,7 @@ class [[nodiscard]] Result final {
     ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
   template <class U, class F>
-    requires(VoidOrOrd<T, U> && ::sus::ops::Ord<E, F>)
+    requires(VoidOrOrd<T, U> && ::sus::ops::StrongOrd<E, F>)
   friend constexpr auto operator<=>(const Result& l,
                                     const Result<U, F>& r) noexcept {
     ::sus::check(l.state_ != ResultState::IsMoved);
@@ -937,10 +937,10 @@ class [[nodiscard]] Result final {
     ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
 
-  // sus::ops::WeakOrd<Result<T, E>> trait.
+  // sus::ops::Ord<Result<T, E>> trait.
   friend constexpr auto operator<=>(const Result& l, const Result& r) noexcept
-    requires((!VoidOrOrd<T> || !::sus::ops::Ord<E>) && VoidOrWeakOrd<T> &&
-             ::sus::ops::WeakOrd<E>)
+    requires((!VoidOrOrd<T> || !::sus::ops::StrongOrd<E>) && VoidOrWeakOrd<T> &&
+             ::sus::ops::Ord<E>)
   {
     ::sus::check(l.state_ != ResultState::IsMoved);
     switch (l.state_) {
@@ -963,8 +963,8 @@ class [[nodiscard]] Result final {
     ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
   template <class U, class F>
-    requires((!VoidOrOrd<T, U> || !::sus::ops::Ord<E, F>) &&
-             VoidOrWeakOrd<T, U> && ::sus::ops::WeakOrd<E, F>)
+    requires((!VoidOrOrd<T, U> || !::sus::ops::StrongOrd<E, F>) &&
+             VoidOrWeakOrd<T, U> && ::sus::ops::Ord<E, F>)
   friend constexpr auto operator<=>(const Result& l,
                                     const Result<U, F>& r) noexcept {
     ::sus::check(l.state_ != ResultState::IsMoved);
@@ -990,7 +990,7 @@ class [[nodiscard]] Result final {
 
   // sus::ops::PartialOrd<Result<T, E>> trait.
   friend constexpr auto operator<=>(const Result& l, const Result& r) noexcept
-    requires((!VoidOrWeakOrd<T> || !::sus::ops::WeakOrd<E>) &&
+    requires((!VoidOrWeakOrd<T> || !::sus::ops::Ord<E>) &&
              VoidOrPartialOrd<T> && ::sus::ops::PartialOrd<E>)
   {
     ::sus::check(l.state_ != ResultState::IsMoved);
@@ -1014,7 +1014,7 @@ class [[nodiscard]] Result final {
     ::sus::unreachable_unchecked(::sus::marker::unsafe_fn);
   }
   template <class U, class F>
-    requires((!VoidOrWeakOrd<T, U> || !::sus::ops::WeakOrd<E, F>) &&
+    requires((!VoidOrWeakOrd<T, U> || !::sus::ops::Ord<E, F>) &&
              VoidOrPartialOrd<T, U> && ::sus::ops::PartialOrd<E, F>)
   friend constexpr auto operator<=>(const Result& l,
                                     const Result<U, F>& r) noexcept {

--- a/sus/result/result_unittest.cc
+++ b/sus/result/result_unittest.cc
@@ -1766,8 +1766,8 @@ TEST(Result, Eq) {
             (Result<NoCopyMove&, i32>::with_err(2)));
 }
 
-TEST(Result, Ord) {
-  static_assert(::sus::ops::Ord<Result<i32, i32>>);
+TEST(Result, StrongOrd) {
+  static_assert(::sus::ops::StrongOrd<Result<i32, i32>>);
 
   static_assert(Result<i32, i32>::with(1) < Result<i32, i32>::with(2));
   static_assert(Result<i32, i32>::with(3) > Result<i32, i32>::with(2));
@@ -1841,13 +1841,13 @@ struct Weak {
 };
 
 TEST(Result, WeakOrder) {
-  static_assert(!::sus::ops::Ord<Result<Weak, i32>>);
-  static_assert(!::sus::ops::Ord<Result<i32, Weak>>);
-  static_assert(!::sus::ops::Ord<Result<Weak, Weak>>);
+  static_assert(!::sus::ops::StrongOrd<Result<Weak, i32>>);
+  static_assert(!::sus::ops::StrongOrd<Result<i32, Weak>>);
+  static_assert(!::sus::ops::StrongOrd<Result<Weak, Weak>>);
 
-  static_assert(::sus::ops::WeakOrd<Result<Weak, i32>>);
-  static_assert(::sus::ops::WeakOrd<Result<i32, Weak>>);
-  static_assert(::sus::ops::WeakOrd<Result<Weak, Weak>>);
+  static_assert(::sus::ops::Ord<Result<Weak, i32>>);
+  static_assert(::sus::ops::Ord<Result<i32, Weak>>);
+  static_assert(::sus::ops::Ord<Result<Weak, Weak>>);
 
   static_assert(std::weak_order(Result<Weak, i32>::with(Weak(1, 2)),
                                 Result<Weak, i32>::with(Weak(1, 2))) ==
@@ -1864,13 +1864,13 @@ TEST(Result, WeakOrder) {
 }
 
 TEST(Result, PartialOrder) {
+  static_assert(!::sus::ops::StrongOrd<Result<f32, i8>>);
+  static_assert(!::sus::ops::StrongOrd<Result<i8, f32>>);
+  static_assert(!::sus::ops::StrongOrd<Result<f32, f32>>);
+
   static_assert(!::sus::ops::Ord<Result<f32, i8>>);
   static_assert(!::sus::ops::Ord<Result<i8, f32>>);
   static_assert(!::sus::ops::Ord<Result<f32, f32>>);
-
-  static_assert(!::sus::ops::WeakOrd<Result<f32, i8>>);
-  static_assert(!::sus::ops::WeakOrd<Result<i8, f32>>);
-  static_assert(!::sus::ops::WeakOrd<Result<f32, f32>>);
 
   static_assert(::sus::ops::PartialOrd<Result<f32, i8>>);
   static_assert(::sus::ops::PartialOrd<Result<i8, f32>>);

--- a/sus/tuple/tuple.h
+++ b/sus/tuple/tuple.h
@@ -181,17 +181,17 @@ class Tuple final {
 
   /// Compares two Tuples.
   ///
-  /// Satisfies sus::ops::Ord<Tuple<...>> if sus::ops::Ord<...>.
-  /// Satisfies sus::ops::WeakOrd<Option<...>> if sus::ops::WeakOrd<...>.
+  /// Satisfies sus::ops::StrongOrd<Tuple<...>> if sus::ops::StrongOrd<...>.
+  /// Satisfies sus::ops::Ord<Option<...>> if sus::ops::Ord<...>.
   /// Satisfies sus::ops::PartialOrd<Option<...>> if sus::ops::PartialOrd<...>.
   ///
   /// The non-template overloads allow tuple() marker types to convert to
   /// Option for comparison.
   //
-  // sus::ops::Ord<Tuple<U...>> trait.
+  // sus::ops::StrongOrd<Tuple<U...>> trait.
   constexpr auto operator<=>(const Tuple& r) const& noexcept
-    requires((::sus::ops::ExclusiveOrd<T> && ... &&
-              ::sus::ops::ExclusiveOrd<Ts>))
+    requires((::sus::ops::ExclusiveStrongOrd<T> && ... &&
+              ::sus::ops::ExclusiveStrongOrd<Ts>))
   {
     return __private::storage_cmp(
         std::strong_ordering::equal, storage_, r.storage_,
@@ -199,18 +199,18 @@ class Tuple final {
   }
   template <class U, class... Us>
     requires(sizeof...(Us) == sizeof...(Ts) &&
-             (::sus::ops::ExclusiveOrd<T, U> && ... &&
-              ::sus::ops::ExclusiveOrd<Ts, Us>))
+             (::sus::ops::ExclusiveStrongOrd<T, U> && ... &&
+              ::sus::ops::ExclusiveStrongOrd<Ts, Us>))
   constexpr auto operator<=>(const Tuple<U, Us...>& r) const& noexcept {
     return __private::storage_cmp(
         std::strong_ordering::equal, storage_, r.storage_,
         std::make_index_sequence<1u + sizeof...(Ts)>());
   }
 
-  // sus::ops::WeakOrd<Tuple<U...>> trait.
+  // sus::ops::Ord<Tuple<U...>> trait.
   constexpr auto operator<=>(const Tuple& r) const& noexcept
-    requires((::sus::ops::ExclusiveWeakOrd<T> && ... &&
-              ::sus::ops::ExclusiveWeakOrd<Ts>))
+    requires((::sus::ops::ExclusiveOrd<T> && ... &&
+              ::sus::ops::ExclusiveOrd<Ts>))
   {
     return __private::storage_cmp(
         std::weak_ordering::equivalent, storage_, r.storage_,
@@ -218,8 +218,8 @@ class Tuple final {
   }
   template <class U, class... Us>
     requires(sizeof...(Us) == sizeof...(Ts) &&
-             (::sus::ops::ExclusiveWeakOrd<T, U> && ... &&
-              ::sus::ops::ExclusiveWeakOrd<Ts, Us>))
+             (::sus::ops::ExclusiveOrd<T, U> && ... &&
+              ::sus::ops::ExclusiveOrd<Ts, Us>))
   constexpr auto operator<=>(const Tuple<U, Us...>& r) const& noexcept {
     return __private::storage_cmp(
         std::weak_ordering::equivalent, storage_, r.storage_,

--- a/sus/tuple/tuple_unittest.cc
+++ b/sus/tuple/tuple_unittest.cc
@@ -430,7 +430,7 @@ TEST(Tuple, Eq) {
   EXPECT_NE(tn1, tn2);
 }
 
-TEST(Tuple, Ord) {
+TEST(Tuple, StrongOrd) {
   EXPECT_LT(Tuple<int>::with(1), Tuple<int>::with(2));
   EXPECT_GT(Tuple<int>::with(3), Tuple<int>::with(2));
   EXPECT_GT((Tuple<int, int>::with(3, 4)), (Tuple<int, int>::with(3, 3)));
@@ -524,11 +524,11 @@ TEST(Tuple, PartialOrder) {
 struct NotCmp {};
 static_assert(!sus::ops::PartialOrd<NotCmp>);
 
-static_assert(sus::ops::Ord<Tuple<int>>);
-static_assert(!sus::ops::Ord<Tuple<Weak>>);
-static_assert(sus::ops::WeakOrd<Tuple<Weak>>);
-static_assert(!sus::ops::WeakOrd<Tuple<float>>);
-static_assert(!sus::ops::WeakOrd<Tuple<float>>);
+static_assert(sus::ops::StrongOrd<Tuple<int>>);
+static_assert(!sus::ops::StrongOrd<Tuple<Weak>>);
+static_assert(sus::ops::Ord<Tuple<Weak>>);
+static_assert(!sus::ops::Ord<Tuple<float>>);
+static_assert(!sus::ops::Ord<Tuple<float>>);
 static_assert(!sus::ops::PartialOrd<Tuple<NotCmp>>);
 
 TEST(Tuple, StructuredBinding) {


### PR DESCRIPTION
The common case of ordering is just that a total order exists. The equality comparison of operator== is completely separate and requiring Ord does not mean the function may even use operator==. This is satisfied by std::weak_ordering. Since it is the common case, and it is the safer choice (you can't do it wrong with an incorrect operator==) and it matches the requirements of Ord in Rust, we name this Ord here.

C++ has an additional ordering to Rust which is std::strong_ordering. This ordering guarantees that (if Eq is satisifed) the operator== will return true iff the ordering of two elements are the same. That is each different object value is unique in the total ordering. This requires that the developer write operator== correctly (if at all), and it is uncommon to require this over std::weak_ordering. So we name this StrongOrd and document it accordingly.

Closes #310