### PR TITLE
Fix compilation on Clang Mac

### DIFF
--- a/sus/iter/size_hint_impl.h
+++ b/sus/iter/size_hint_impl.h
@@ -19,6 +19,7 @@
 #include "fmt/format.h"
 #include "sus/iter/size_hint.h"
 #include "sus/num/unsigned_integer_impl.h"  // For formatting usize.
+#include "sus/option/option.h"              // For formatting option.
 #include "sus/string/__private/format_to_stream.h"
 
 // fmt support.

--- a/sus/num/__private/int_log10.h
+++ b/sus/num/__private/int_log10.h
@@ -16,6 +16,7 @@
 // IWYU pragma: friend "sus/.*"
 #pragma once
 
+#include <concepts>
 #include <stdint.h>
 
 #include "sus/macros/inline.h"
@@ -80,22 +81,22 @@ sus_pure_const sus_always_inline constexpr uint32_t u64(uint64_t val) noexcept {
 }
 
 sus_pure_const sus_always_inline constexpr uint32_t usize(
-    uint32_t val) noexcept {
+    std::same_as<uint32_t> auto val) noexcept {
   return u32(val);
 }
 
 sus_pure_const sus_always_inline constexpr uint32_t usize(
-    uint64_t val) noexcept {
+    std::same_as<uint64_t> auto val) noexcept {
   return u64(val);
 }
 
 sus_pure_const sus_always_inline constexpr uint32_t uptr(
-    uint32_t val) noexcept {
+    std::same_as<uint32_t> auto val) noexcept {
   return u32(val);
 }
 
 sus_pure_const sus_always_inline constexpr uint32_t uptr(
-    uint64_t val) noexcept {
+    std::same_as<uint64_t> auto val) noexcept {
   return u64(val);
 }
 

--- a/sus/num/__private/unsigned_integer_methods_impl.inc
+++ b/sus/num/__private/unsigned_integer_methods_impl.inc
@@ -187,8 +187,7 @@ sus_pure constexpr ::sus::tuple_type::Tuple<_self, bool> _self::overflowing_add(
     _self rhs) const& noexcept {
   const auto out =
       __private::add_with_overflow(primitive_value, rhs.primitive_value);
-  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value),
-                                                     out.overflow);
+  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value), out.overflow);
 }
 
 #if !_pointer  // No `_signed` for uptr.
@@ -257,8 +256,7 @@ sus_pure constexpr ::sus::tuple_type::Tuple<_self, bool> _self::overflowing_mul(
     _self rhs) const& noexcept {
   const auto out =
       __private::mul_with_overflow(primitive_value, rhs.primitive_value);
-  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value),
-                                                     out.overflow);
+  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value), out.overflow);
 }
 
 sus_pure constexpr ::sus::option::Option<_self> _self::checked_neg()
@@ -345,8 +343,7 @@ sus_pure constexpr ::sus::tuple_type::Tuple<_self, bool> _self::overflowing_shl(
     u32 rhs) const& noexcept {
   const auto out =
       __private::shl_with_overflow(primitive_value, rhs.primitive_value);
-  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value),
-                                                     out.overflow);
+  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value), out.overflow);
 }
 
 sus_pure constexpr ::sus::option::Option<_self> _self::checked_shr(
@@ -363,8 +360,7 @@ sus_pure constexpr ::sus::tuple_type::Tuple<_self, bool> _self::overflowing_shr(
     u32 rhs) const& noexcept {
   const auto out =
       __private::shr_with_overflow(primitive_value, rhs.primitive_value);
-  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value),
-                                                     out.overflow);
+  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value), out.overflow);
 }
 
 sus_pure constexpr ::sus::option::Option<_self> _self::checked_sub(
@@ -381,8 +377,7 @@ sus_pure constexpr ::sus::tuple_type::Tuple<_self, bool> _self::overflowing_sub(
     _self rhs) const& noexcept {
   const auto out =
       __private::sub_with_overflow(primitive_value, rhs.primitive_value);
-  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value),
-                                                     out.overflow);
+  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value), out.overflow);
 }
 
 sus_pure constexpr ::sus::option::Option<_self> _self::checked_pow(
@@ -400,8 +395,7 @@ sus_pure constexpr ::sus::tuple_type::Tuple<_self, bool> _self::overflowing_pow(
     u32 exp) const& noexcept {
   const auto out =
       __private::pow_with_overflow(primitive_value, exp.primitive_value);
-  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value),
-                                                     out.overflow);
+  return ::sus::tuple_type::Tuple<_self, bool>(_self(out.value), out.overflow);
 }
 
 sus_pure constexpr ::sus::option::Option<u32> _self::checked_log2()
@@ -527,7 +521,8 @@ sus_pure constexpr _self _self::from_ne_bytes(
   } else {
     ::sus::ptr::copy_nonoverlapping(
         ::sus::marker::unsafe_fn, reinterpret_cast<const char*>(bytes.as_ptr()),
-        reinterpret_cast<char*>(&val.primitive_value), ::sus::mem::size_of<_primitive>());
+        reinterpret_cast<char*>(&val.primitive_value),
+        ::sus::mem::size_of<_primitive>());
   }
   return _self(val);
 }

--- a/sus/num/unsigned_integer.h
+++ b/sus/num/unsigned_integer.h
@@ -130,13 +130,13 @@ struct [[sus_trivial_abi]] usize final {
 #define _self usize
 #define _pointer false
 #define _pointer_sized
-#define _primitive size_t
+#define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<size_t>()>::unsigned_type
 #define _signed isize
 #include "sus/num/__private/unsigned_integer_methods.inc"
 };
 #define _self usize
 #define _pointer false
-#define _primitive size_t
+#define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<size_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_consts.inc"
 
 /// A pointer-sized unsigned integer.
@@ -167,12 +167,12 @@ struct [[sus_trivial_abi]] uptr final {
 #define _self uptr
 #define _pointer true
 #define _pointer_sized ::sus::num::__private::ptr_type<>::pointer_sized_type
-#define _primitive uintptr_t
+#define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_methods.inc"
 };
 #define _self uptr
 #define _pointer true
-#define _primitive uintptr_t
+#define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_consts.inc"
 
 /// sus::num::Add<T*, usize> trait.

--- a/sus/num/unsigned_integer_impl.h
+++ b/sus/num/unsigned_integer_impl.h
@@ -52,11 +52,11 @@
 
 #define _self usize
 #define _pointer 0
-#define _primitive size_t
+#define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<size_t>()>::unsigned_type
 #define _signed isize
 #include "sus/num/__private/unsigned_integer_methods_impl.inc"
 
 #define _self uptr
 #define _pointer 1
-#define _primitive uintptr_t
+#define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_methods_impl.inc"


### PR DESCRIPTION
On Mac, the size_t and uintptr_t types are not interchangeable with uint32_t or uint64_t, so don't use them as the usize and uptr primitive_value field types. Doing so leads to ambiguous overload problems when calling overloads based on uint32_t and uint64_t as it could convert to either one.

Instead, use the uint32_t or uint64_t type directly.

Include option.h in size_hint_impl.h to ensure the formattability of it is visible always when defining the formatting of SizeHint.