### PR TITLE
Add as_ptr/as_mut_ptr to numeric types

### DIFF
--- a/sus/num/__private/float_methods.inc
+++ b/sus/num/__private/float_methods.inc
@@ -236,6 +236,23 @@ sus_pure constexpr inline operator U() const noexcept {
   return primitive_value;
 }
 
+/// Returns a mutable pointer to the underlying C++ primitive value type.
+///
+/// This allows Subspace numerics be used with APIs that expect a pointer to a
+/// C++ primitive type.
+sus_pure constexpr _primitive* as_mut_ptr() & noexcept {
+  return &primitive_value;
+}
+
+/// Returns a const pointer to the underlying C++ primitive value type.
+///
+/// This allows Subspace numerics be used with APIs that expect a pointer to a
+/// C++ primitive type.
+sus_pure constexpr const _primitive* as_ptr() const& noexcept {
+  return &primitive_value;
+}
+sus_pure constexpr const _primitive* as_ptr() && noexcept = delete;
+
 /// Satisfies the [`Eq`]($sus::ops::Eq) concept for floating point numbers.
 /// #[doc.overloads=float.eq]
 [[nodiscard]] sus_pure_const friend constexpr inline bool operator==(

--- a/sus/num/__private/signed_integer_methods.inc
+++ b/sus/num/__private/signed_integer_methods.inc
@@ -494,6 +494,23 @@ sus_pure constexpr inline operator U() const noexcept {
   return primitive_value;
 }
 
+/// Returns a mutable pointer to the underlying C++ primitive value type.
+///
+/// This allows Subspace numerics be used with APIs that expect a pointer to a
+/// C++ primitive type.
+sus_pure constexpr _primitive* as_mut_ptr() & noexcept {
+  return &primitive_value;
+}
+
+/// Returns a const pointer to the underlying C++ primitive value type.
+///
+/// This allows Subspace numerics be used with APIs that expect a pointer to a
+/// C++ primitive type.
+sus_pure constexpr const _primitive* as_ptr() const& noexcept {
+  return &primitive_value;
+}
+sus_pure constexpr const _primitive* as_ptr() && noexcept = delete;
+
 /// Returns true if the current value is positive and false if the number is
 /// zero or negative.
 sus_pure constexpr bool is_negative() const& noexcept {

--- a/sus/num/__private/unsigned_integer_methods.inc
+++ b/sus/num/__private/unsigned_integer_methods.inc
@@ -561,6 +561,23 @@ sus_pure constexpr inline operator U() const noexcept {
 
 #endif
 
+/// Returns a mutable pointer to the underlying C++ primitive value type.
+///
+/// This allows Subspace numerics be used with APIs that expect a pointer to a
+/// C++ primitive type.
+sus_pure constexpr _primitive* as_mut_ptr() & noexcept {
+  return &primitive_value;
+}
+
+/// Returns a const pointer to the underlying C++ primitive value type.
+///
+/// This allows Subspace numerics be used with APIs that expect a pointer to a
+/// C++ primitive type.
+sus_pure constexpr const _primitive* as_ptr() const& noexcept {
+  return &primitive_value;
+}
+sus_pure constexpr const _primitive* as_ptr() && noexcept = delete;
+
 /// Satisfies the [`Eq`]($sus::ops::Eq) concept for unsigned integers.
 /// #[doc.overloads=uint.eq]
 [[nodiscard]] sus_pure friend constexpr inline bool operator==(
@@ -627,8 +644,8 @@ template <Unsigned U>
 /// #[doc.overloads=unsignedint.+]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator+(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator+(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} + r;
 }
 #endif
@@ -689,8 +706,8 @@ template <Unsigned U>
 /// #[doc.overloads=unsignedint.-]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator-(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator-(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} - r;
 }
 #endif
@@ -751,8 +768,8 @@ template <Unsigned U>
 /// #[doc.overloads=unsignedint.*]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator*(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator*(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} * r;
 }
 #endif
@@ -811,8 +828,8 @@ template <Unsigned U>
 /// #[doc.overloads=unsignedint./]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator/(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator/(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} / r;
 }
 #endif
@@ -871,8 +888,8 @@ template <Unsigned U>
 /// #[doc.overloads=unsignedint.%]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator%(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator%(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} % r;
 }
 #endif
@@ -930,8 +947,8 @@ template <Unsigned U>
 /// #[doc.overloads=unsignedint.&]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator&(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator&(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} & r;
 }
 #endif
@@ -988,8 +1005,8 @@ template <Unsigned U>
 /// #[doc.overloads=unsignedint.|]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator|(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator|(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} | r;
 }
 #endif
@@ -1041,13 +1058,13 @@ template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
 [[nodiscard]] sus_pure friend constexpr inline _self operator^(_self l,
                                                                U r) noexcept {
-  return l ^ _primitive{r.primitive_value};
+  return l ^ _primitive { r.primitive_value };
 }
 /// #[doc.overloads=unsignedint.^]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator^(U l,
-                                                               _self r) noexcept {
+[[nodiscard]] sus_pure friend constexpr inline _self operator^(
+    U l, _self r) noexcept {
   return _primitive{l.primitive_value} ^ r;
 }
 #endif

--- a/sus/num/f32_unittest.cc
+++ b/sus/num/f32_unittest.cc
@@ -1114,4 +1114,17 @@ TEST(f32, NextToward) {
   EXPECT_LT((0_f32).next_toward(-1_f32), 0_f32);
 }
 
+// ==== AsPtr / AsMutPtr
+
+static_assert([] {
+  f32 f;
+  static_assert(std::same_as<decltype(f.as_ptr()), const float*>);
+  return f.as_ptr() == &f.primitive_value;
+}());
+static_assert([] {
+  f32 f;
+  static_assert(std::same_as<decltype(f.as_mut_ptr()), float*>);
+  return f.as_mut_ptr() == &f.primitive_value;
+}());
+
 }  // namespace

--- a/sus/num/i32_unittest.cc
+++ b/sus/num/i32_unittest.cc
@@ -2928,4 +2928,17 @@ TEST(i32, Stream) {
 
 TEST(i32, GTest) { EXPECT_EQ(testing::PrintToString(123_i32), "123"); }
 
+// ==== AsPtr / AsMutPtr
+
+static_assert([] {
+  i32 v;
+  static_assert(std::same_as<decltype(v.as_ptr()), const int32_t*>);
+  return v.as_ptr() == &v.primitive_value;
+}());
+static_assert([] {
+  i32 v;
+  static_assert(std::same_as<decltype(v.as_mut_ptr()), int32_t*>);
+  return v.as_mut_ptr() == &v.primitive_value;
+}());
+
 }  // namespace

--- a/sus/num/u32_unittest.cc
+++ b/sus/num/u32_unittest.cc
@@ -2137,4 +2137,17 @@ TEST(u32, Stream) {
 
 TEST(u32, GTest) { EXPECT_EQ(testing::PrintToString(123_u32), "123"); }
 
+// ==== AsPtr / AsMutPtr
+
+static_assert([] {
+  u32 v;
+  static_assert(std::same_as<decltype(v.as_ptr()), const uint32_t*>);
+  return v.as_ptr() == &v.primitive_value;
+}());
+static_assert([] {
+  u32 v;
+  static_assert(std::same_as<decltype(v.as_mut_ptr()), uint32_t*>);
+  return v.as_mut_ptr() == &v.primitive_value;
+}());
+
 }  // namespace


### PR DESCRIPTION
These return a pointer to underlying C++ primitive type, so they can be used with legacy APIs that need such pointers more easily. As they are technically a container of a single primitive, they use the as_ptr syntax following Slice/SliceMut/Box.

Closes #372