### PR TITLE
Put moved() onto IteratorOverRange and make it unsafe

### DIFF
--- a/sus/collections/compat_deque_unittest.cc
+++ b/sus/collections/compat_deque_unittest.cc
@@ -25,9 +25,9 @@ static_assert(sus::iter::FromIterator<std::deque<usize>, usize>);
 
 TEST(CompatDeque, FromIterator) {
   auto in = std::deque<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::deque<i32>>();
   sus::check(out == std::deque<i32>{2, 4, 6});
 }

--- a/sus/collections/compat_forward_list_unittest.cc
+++ b/sus/collections/compat_forward_list_unittest.cc
@@ -21,7 +21,8 @@
 namespace sus::test::compat_forward_list {
 
 template <sus::iter::Iterator<i32> Iter>
-struct SingleEnded final : public sus::iter::IteratorBase<SingleEnded<Iter>, i32> {
+struct SingleEnded final
+    : public sus::iter::IteratorBase<SingleEnded<Iter>, i32> {
   SingleEnded(Iter it) : it_(sus::move(it)) {}
 
   using Item = i32;
@@ -47,21 +48,20 @@ TEST(CompatForwardList, FromIterator) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
   static_assert(sus::iter::DoubleEndedIterator<
                 decltype(sus::iter::from_range(sus::move(in))), i32&>);
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::forward_list<i32>>();
   sus::check(out == std::forward_list<i32>{2, 4, 6});
 }
 
 TEST(CompatForwardList, FromIteratorNotDoubleEnded) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto it = SingleEnded(sus::iter::from_range(sus::move(in)).moved());
+  auto it = SingleEnded(sus::iter::from_range(in).moved(unsafe_fn));
   static_assert(sus::iter::Iterator<decltype(it), i32>);
   static_assert(!sus::iter::DoubleEndedIterator<decltype(it), i32>);
   auto out = sus::move(it)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::forward_list<i32>>();
   sus::check(out == std::forward_list<i32>{2, 4, 6});
 }

--- a/sus/collections/compat_list_unittest.cc
+++ b/sus/collections/compat_list_unittest.cc
@@ -25,9 +25,9 @@ static_assert(sus::iter::FromIterator<std::list<usize>, usize>);
 
 TEST(CompatList, FromIterator) {
   auto in = std::list<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::list<i32>>();
   sus::check(out == std::list<i32>{2, 4, 6});
 }

--- a/sus/collections/compat_queue_unittest.cc
+++ b/sus/collections/compat_queue_unittest.cc
@@ -26,9 +26,9 @@ static_assert(sus::iter::FromIterator<std::priority_queue<usize>, usize>);
 
 TEST(CompatQueue, FromIterator) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::queue<i32>>();
   static_assert(std::same_as<decltype(out), std::queue<i32>>);
   sus::check(out == std::queue<i32>(std::deque<i32>{2, 4, 6}));
@@ -36,10 +36,10 @@ TEST(CompatQueue, FromIterator) {
 
 TEST(CompatQueue, FromIteratorRef) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
                  .rev()
-                 .moved()
                  .collect<std::queue<i32>>();
   static_assert(std::same_as<decltype(out), std::queue<i32>>);
   sus::check(out == std::queue<i32>(std::deque<i32>{6, 4, 2}));
@@ -47,9 +47,9 @@ TEST(CompatQueue, FromIteratorRef) {
 
 TEST(CompatPriorityQueue, FromIterator) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::priority_queue<i32>>();
   static_assert(std::same_as<decltype(out), std::priority_queue<i32>>);
   auto cmp =
@@ -65,10 +65,10 @@ TEST(CompatPriorityQueue, FromIterator) {
 
 TEST(CompatPriorityQueue, FromIteratorRef) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
                  .rev()
-                 .moved()
                  .collect<std::priority_queue<i32>>();
   static_assert(std::same_as<decltype(out), std::priority_queue<i32>>);
   auto cmp =

--- a/sus/collections/compat_set_unittest.cc
+++ b/sus/collections/compat_set_unittest.cc
@@ -26,9 +26,9 @@ static_assert(sus::iter::FromIterator<std::set<usize>, usize>);
 
 TEST(CompatSet, FromIterator) {
   auto in = std::vector<i32>{3, 4, 2, 7, 6, 1, 5};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::set<i32>>();
   static_assert(std::same_as<decltype(out), std::set<i32>>);
   sus::check(out == std::set<i32>{2, 4, 6});
@@ -36,9 +36,9 @@ TEST(CompatSet, FromIterator) {
 
 TEST(CompaMultiSet, FromIterator) {
   auto in = std::vector<i32>{3, 4, 2, 7, 6, 2, 1, 5, 2};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::multiset<i32>>();
   static_assert(std::same_as<decltype(out), std::multiset<i32>>);
   sus::check(out == std::multiset<i32>{2, 2, 2, 4, 6});

--- a/sus/collections/compat_stack_unittest.cc
+++ b/sus/collections/compat_stack_unittest.cc
@@ -25,9 +25,9 @@ static_assert(sus::iter::FromIterator<std::stack<usize>, usize>);
 
 TEST(CompatStack, FromIterator) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::stack<i32>>();
   static_assert(std::same_as<decltype(out), std::stack<i32>>);
   sus::check(out == std::stack<i32>(std::deque<i32>{2, 4, 6}));
@@ -35,10 +35,10 @@ TEST(CompatStack, FromIterator) {
 
 TEST(CompatStack, FromIteratorRef) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
                  .rev()
-                 .moved()
                  .collect<std::stack<i32>>();
   static_assert(std::same_as<decltype(out), std::stack<i32>>);
   sus::check(out == std::stack<i32>(std::deque<i32>{6, 4, 2}));

--- a/sus/collections/compat_unordered_set_unittest.cc
+++ b/sus/collections/compat_unordered_set_unittest.cc
@@ -26,9 +26,9 @@ static_assert(sus::iter::FromIterator<std::unordered_set<usize>, usize>);
 
 TEST(CompatUnorderedSet, FromIterator) {
   auto in = std::vector<i32>{3, 4, 2, 7, 6, 1, 5};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::unordered_set<i32>>();
   static_assert(std::same_as<decltype(out), std::unordered_set<i32>>);
   sus::check(out == std::unordered_set<i32>{2, 4, 6});
@@ -39,8 +39,8 @@ TEST(CompatUnorderedSet, Options) {
       sus::some(3), sus::some(4), sus::some(2), sus::some(7),
       sus::none(),  // None is present, so output is None.
       sus::some(6), sus::some(1), sus::some(5)};
-  auto out_with_none = sus::iter::from_range(sus::move(with_none))
-                           .moved()
+  auto out_with_none = sus::iter::from_range(with_none)
+                           .moved(unsafe_fn)
                            .collect<sus::Option<std::unordered_set<i32>>>();
   static_assert(std::same_as<decltype(out_with_none),
                              sus::Option<std::unordered_set<i32>>>);
@@ -49,8 +49,8 @@ TEST(CompatUnorderedSet, Options) {
   auto all_some = std::vector<sus::Option<i32>>{
       sus::some(3), sus::some(4), sus::some(2), sus::some(7),
       sus::some(6), sus::some(1), sus::some(5)};
-  auto out_all_some = sus::iter::from_range(sus::move(all_some))
-                          .moved()
+  auto out_all_some = sus::iter::from_range(all_some)
+                          .moved(unsafe_fn)
                           .collect<sus::Option<std::unordered_set<i32>>>();
   static_assert(std::same_as<decltype(out_all_some),
                              sus::Option<std::unordered_set<i32>>>);
@@ -60,9 +60,9 @@ TEST(CompatUnorderedSet, Options) {
 
 TEST(CompatUnorderedMultiSet, FromIterator) {
   auto in = std::vector<i32>{3, 4, 2, 7, 2, 6, 1, 2, 5};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::unordered_multiset<i32>>();
   static_assert(std::same_as<decltype(out), std::unordered_multiset<i32>>);
   sus::check(out == std::unordered_multiset<i32>{2, 2, 2, 4, 6});

--- a/sus/collections/compat_vector_unittest.cc
+++ b/sus/collections/compat_vector_unittest.cc
@@ -25,9 +25,9 @@ static_assert(sus::iter::FromIterator<std::vector<usize>, usize>);
 
 TEST(CompatVector, FromIterator) {
   auto in = std::vector<i32>{1, 2, 3, 4, 5, 6, 7};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](const i32& i) { return i % 2 == 0; })
-                 .moved()
                  .collect<std::vector<i32>>();
   sus::check(out == std::vector<i32>{2, 4, 6});
 }

--- a/sus/iter/iterator.h
+++ b/sus/iter/iterator.h
@@ -45,7 +45,6 @@
 #include "sus/iter/adaptors/inspect.h"
 #include "sus/iter/adaptors/map.h"
 #include "sus/iter/adaptors/map_while.h"
-#include "sus/iter/adaptors/moved.h"
 #include "sus/iter/adaptors/peekable.h"
 #include "sus/iter/adaptors/reverse.h"
 #include "sus/iter/adaptors/scan.h"

--- a/sus/iter/iterator_defn.h
+++ b/sus/iter/iterator_defn.h
@@ -574,14 +574,6 @@ class IteratorBase {
              !std::is_reference_v<Key>)
   constexpr Option<Item> min_by_key(KeyFn fn) && noexcept;
 
-  /// Creates an iterator which moves all of its elements.
-  ///
-  /// This is useful when you have an iterator over `T&`, but you need an iterator
-  /// over `T`.
-  constexpr Iterator<std::remove_cvref_t<Item>> auto moved() && noexcept
-    requires(::sus::mem::Move<Item> &&  //
-             !std::is_const_v<std::remove_reference_t<Item>>);
-
   /// Determines if the elements of this `Iterator` are not equal to those of
   /// another.
   template <IntoIteratorAny Other, int&...,
@@ -1575,16 +1567,6 @@ constexpr Option<Item> IteratorBase<Iter, Item>::min_by_key(
       [](auto&& key_item) -> Item {
         return sus::move(key_item).template into_inner<1>();
       });
-}
-
-template <class Iter, class Item>
-Iterator<std::remove_cvref_t<Item>> auto constexpr IteratorBase<
-    Iter, Item>::moved() && noexcept
-  requires(::sus::mem::Move<Item> &&  //
-           !std::is_const_v<std::remove_reference_t<Item>>)
-{
-  using Moved = Moved<Iter>;
-  return Moved(static_cast<Iter&&>(*this));
 }
 
 template <class Iter, class Item>

--- a/sus/iter/iterator_unittest.cc
+++ b/sus/iter/iterator_unittest.cc
@@ -861,57 +861,6 @@ TEST(Iterator, Copied) {
   static_assert(sus::Vec<usize>(1u, 2u).into_iter().copied().sum() == 1u + 2u);
 }
 
-TEST(Iterator, Moved) {
-  struct Movable {
-    Movable(i32 i) : i(i) {}
-    Movable(Movable&& m) : i(m.i) { m.i += 1; }
-    Movable& operator=(Movable&& m) { return i = m.i, m.i += 1, *this; }
-    i32 i;
-
-    constexpr bool operator==(const Movable& rhs) const noexcept = default;
-  };
-
-  // Move from references.
-  {
-    auto moving = sus::Vec<Movable>(Movable(1), Movable(2));
-    auto mslice = moving.as_slice();
-
-    auto it = moving.iter_mut().moved();
-    static_assert(std::same_as<Movable, decltype(it.next().unwrap())>);
-    EXPECT_EQ(it.size_hint().lower, 2u);
-    EXPECT_EQ(it.size_hint().upper.unwrap(), 2u);
-
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(1), Movable(2))));
-    EXPECT_EQ(it.next().unwrap().i, 1);
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(2), Movable(2))));
-    EXPECT_EQ(it.next().unwrap().i, 2);
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(2), Movable(3))));
-    EXPECT_EQ(it.next(), sus::None);
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(2), Movable(3))));
-  }
-
-  // Move from values.
-  {
-    auto moving = sus::Vec<Movable>(Movable(1), Movable(2));
-    auto mslice = moving.as_slice();
-
-    auto it = sus::move(moving).into_iter().moved();
-    static_assert(std::same_as<Movable, decltype(it.next().unwrap())>);
-    EXPECT_EQ(it.size_hint().lower, 2u);
-    EXPECT_EQ(it.size_hint().upper.unwrap(), 2u);
-
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(1), Movable(2))));
-    EXPECT_EQ(it.next().unwrap().i, 1);
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(2), Movable(2))));
-    EXPECT_EQ(it.next().unwrap().i, 2);
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(2), Movable(3))));
-    EXPECT_EQ(it.next(), sus::None);
-    EXPECT_EQ(mslice, (sus::Vec<Movable>(Movable(2), Movable(3))));
-  }
-
-  static_assert(sus::Vec<usize>(1u, 2u).into_iter().copied().sum() == 1u + 2u);
-}
-
 TEST(Iterator, StrongCmp) {
   {
     auto smol = sus::Vec<i32>(1, 2);

--- a/sus/string/compat_string_unittest.cc
+++ b/sus/string/compat_string_unittest.cc
@@ -37,36 +37,36 @@ Out construct(const Char* s) {
 
 TEST(CompatString, Char) {
   auto in = std::vector<char>{'a', 'b', 'c', 'd'};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](char i) { return i != 'c'; })
-                 .moved()
                  .collect<std::string>();
   sus::check(out == construct<std::string>("abd"));
 }
 
 TEST(CompatString, Char8) {
   auto in = std::vector<char8_t>{'a', 'b', 'c', 'd'};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](char8_t i) { return i != 'c'; })
-                 .moved()
                  .collect<std::u8string>();
   sus::check(out == construct<std::u8string>("abd"));
 }
 
 TEST(CompatString, Char16) {
   auto in = std::vector<char16_t>{'a', 'b', 'c', 'd'};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](char16_t i) { return i != 'c'; })
-                 .moved()
                  .collect<std::u16string>();
   sus::check(out == construct<std::u16string>("abd"));
 }
 
 TEST(CompatString, Char32) {
   auto in = std::vector<char32_t>{'a', 'b', 'c', 'd'};
-  auto out = sus::iter::from_range(sus::move(in))
+  auto out = sus::iter::from_range(in)
+                 .moved(unsafe_fn)
                  .filter([](char32_t i) { return i != 'c'; })
-                 .moved()
                  .collect<std::u32string>();
   sus::check(out == construct<std::u32string>("abd"));
 }


### PR DESCRIPTION
moved() will move from the references in the range, which leaves behing moved-from objects which can cause bugs and Undefined Behaviour. It is up to the caller to clear those elements from the range or destroy the range after using moved(). This type of global analysis requires careful code review and is thus *unsafe*.

Subspace collections don't need the moved() function, as you can consume the collection (move from it) to make the iterator, which will then own the elements and yield them by value, moving them from the iterator.

We do *not* use std::borrowed_range here because it returns the wrong default. It returns false for types it does not know about, but those types (like llvm::ArrayRef for instance) may not own the elements they provide a range over, and moving from them is invalid. Even if borrowed_range could be made accurate though, the requirement for the caller of moved() to clean things up after makes the operation unsafe.