### PR TITLE
Option<T> converts to Option<U> if T converts to U

### DIFF
--- a/sus/option/option.h
+++ b/sus/option/option.h
@@ -530,6 +530,14 @@ class Option final {
              sus::construct::SafelyConstructibleFromReference<T, U &&>)
       : Option(WITH_SOME, move_to_storage(t)) {}
 
+  /// Converts from `Option<X>` to `Option<Y>` if `X` is convertible to `Y`.
+  template <class U>
+    requires(std::convertible_to<U, T>)
+  constexpr Option(const Option<U>& other) : t_(other.t_) {}
+  template <class U>
+    requires(std::convertible_to<U &&, T>)
+  constexpr Option(Option<U>&& other) : t_(::sus::move(other.t_)) {}
+
   /// Moves or copies `val` into a new option holding `Some(val)`.
   ///
   /// Implements [`From<Option<T>, T>`]($sus::construct::From).


### PR DESCRIPTION
This also implies From<Option<U>, Option<T>>.

This is important for inheritance/subtyping, to be able to up-cast. Once downcast exists, we could consider a downcast method on option, though Rust gets away without that (but also has no inheritance).

It also allows you to `return Option(3)` when the return type is Option<i32>, though some(3) will do a better job.

Closes #384