### PR TITLE
Add round_ties and clarify the rounding behaviour of round

### DIFF
--- a/sus/num/__private/float_methods.inc
+++ b/sus/num/__private/float_methods.inc
@@ -725,10 +725,46 @@ sus_pure inline _self powi(i32 n) const& noexcept {
 sus_pure inline _self recip() const& noexcept {
   return _primitive{1} / primitive_value;
 }
-/// Returns the nearest integer to itself, rounding half-way cases away from
-/// `0.0`.
+/// Returns the nearest integer to self. If a value is half-way between two
+/// integers, round away from `0.0`.
+///
+/// This rounding behaviour matches the behaviour of the [`std::round`](
+/// https://en.cppreference.com/w/cpp/numeric/math/round) standard library
+/// function, but is much slower and less conformant than [`round_ties`](
+/// $sus::num::@doc.self::round_ties) which often makes the latter a better
+/// choice.
+///
+/// As in Rust's [`round`](
+/// https://doc.rust-lang.org/stable/std/primitive.@doc.self.html#method.round),
+/// this method preserves the sign bit when the result is `-0.0`, but this is
+/// unlike [`std::round`](https://en.cppreference.com/w/cpp/numeric/math/round).
 sus_pure inline _self round() const& noexcept {
   return __private::float_round(primitive_value);
+}
+/// Returns the nearest integer to self. If a value is half-way between two
+/// integers, respects the current [rounding mode](
+/// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round). The default mode
+/// will round ties to the nearest even number.
+///
+/// This rounding operation is faster and more standard conformant than
+/// [`round`]($sus::num::@doc.self::round), making it generally preferable.
+/// However it breaks with the legacy behaviour of [`std::round`](
+/// https://en.cppreference.com/w/cpp/numeric/math/round).
+///
+/// Rust has the unstable [`round_ties_even`](
+/// https://doc.rust-lang.org/stable/std/primitive.@doc.self.html#method.round_ties_even)
+/// method that always uses the [`FE_TONEAREST`](
+/// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round) rounding mode. In
+/// C++ the rounding mode can be controlled by the user with
+/// [`std::fesetround`](https://en.cppreference.com/w/cpp/numeric/fenv/feround).
+///
+/// As in Rust's [`round`](
+/// https://doc.rust-lang.org/stable/std/primitive.@doc.self.html#method.round)
+/// and with [`std::nearbyint`](
+/// https://en.cppreference.com/w/cpp/numeric/math/nearbyint), this method
+/// preserves the sign bit when the result is `-0.0`.
+sus_pure inline _self round_ties() const& noexcept {
+  return __private::float_round_ties_by_mode(primitive_value);
 }
 /// Returns a number that represents the sign of self.
 ///

--- a/sus/num/__private/intrinsics.h
+++ b/sus/num/__private/intrinsics.h
@@ -1450,12 +1450,18 @@ sus_pure_const inline T float_signum(T x) noexcept {
 template <class T>
   requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
 sus_pure_const inline T float_round(T x) noexcept {
-  /* MSVC round(float) is returning a double for some reason. */
-  const auto out = into_unsigned_integer(static_cast<T>(::round(x)));
-  // `round()` doesn't preserve the sign bit, so we need to restore it, for
-  // (-0.5, -0.0].
+  // MSVC round(float) is returning a double for some reason.
+  const auto out = into_unsigned_integer(static_cast<T>(std::round(x)));
+  // `round()` doesn't preserve the sign bit for -0, so we need to restore it,
+  // for (-0.5, -0.0].
   return into_float((out & ~high_bit<T>()) |
                     (into_unsigned_integer(x) & high_bit<T>()));
+}
+
+template <class T>
+  requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
+sus_pure_const inline T float_round_ties_by_mode(T x) noexcept {
+  return std::nearbyint(x);
 }
 
 #if __has_builtin(__builtin_fpclassify)


### PR DESCRIPTION
The round methods will match the behaviour of Rust, which matches the C round() function except for also preserving the negative sign on zero.

Add round_ties which will use the current rounding mode to round ties, which by default is to the nearest even number which is also what is specified by the IEEE 754 standard. Rust has an unstable round_ties_even which does the same thing, but does not need to worry about the user specifying a rounding mode, so it can always provide a single behaviour. For this reason and to avoid excessive calls to set the rounding mode, we provide a more general and C++-specific version that follows the mode and does not claim any one in particular.

We document that round_ties is much faster than round and is usually preferable.