### PR TITLE
Add round_to_iN() methods on f32 and f64

### DIFF
--- a/sus/num/__private/float_methods.inc
+++ b/sus/num/__private/float_methods.inc
@@ -725,7 +725,7 @@ sus_pure inline _self powi(i32 n) const& noexcept {
 sus_pure inline _self recip() const& noexcept {
   return _primitive{1} / primitive_value;
 }
-/// Returns the nearest integer to self. If a value is half-way between two
+/// Returns the nearest integer to `self`. If a value is half-way between two
 /// integers, round away from `0.0`.
 ///
 /// This rounding behaviour matches the behaviour of the [`std::round`](
@@ -741,7 +741,7 @@ sus_pure inline _self recip() const& noexcept {
 sus_pure inline _self round() const& noexcept {
   return __private::float_round(primitive_value);
 }
-/// Returns the nearest integer to self. If a value is half-way between two
+/// Returns the nearest integer to `self`. If a value is half-way between two
 /// integers, respects the current [rounding mode](
 /// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round). The default mode
 /// will round ties to the nearest even number.
@@ -765,6 +765,81 @@ sus_pure inline _self round() const& noexcept {
 /// preserves the sign bit when the result is `-0.0`.
 sus_pure inline _self round_ties() const& noexcept {
   return __private::float_round_ties_by_mode(primitive_value);
+}
+/// Returns the nearest [`i8`]($sus::num::i8) representable by `self`.
+///
+/// This is equivalent to `sus::mog<i8>(self.round_ties())` but it may require
+/// fewer instructions on some platforms.
+///
+/// Like [`round_ties`]($sus::num::@doc.self::round_ties), but unlike
+/// [`round`]($sus::num::@doc.self::round), the current [rounding mode](
+/// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round) will be respected
+/// to break ties. The default mode will round ties to the nearest even number.
+///
+/// A `NaN` input will return 0.
+sus_pure inline i8 round_to_i8() const& noexcept {
+  return __private::float_round_to<decltype(i8::MAX_PRIMITIVE)>(
+      primitive_value);
+}
+/// Returns the nearest [`i16`]($sus::num::i16) representable by `self`.
+///
+/// This is equivalent to `sus::mog<i16>(self.round_ties())` but it may require
+/// fewer instructions on some platforms.
+///
+/// Like [`round_ties`]($sus::num::@doc.self::round_ties), but unlike
+/// [`round`]($sus::num::@doc.self::round), the current [rounding mode](
+/// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round) will be respected
+/// to break ties. The default mode will round ties to the nearest even number.
+///
+/// A `NaN` input will return 0.
+sus_pure inline i16 round_to_i16() const& noexcept {
+  return __private::float_round_to<decltype(i16::MAX_PRIMITIVE)>(
+      primitive_value);
+}
+/// Returns the nearest [`i32`]($sus::num::i32) representable by `self`.
+///
+/// This is equivalent to `sus::mog<i32>(self.round_ties())` but it may require
+/// fewer instructions on some platforms.
+///
+/// Like [`round_ties`]($sus::num::@doc.self::round_ties), but unlike
+/// [`round`]($sus::num::@doc.self::round), the current [rounding mode](
+/// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round) will be respected
+/// to break ties. The default mode will round ties to the nearest even number.
+///
+/// A `NaN` input will return 0.
+sus_pure inline i32 round_to_i32() const& noexcept {
+  return __private::float_round_to<decltype(i32::MAX_PRIMITIVE)>(
+      primitive_value);
+}
+/// Returns the nearest [`i64`]($sus::num::i64) representable by `self`.
+///
+/// This is equivalent to `sus::mog<i64>(self.round_ties())` but it may require
+/// fewer instructions on some platforms.
+///
+/// Like [`round_ties`]($sus::num::@doc.self::round_ties), but unlike
+/// [`round`]($sus::num::@doc.self::round), the current [rounding mode](
+/// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round) will be respected
+/// to break ties. The default mode will round ties to the nearest even number.
+///
+/// A `NaN` input will return 0.
+sus_pure inline i64 round_to_i64() const& noexcept {
+  return __private::float_round_to<decltype(i64::MAX_PRIMITIVE)>(
+      primitive_value);
+}
+/// Returns the nearest [`isize`]($sus::num::isize) representable by `self`.
+///
+/// This is equivalent to `sus::mog<isize>(self.round_ties())` but it may
+/// require fewer instructions on some platforms.
+///
+/// Like [`round_ties`]($sus::num::@doc.self::round_ties), but unlike
+/// [`round`]($sus::num::@doc.self::round), the current [rounding mode](
+/// https://en.cppreference.com/w/cpp/numeric/fenv/FE_round) will be respected
+/// to break ties. The default mode will round ties to the nearest even number.
+///
+/// A `NaN` input will return 0.
+sus_pure inline isize round_to_isize() const& noexcept {
+  return __private::float_round_to<decltype(isize::MAX_PRIMITIVE)>(
+      primitive_value);
 }
 /// Returns a number that represents the sign of self.
 ///
@@ -951,12 +1026,12 @@ sus_pure constexpr inline bool is_subnormal() const& noexcept {
 /// # Panics
 /// Panics if min > max, min is NaN, or max is NaN.
 sus_pure constexpr inline _self clamp(_self min, _self max) const& noexcept {
-  check(!min.is_nan() && !max.is_nan() &&
-        min.primitive_value <= max.primitive_value);
+  ::sus::check(!min.is_nan() && !max.is_nan() &&
+               min.primitive_value <= max.primitive_value);
   // SAFETY: We have verified that the min and max are not NaN and that
   // `min <= max`.
-  return __private::float_clamp(::sus::marker::unsafe_fn, primitive_value,
-                                min.primitive_value, max.primitive_value);
+  return __private::float_clamp(primitive_value, min.primitive_value,
+                                max.primitive_value);
 }
 
 /// Calculates Euclidean division, the matching method for

--- a/sus/num/__private/intrinsics.h
+++ b/sus/num/__private/intrinsics.h
@@ -187,6 +187,246 @@ sus_pure_const sus_always_inline constexpr T max_value() noexcept {
 }
 
 template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_int64_float() noexcept {
+  // Computed with https://godbolt.org/z/1sj8YdMf5.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= i64::MAX.
+    return 9223371487098961920.f;
+  } else {
+    // Largest double that is <= i64::MAX.
+    return 9223372036854774784.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_int32_float() noexcept {
+  // Computed with https://godbolt.org/z/1sj8YdMf5.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= i32::MAX.
+    return 2147483520.f;
+  } else {
+    // Largest double that is <= i32::MAX.
+    return 2147483648.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_int16_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= i16::MAX.
+    return 32767.f;
+  } else {
+    // Largest double that is <= i16::MAX.
+    return 32767.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_int8_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= i8::MAX.
+    return 127.f;
+  } else {
+    // Largest double that is <= i8::MAX.
+    return 127.0;
+  }
+}
+
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_int64_float() noexcept {
+  // Computed with https://godbolt.org/z/1sj8YdMf5.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Smallest float that is >= i64::MIN.
+    return -9223371487098961920.f;
+  } else {
+    // Smallest double that is >= i64::MIN.
+    return -9223372036854774784.0;
+  }
+}
+
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_int32_float() noexcept {
+  // Computed with https://godbolt.org/z/1sj8YdMf5.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Smallest float that is >= i32::MIN.
+    return -2147483520.f;
+  } else {
+    // Smallest float that is >= i32::MIN.
+    return -2147483649.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_int16_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is >= i16::MIN.
+    return -32768.f;
+  } else {
+    // Largest double that is >= i16::MIN.
+    return -32768.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_int8_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is >= i8::MIN.
+    return -128.f;
+  } else {
+    // Largest double that is >= i8::MIN.
+    return -128.0;
+  }
+}
+
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_uint64_float() noexcept {
+  // Computed with https://godbolt.org/z/bY3vrvos9.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= u64::MAX.
+    return 18446742974197923840.f;
+  } else {
+    // Largest double that is <= u64::MAX.
+    return 18446744073709549568.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_uint32_float() noexcept {
+  // Computed with https://godbolt.org/z/bY3vrvos9.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= u32::MAX.
+    return 4294967040.f;
+  } else {
+    // Largest double that is <= u32::MAX.
+    return 4294967295.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_uint16_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= u16::MAX.
+    return 65535.f;
+  } else {
+    // Largest double that is <= u16::MAX.
+    return 65535.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T max_uint8_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is <= u8::MAX.
+    return 255.f;
+  } else {
+    // Largest double that is <= u8::MAX.
+    return 255.0;
+  }
+}
+
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_uint64_float() noexcept {
+  // Computed with https://godbolt.org/z/bY3vrvos9.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Smallest float that is >= u64::MIN.
+    return 0.f;
+  } else {
+    // Smallest double that is >= u64::MIN.
+    return 0.0;
+  }
+}
+
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_uint32_float() noexcept {
+  // Computed with https://godbolt.org/z/bY3vrvos9.
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Smallest float that is >= u32::MIN.
+    return 0.f;
+  } else {
+    // Smallest float that is >= u32::MIN.
+    return 0.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_uint16_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is >= u16::MIN.
+    return 0.f;
+  } else {
+    // Largest double that is >= u16::MIN.
+    return 0.0;
+  }
+}
+template <class T>
+  requires(std::is_floating_point_v<T>)
+sus_pure_const sus_always_inline constexpr T min_uint8_float() noexcept {
+  if constexpr (::sus::mem::size_of<T>() == 4) {
+    // Largest float that is >= u8::MIN.
+    return 0.f;
+  } else {
+    // Largest double that is >= u8::MIN.
+    return 0.0;
+  }
+}
+
+template <class I, class T>
+  requires(std::is_floating_point_v<T> && std::is_integral_v<I> &&
+           ::sus::mem::size_of<I>() <= 8)
+sus_pure_const sus_always_inline constexpr T max_int_float() noexcept {
+  if constexpr (std::is_signed_v<I>) {
+    if constexpr (::sus::mem::size_of<I>() == 8)
+      return max_int64_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 4)
+      return max_int32_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 2)
+      return max_int16_float<T>();
+    else
+      return max_int8_float<T>();
+  } else {
+    if constexpr (::sus::mem::size_of<I>() == 8)
+      return max_uint64_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 4)
+      return max_uint32_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 2)
+      return max_uint16_float<T>();
+    else
+      return max_uint8_float<T>();
+  }
+}
+
+template <class I, class T>
+  requires(std::is_floating_point_v<T> && std::is_integral_v<I> &&
+           ::sus::mem::size_of<I>() <= 8)
+sus_pure_const sus_always_inline constexpr T min_int_float() noexcept {
+  if constexpr (std::is_signed_v<I>) {
+    if constexpr (::sus::mem::size_of<I>() == 8)
+      return min_int64_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 4)
+      return min_int32_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 2)
+      return min_int16_float<T>();
+    else
+      return min_int8_float<T>();
+  } else {
+    if constexpr (::sus::mem::size_of<I>() == 8)
+      return min_uint64_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 4)
+      return min_uint32_float<T>();
+    else if constexpr (::sus::mem::size_of<I>() == 2)
+      return min_uint16_float<T>();
+    else
+      return min_uint8_float<T>();
+  }
+}
+
+template <class T>
   requires(std::is_integral_v<T> && !std::is_signed_v<T>)
 sus_pure_const sus_always_inline constexpr T min_value() noexcept {
   return T{0};
@@ -1379,23 +1619,8 @@ sus_pure_const inline constexpr bool float_is_normal(double x) noexcept {
 template <class T>
   requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
 sus_pure_const inline constexpr T truncate_float(T x) noexcept {
-  if constexpr (::sus::mem::size_of<T>() == 4) {
-    // Largest float that is <= i64::MAX.
-    constexpr float max_i64 = 9223371487098961920.f;
-    // Smallest float that is >= i64::MIN.
-    constexpr float min_i64 = -9223372036854775808.f;
-
-    if (x <= max_i64 && x >= min_i64)
-      return static_cast<T>(static_cast<int64_t>(x));
-  } else {
-    // Largest double that is <= i64::MAX.
-    constexpr double max_i64 = 9223372036854774784.0;
-    // Smallest double that is >= i64::MIN.
-    constexpr float min_i64 = -9223372036854775808.0;
-
-    if (x <= max_i64 && x >= min_i64)
-      return static_cast<T>(static_cast<int64_t>(x));
-  }
+  if (x <= max_int64_float<T>() && x >= min_int64_float<T>())
+    return static_cast<T>(static_cast<int64_t>(x));
 
   constexpr auto mantissa_width =
       ::sus::mem::size_of<T>() == ::sus::mem::size_of<float>() ? uint32_t{23}
@@ -1449,7 +1674,7 @@ sus_pure_const inline T float_signum(T x) noexcept {
 
 template <class T>
   requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
-sus_pure_const inline T float_round(T x) noexcept {
+sus_pure_const sus_always_inline T float_round(T x) noexcept {
   // MSVC round(float) is returning a double for some reason.
   const auto out = into_unsigned_integer(static_cast<T>(std::round(x)));
   // `round()` doesn't preserve the sign bit for -0, so we need to restore it,
@@ -1460,8 +1685,30 @@ sus_pure_const inline T float_round(T x) noexcept {
 
 template <class T>
   requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
-sus_pure_const inline T float_round_ties_by_mode(T x) noexcept {
+sus_pure_const sus_always_inline T float_round_ties_by_mode(T x) noexcept {
   return std::nearbyint(x);
+}
+
+template <class I, class T>
+  requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
+sus_pure_const sus_always_inline I float_round_to(T x) noexcept {
+  static_assert(::sus::mem::size_of<I>() <= ::sus::mem::size_of<long long>());
+
+  if (float_is_nan(x)) [[unlikely]]
+    return I{0};
+  if constexpr (::sus::mem::size_of<I>() == ::sus::mem::size_of<long long>()) {
+    if (x > max_int_float<I, T>()) [[unlikely]]
+      return max_value<I>();
+    if (x < min_int_float<I, T>()) [[unlikely]]
+      return min_value<I>();
+    return std::llrint(x);
+  } else {
+    if (x > max_int_float<I, T>()) [[unlikely]]
+      return max_value<I>();
+    if (x < min_int_float<I, T>()) [[unlikely]]
+      return min_value<I>();
+    return std::lrint(x);
+  }
 }
 
 #if __has_builtin(__builtin_fpclassify)
@@ -1511,8 +1758,7 @@ sus_pure_const constexpr inline ::sus::num::FpCategory float_category(
 // function produces Undefined Behaviour.
 template <class T>
   requires(std::is_floating_point_v<T> && ::sus::mem::size_of<T>() <= 8)
-sus_pure_const constexpr inline T float_clamp(marker::UnsafeFnMarker, T x,
-                                              T min, T max) noexcept {
+sus_pure_const constexpr inline T float_clamp(T x, T min, T max) noexcept {
   if (float_is_nan(x)) [[unlikely]]
     return nan<T>();
   else if (x < min)

--- a/sus/num/f32_unittest.cc
+++ b/sus/num/f32_unittest.cc
@@ -819,6 +819,50 @@ TEST(f32, RoundTies) {
   EXPECT_EQ(g, -0_f32);
 }
 
+TEST(f32, RoundTo) {
+  static_assert(std::same_as<decltype((0_f32).round_to_i8()), i8>);
+  static_assert(std::same_as<decltype((0_f32).round_to_i16()), i16>);
+  static_assert(std::same_as<decltype((0_f32).round_to_i32()), i32>);
+  static_assert(std::same_as<decltype((0_f32).round_to_i64()), i64>);
+  static_assert(std::same_as<decltype((0_f32).round_to_isize()), isize>);
+
+  EXPECT_EQ(i8::MAX, (9999999_f32).round_to_i8());
+  EXPECT_EQ(i8::MIN, (-9999999_f32).round_to_i8());
+  EXPECT_EQ(i16::MAX, (9999999_f32).round_to_i16());
+  EXPECT_EQ(i16::MIN, (-9999999_f32).round_to_i16());
+  EXPECT_EQ(i32::MAX, (99999999999_f32).round_to_i32());
+  EXPECT_EQ(i32::MIN, (-9999999999_f32).round_to_i32());
+  EXPECT_EQ(i64::MAX, (9999999999999999999_f32).round_to_i64());
+  EXPECT_EQ(i64::MIN, (-9999999999999999999_f32).round_to_i64());
+
+  // Respects the rounding mode (default is to nearest even).
+  EXPECT_EQ(-100_i8, (-99.5_f32).round_to_i8());
+  EXPECT_EQ(100_i8, (99.5_f32).round_to_i8());
+  EXPECT_EQ(-100_i8, (-100.5_f32).round_to_i8());
+  EXPECT_EQ(100_i8, (100.5_f32).round_to_i8());
+  EXPECT_EQ(-100_i16, (-99.5_f32).round_to_i16());
+  EXPECT_EQ(100_i16, (99.5_f32).round_to_i16());
+  EXPECT_EQ(-100_i16, (-100.5_f32).round_to_i16());
+  EXPECT_EQ(100_i16, (100.5_f32).round_to_i16());
+  EXPECT_EQ(-100_i32, (-99.5_f32).round_to_i32());
+  EXPECT_EQ(100_i32, (99.5_f32).round_to_i32());
+  EXPECT_EQ(-100_i32, (-100.5_f32).round_to_i32());
+  EXPECT_EQ(100_i32, (100.5_f32).round_to_i32());
+  EXPECT_EQ(-100_i64, (-99.5_f32).round_to_i64());
+  EXPECT_EQ(100_i64, (99.5_f32).round_to_i64());
+  EXPECT_EQ(-100_i64, (-100.5_f32).round_to_i64());
+  EXPECT_EQ(100_i64, (100.5_f32).round_to_i64());
+  EXPECT_EQ(-100_isize, (-99.5_f32).round_to_isize());
+  EXPECT_EQ(100_isize, (99.5_f32).round_to_isize());
+  EXPECT_EQ(-100_isize, (-100.5_f32).round_to_isize());
+  EXPECT_EQ(100_isize, (100.5_f32).round_to_isize());
+
+  EXPECT_EQ(0_i8, (0.49_f32).round_to_i8());
+  EXPECT_EQ(0_i8, (-0.49_f32).round_to_i8());
+  EXPECT_EQ(1_i16, (0.51_f32).round_to_i16());
+  EXPECT_EQ(-1_i16, (-0.51_f32).round_to_i16());
+}
+
 TEST(f32, Signum) {
   EXPECT_EQ((0_f32).signum(), 1_f32);
   EXPECT_EQ((-0_f32).signum(), -1_f32);

--- a/sus/num/f64_unittest.cc
+++ b/sus/num/f64_unittest.cc
@@ -819,6 +819,50 @@ TEST(f64, RoundTies) {
   EXPECT_EQ(g, -0_f64);
 }
 
+TEST(f64, RoundTo) {
+  static_assert(std::same_as<decltype((0_f64).round_to_i8()), i8>);
+  static_assert(std::same_as<decltype((0_f64).round_to_i16()), i16>);
+  static_assert(std::same_as<decltype((0_f64).round_to_i32()), i32>);
+  static_assert(std::same_as<decltype((0_f64).round_to_i64()), i64>);
+  static_assert(std::same_as<decltype((0_f64).round_to_isize()), isize>);
+
+  EXPECT_EQ(i8::MAX, (9999999_f64).round_to_i8());
+  EXPECT_EQ(i8::MIN, (-9999999_f64).round_to_i8());
+  EXPECT_EQ(i16::MAX, (9999999_f64).round_to_i16());
+  EXPECT_EQ(i16::MIN, (-9999999_f64).round_to_i16());
+  EXPECT_EQ(i32::MAX, (99999999999_f64).round_to_i32());
+  EXPECT_EQ(i32::MIN, (-9999999999_f64).round_to_i32());
+  EXPECT_EQ(i64::MAX, (9999999999999999999_f64).round_to_i64());
+  EXPECT_EQ(i64::MIN, (-9999999999999999999_f64).round_to_i64());
+
+  // Respects the rounding mode (default is to nearest even).
+  EXPECT_EQ(-100_i8, (-99.5_f64).round_to_i8());
+  EXPECT_EQ(100_i8, (99.5_f64).round_to_i8());
+  EXPECT_EQ(-100_i8, (-100.5_f64).round_to_i8());
+  EXPECT_EQ(100_i8, (100.5_f64).round_to_i8());
+  EXPECT_EQ(-100_i16, (-99.5_f64).round_to_i16());
+  EXPECT_EQ(100_i16, (99.5_f64).round_to_i16());
+  EXPECT_EQ(-100_i16, (-100.5_f64).round_to_i16());
+  EXPECT_EQ(100_i16, (100.5_f64).round_to_i16());
+  EXPECT_EQ(-100_i32, (-99.5_f64).round_to_i32());
+  EXPECT_EQ(100_i32, (99.5_f64).round_to_i32());
+  EXPECT_EQ(-100_i32, (-100.5_f64).round_to_i32());
+  EXPECT_EQ(100_i32, (100.5_f64).round_to_i32());
+  EXPECT_EQ(-100_i64, (-99.5_f64).round_to_i64());
+  EXPECT_EQ(100_i64, (99.5_f64).round_to_i64());
+  EXPECT_EQ(-100_i64, (-100.5_f64).round_to_i64());
+  EXPECT_EQ(100_i64, (100.5_f64).round_to_i64());
+  EXPECT_EQ(-100_isize, (-99.5_f64).round_to_isize());
+  EXPECT_EQ(100_isize, (99.5_f64).round_to_isize());
+  EXPECT_EQ(-100_isize, (-100.5_f64).round_to_isize());
+  EXPECT_EQ(100_isize, (100.5_f64).round_to_isize());
+
+  EXPECT_EQ(0_i8, (0.49_f64).round_to_i8());
+  EXPECT_EQ(0_i8, (-0.49_f64).round_to_i8());
+  EXPECT_EQ(1_i16, (0.51_f64).round_to_i16());
+  EXPECT_EQ(-1_i16, (-0.51_f64).round_to_i16());
+}
+
 TEST(f64, Signum) {
   EXPECT_EQ((0_f64).signum(), 1_f64);
   EXPECT_EQ((-0_f64).signum(), -1_f64);

--- a/sus/num/transmogrify_unittest.cc
+++ b/sus/num/transmogrify_unittest.cc
@@ -373,12 +373,11 @@ TEST(NumTransmogrify, f64tof32) {
 
   // Just past the valid range of values for f32 in either direciton. A
   // static_cast<float>(double) for these values would cause UB.
-  EXPECT_EQ(sus::mog<f32>(
-                sus::mog<f64>(f32::MIN).next_toward(f64::NEG_INFINITY)),
-            f32::NEG_INFINITY);
   EXPECT_EQ(
-      sus::mog<f32>(sus::mog<f64>(f32::MAX).next_toward(f64::INFINITY)),
-      f32::INFINITY);
+      sus::mog<f32>(sus::mog<f64>(f32::MIN).next_toward(f64::NEG_INFINITY)),
+      f32::NEG_INFINITY);
+  EXPECT_EQ(sus::mog<f32>(sus::mog<f64>(f32::MAX).next_toward(f64::INFINITY)),
+            f32::INFINITY);
 
   // This is a value with bits set throughout the exponent and mantissa. Its
   // exponent is <= 127 and >= -126 so it's possible to represent it in f32.
@@ -408,6 +407,12 @@ TEST(NumTransmogrify, f32) {
     EXPECT_EQ(sus::mog<u16>(65536_f32), u16::MAX);
     EXPECT_EQ(sus::mog<u16>(999999999_f32), u16::MAX);
     EXPECT_EQ(sus::mog<u16>(f32::INFINITY), u16::MAX);
+
+    EXPECT_EQ(sus::mog<u8>(f32::NAN), 0_u8);
+    EXPECT_EQ(sus::mog<u8>(-99999999_f32), u8::MIN);
+    EXPECT_EQ(sus::mog<u8>(999999999_f32), u8::MAX);
+    EXPECT_EQ(sus::mog<u8>(1.1_f32), 1_u8);
+    EXPECT_EQ(sus::mog<u8>(0.9_f32), 0_u8);
   }
   // Float to smaller signed.
   {
@@ -433,6 +438,15 @@ TEST(NumTransmogrify, f32) {
     EXPECT_EQ(sus::mog<i16>(32767_f32), i16::MAX);
     EXPECT_EQ(sus::mog<i16>(999999999_f32), i16::MAX);
     EXPECT_EQ(sus::mog<i16>(f32::INFINITY), i16::MAX);
+
+    EXPECT_EQ(sus::mog<i8>(f32::NAN), 0_i8);
+    EXPECT_EQ(sus::mog<i8>(f32::NAN), 0_i8);
+    EXPECT_EQ(sus::mog<i8>(-99999999_f32), i8::MIN);
+    EXPECT_EQ(sus::mog<i8>(999999999_f32), i8::MAX);
+    EXPECT_EQ(sus::mog<i8>(1.1_f32), 1_i8);
+    EXPECT_EQ(sus::mog<i8>(0.9_f32), 0_i8);
+    EXPECT_EQ(sus::mog<i8>(-1.1_f32), -1_i8);
+    EXPECT_EQ(sus::mog<i8>(-0.9_f32), 0_i8);
   }
 
   // Float to larger unsigned.
@@ -456,6 +470,12 @@ TEST(NumTransmogrify, f32) {
     EXPECT_EQ(sus::mog<u64>(18446744073709551615_f32 + 1_f32), u64::MAX);
     EXPECT_EQ(sus::mog<u64>(18446744073709551615_f32 * 2_f32), u64::MAX);
     EXPECT_EQ(sus::mog<u64>(f32::INFINITY), u64::MAX);
+
+    EXPECT_EQ(sus::mog<u32>(f32::NAN), 0_u32);
+    EXPECT_EQ(sus::mog<u32>(-99999999999_f32), u32::MIN);
+    EXPECT_EQ(sus::mog<u32>(99999999999_f32), u32::MAX);
+    EXPECT_EQ(sus::mog<u32>(0.9_f32), 0_u32);
+    EXPECT_EQ(sus::mog<u32>(1.1_f32), 1_u32);
   }
   // Float to larger signed.
   {
@@ -484,6 +504,14 @@ TEST(NumTransmogrify, f32) {
     EXPECT_EQ(sus::mog<i64>(9223372036854775808_f32), i64::MAX);
     EXPECT_EQ(sus::mog<i64>(9999999999999999999_f32), i64::MAX);
     EXPECT_EQ(sus::mog<i64>(f32::INFINITY), i64::MAX);
+
+    EXPECT_EQ(sus::mog<i32>(f32::NAN), 0_i32);
+    EXPECT_EQ(sus::mog<i32>(-99999999999_f32), i32::MIN);
+    EXPECT_EQ(sus::mog<i32>(999999999999_f32), i32::MAX);
+    EXPECT_EQ(sus::mog<i32>(1.1_f32), 1_i32);
+    EXPECT_EQ(sus::mog<i32>(0.9_f32), 0_i32);
+    EXPECT_EQ(sus::mog<i32>(-1.1_f32), -1_i32);
+    EXPECT_EQ(sus::mog<i32>(-0.9_f32), 0_i32);
   }
 
   // Ints to f32.


### PR DESCRIPTION
These methods perform the same thing as `round_ties()` and then a safe saturating cast. But that requires a separate instruction for the rounding and the casting. Some platforms have a single instruction that does both. So this gives access to that instruction while guarding for UB when the value is out of bounds for the target type and saturating, and returning 0 for NaN.