### PR TITLE
Allow integer shifting by u64

### DIFF
--- a/sus/num/__private/signed_integer_methods.inc
+++ b/sus/num/__private/signed_integer_methods.inc
@@ -887,46 +887,6 @@ template <class U>
   requires((PrimitiveInteger<U> || PrimitiveEnum<U>) &&
            !std::convertible_to<U, _self>)
 friend constexpr inline _self operator^(U l, _self r) noexcept = delete;
-/// Satisfies the [`Shl`]($sus::num::Shl) concept for signed integers.
-///
-/// This operation supports shifting with primitive signed or unsigned integers
-/// that convert to the safe numeric, as well as enums.
-/// However enum class is excluded as they require an explicit conversion to an
-/// integer.
-///
-/// Thus the bound is `std::convertible_to` (implicit conversion) instead of
-/// `sus::construct::From` (explicit conversion).
-///
-/// #[doc.overloads=signedint.<<]
-[[nodiscard]] sus_pure friend constexpr inline _self operator<<(
-    _self l, std::convertible_to<u32> auto r) noexcept {
-  const auto out =
-      __private::shl_with_overflow(l.primitive_value, u32(r).primitive_value);
-  // TODO: Allow opting out of all overflow checks?
-  ::sus::check(!out.overflow);
-  return out.value;
-}
-/// #[doc.overloads=signedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u32>)
-[[nodiscard]] sus_pure friend constexpr inline _self operator<<(
-    _self l, U r) noexcept = delete;
-/// Satisfies the [`Shr`]($sus::num::Shr) concept for signed integers.
-///
-/// #[doc.overloads=signedint.>>]
-[[nodiscard]] sus_pure friend constexpr inline _self operator>>(
-    _self l, std::convertible_to<u32> auto r) noexcept {
-  const auto out =
-      __private::shr_with_overflow(l.primitive_value, u32(r).primitive_value);
-  // TODO: Allow opting out of all overflow checks?
-  ::sus::check(!out.overflow);
-  return out.value;
-}
-/// #[doc.overloads=signedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u32>)
-[[nodiscard]] sus_pure friend constexpr inline _self operator>>(
-    _self l, U r) noexcept = delete;
 
 /// Satisfies the [`AddAssign<@doc.self>`]($sus::num::AddAssign) concept.
 constexpr inline void operator+=(_self r) & noexcept {

--- a/sus/num/__private/unsigned_integer_methods.inc
+++ b/sus/num/__private/unsigned_integer_methods.inc
@@ -580,33 +580,33 @@ sus_pure constexpr const _primitive* as_ptr() && noexcept = delete;
 
 /// Satisfies the [`Eq`]($sus::cmp::Eq) concept for unsigned integers.
 /// #[doc.overloads=uint.eq]
-[[nodiscard]] sus_pure friend constexpr inline bool operator==(
+[[nodiscard]] sus_pure_const friend constexpr inline bool operator==(
     _self l, _self r) noexcept = default;
 /// #[doc.overloads=uint.eq]
-[[nodiscard]] sus_pure friend constexpr inline bool operator==(
+[[nodiscard]] sus_pure_const friend constexpr inline bool operator==(
     _self l, Unsigned auto r) noexcept {
   return l.primitive_value == r.primitive_value;
 }
 /// #[doc.overloads=uint.eq]
-[[nodiscard]] sus_pure friend constexpr inline bool operator==(
+[[nodiscard]] sus_pure_const friend constexpr inline bool operator==(
     _self l, UnsignedPrimitiveInteger auto r) noexcept {
   return l.primitive_value == r;
 }
 /// Satisfies the [`StrongOrd`]($sus::cmp::StrongOrd) concept for unsigned
 /// integers.
 /// #[doc.overloads=uint.strongord]
-[[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(
-    _self l, _self r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline std::strong_ordering
+operator<=>(_self l, _self r) noexcept {
   return l.primitive_value <=> r.primitive_value;
 }
 /// #[doc.overloads=uint.strongord]
-[[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(
-    _self l, Unsigned auto r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline std::strong_ordering
+operator<=>(_self l, Unsigned auto r) noexcept {
   return l.primitive_value <=> r.primitive_value;
 }
 /// #[doc.overloads=uint.strongord]
-[[nodiscard]] sus_pure friend constexpr inline std::strong_ordering operator<=>(
-    _self l, UnsignedPrimitiveInteger auto r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline std::strong_ordering
+operator<=>(_self l, UnsignedPrimitiveInteger auto r) noexcept {
   return l.primitive_value <=> r;
 }
 
@@ -625,7 +625,7 @@ sus_pure constexpr inline _self operator~() const& noexcept {
 /// integer.
 ///
 /// #[doc.overloads=unsignedint.+]
-[[nodiscard]] sus_pure friend constexpr inline _self operator+(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator+(
     _self l, _self r) noexcept {
   const auto out =
       __private::add_with_overflow(l.primitive_value, r.primitive_value);
@@ -637,14 +637,14 @@ sus_pure constexpr inline _self operator~() const& noexcept {
 /// #[doc.overloads=unsignedint.+]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator+(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator+(
+    _self l, U r) noexcept {
   return l + _primitive{r.primitive_value};
 }
 /// #[doc.overloads=unsignedint.+]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator+(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator+(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} + r;
 }
@@ -687,7 +687,7 @@ friend constexpr inline _self operator+(U l, _self r) noexcept = delete;
 /// integer.
 ///
 /// #[doc.overloads=unsignedint.-]
-[[nodiscard]] sus_pure friend constexpr inline _self operator-(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator-(
     _self l, _self r) noexcept {
   const auto out =
       __private::sub_with_overflow(l.primitive_value, r.primitive_value);
@@ -699,14 +699,14 @@ friend constexpr inline _self operator+(U l, _self r) noexcept = delete;
 /// #[doc.overloads=unsignedint.-]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator-(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator-(
+    _self l, U r) noexcept {
   return l - _primitive{r.primitive_value};
 }
 /// #[doc.overloads=unsignedint.-]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator-(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator-(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} - r;
 }
@@ -749,7 +749,7 @@ friend constexpr inline _self operator-(U l, _self r) noexcept = delete;
 /// integer.
 ///
 /// #[doc.overloads=unsignedint.*]
-[[nodiscard]] sus_pure friend constexpr inline _self operator*(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator*(
     _self l, _self r) noexcept {
   const auto out =
       __private::mul_with_overflow(l.primitive_value, r.primitive_value);
@@ -761,14 +761,14 @@ friend constexpr inline _self operator-(U l, _self r) noexcept = delete;
 /// #[doc.overloads=unsignedint.*]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator*(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator*(
+    _self l, U r) noexcept {
   return l * _primitive{r.primitive_value};
 }
 /// #[doc.overloads=unsignedint.*]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator*(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator*(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} * r;
 }
@@ -811,7 +811,7 @@ friend constexpr inline _self operator*(U l, _self r) noexcept = delete;
 /// integer.
 ///
 /// #[doc.overloads=unsignedint./]
-[[nodiscard]] sus_pure friend constexpr inline _self operator/(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator/(
     _self l, _self r) noexcept {
   // TODO: Allow opting out of all overflow checks?
   ::sus::check(r.primitive_value != 0u);
@@ -821,14 +821,14 @@ friend constexpr inline _self operator*(U l, _self r) noexcept = delete;
 /// #[doc.overloads=unsignedint./]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator/(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator/(
+    _self l, U r) noexcept {
   return l / _primitive{r.primitive_value};
 }
 /// #[doc.overloads=unsignedint./]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator/(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator/(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} / r;
 }
@@ -871,7 +871,7 @@ friend constexpr inline _self operator/(U l, _self r) noexcept = delete;
 /// integer.
 ///
 /// #[doc.overloads=unsignedint.%]
-[[nodiscard]] sus_pure friend constexpr inline _self operator%(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator%(
     _self l, _self r) noexcept {
   // TODO: Allow opting out of all overflow checks?
   ::sus::check(r.primitive_value != 0u);
@@ -881,14 +881,14 @@ friend constexpr inline _self operator/(U l, _self r) noexcept = delete;
 /// #[doc.overloads=unsignedint.%]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator%(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator%(
+    _self l, U r) noexcept {
   return l % _primitive{r.primitive_value};
 }
 /// #[doc.overloads=unsignedint.%]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator%(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator%(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} % r;
 }
@@ -932,7 +932,7 @@ friend constexpr inline _self operator%(U l, _self r) noexcept = delete;
 /// integer.
 ///
 /// #[doc.overloads=unsignedint.&]
-[[nodiscard]] sus_pure friend constexpr inline _self operator&(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator&(
     _self l, _self r) noexcept {
   return _self(__private::unchecked_and(l.primitive_value, r.primitive_value));
 }
@@ -940,14 +940,14 @@ friend constexpr inline _self operator%(U l, _self r) noexcept = delete;
 /// #[doc.overloads=unsignedint.&]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator&(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator&(
+    _self l, U r) noexcept {
   return l & _primitive{r.primitive_value};
 }
 /// #[doc.overloads=unsignedint.&]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator&(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator&(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} & r;
 }
@@ -990,7 +990,7 @@ friend constexpr inline _self operator&(U l, _self r) noexcept = delete;
 /// integer.
 ///
 /// #[doc.overloads=unsignedint.|]
-[[nodiscard]] sus_pure friend constexpr inline _self operator|(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator|(
     _self l, _self r) noexcept {
   return _self(__private::unchecked_or(l.primitive_value, r.primitive_value));
 }
@@ -998,14 +998,14 @@ friend constexpr inline _self operator&(U l, _self r) noexcept = delete;
 /// #[doc.overloads=unsignedint.|]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator|(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator|(
+    _self l, U r) noexcept {
   return l | _primitive{r.primitive_value};
 }
 /// #[doc.overloads=unsignedint.|]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator|(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator|(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} | r;
 }
@@ -1048,7 +1048,7 @@ friend constexpr inline _self operator|(U l, _self r) noexcept = delete;
 /// integer.
 ///
 /// #[doc.overloads=unsignedint.^]
-[[nodiscard]] sus_pure friend constexpr inline _self operator^(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator^(
     _self l, _self r) noexcept {
   return _self(__private::unchecked_xor(l.primitive_value, r.primitive_value));
 }
@@ -1056,14 +1056,14 @@ friend constexpr inline _self operator|(U l, _self r) noexcept = delete;
 /// #[doc.overloads=unsignedint.^]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator^(_self l,
-                                                               U r) noexcept {
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator^(
+    _self l, U r) noexcept {
   return l ^ _primitive { r.primitive_value };
 }
 /// #[doc.overloads=unsignedint.^]
 template <Unsigned U>
   requires(::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>())
-[[nodiscard]] sus_pure friend constexpr inline _self operator^(
+[[nodiscard]] sus_pure_const friend constexpr inline _self operator^(
     U l, _self r) noexcept {
   return _primitive{l.primitive_value} ^ r;
 }
@@ -1098,36 +1098,6 @@ template <class U>
            !((UnsignedPrimitiveInteger<U> || UnsignedPrimitiveEnum<U>) &&  //
              ::sus::mem::size_of<U>() <= ::sus::mem::size_of<_primitive>()))
 friend constexpr inline _self operator^(U l, _self r) noexcept = delete;
-/// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned integers.
-///
-/// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] sus_pure friend constexpr inline _self operator<<(
-    _self l, std::convertible_to<u32> auto r) noexcept {
-  // TODO: Allow opting out of all overflow checks?
-  ::sus::check(r < u32(__private::num_bits<_primitive>()));
-  return _self(
-      __private::unchecked_shl(l.primitive_value, u32(r).primitive_value));
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u32>)
-[[nodiscard]] sus_pure friend constexpr inline _self operator<<(
-    _self l, U r) noexcept = delete;
-/// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned integers.
-///
-/// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] sus_pure friend constexpr inline _self operator>>(
-    _self l, std::convertible_to<u32> auto r) noexcept {
-  // TODO: Allow opting out of all overflow checks?
-  ::sus::check(r < u32(__private::num_bits<_primitive>()));
-  return _self(
-      __private::unchecked_shr(l.primitive_value, u32(r).primitive_value));
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u32>)
-[[nodiscard]] sus_pure friend constexpr inline _self operator>>(
-    _self l, U r) noexcept = delete;
 
 /// Satisfies the [`AddAssign<@doc.self>`]($sus::num::AddAssign) concept.
 constexpr inline void operator+=(_self r) & noexcept {

--- a/sus/num/i16_unittest.cc
+++ b/sus/num/i16_unittest.cc
@@ -435,11 +435,11 @@ TEST(i16, OperatorsWithPrimitives) {
   static_assert(CanShift<i16, uint8_t>);
   static_assert(CanShift<i16, uint16_t>);
   static_assert(CanShift<i16, uint32_t>);
-  static_assert(CantShift<i16, uint64_t>);
+  static_assert(CanShift<i16, uint64_t>);
   static_assert(CanShift<i16, ENUM(, uint8_t)>);
   static_assert(CanShift<i16, ENUM(, uint16_t)>);
   static_assert(CanShift<i16, ENUM(, uint32_t)>);
-  static_assert(CantShift<i16, ENUM(, uint64_t)>);
+  static_assert(CanShift<i16, ENUM(, uint64_t)>);
   static_assert(CantShift<i16, ENUM(class, uint8_t)>);
   static_assert(CantShift<i16, ENUM(class, uint16_t)>);
   static_assert(CantShift<i16, ENUM(class, uint32_t)>);

--- a/sus/num/i32_unittest.cc
+++ b/sus/num/i32_unittest.cc
@@ -16,6 +16,8 @@
 #include <type_traits>
 
 #include "googletest/include/gtest/gtest.h"
+#include "sus/cmp/eq.h"
+#include "sus/cmp/ord.h"
 #include "sus/collections/array.h"
 #include "sus/construct/default.h"
 #include "sus/construct/into.h"
@@ -24,8 +26,6 @@
 #include "sus/num/num_concepts.h"
 #include "sus/num/signed_integer.h"
 #include "sus/num/unsigned_integer.h"
-#include "sus/cmp/eq.h"
-#include "sus/cmp/ord.h"
 #include "sus/option/option.h"
 #include "sus/prelude.h"
 #include "sus/test/ensure_use.h"
@@ -449,11 +449,11 @@ TEST(i32, OperatorsWithPrimitives) {
   static_assert(CanShift<i32, uint8_t>);
   static_assert(CanShift<i32, uint16_t>);
   static_assert(CanShift<i32, uint32_t>);
-  static_assert(CantShift<i32, uint64_t>);
+  static_assert(CanShift<i32, uint64_t>);
   static_assert(CanShift<i32, ENUM(, uint8_t)>);
   static_assert(CanShift<i32, ENUM(, uint16_t)>);
   static_assert(CanShift<i32, ENUM(, uint32_t)>);
-  static_assert(CantShift<i32, ENUM(, uint64_t)>);
+  static_assert(CanShift<i32, ENUM(, uint64_t)>);
   static_assert(CantShift<i32, ENUM(class, uint8_t)>);
   static_assert(CantShift<i32, ENUM(class, uint16_t)>);
   static_assert(CantShift<i32, ENUM(class, uint32_t)>);

--- a/sus/num/i64_unittest.cc
+++ b/sus/num/i64_unittest.cc
@@ -435,11 +435,11 @@ TEST(i64, OperatorsWithPrimitives) {
   static_assert(CanShift<i64, uint8_t>);
   static_assert(CanShift<i64, uint16_t>);
   static_assert(CanShift<i64, uint32_t>);
-  static_assert(CantShift<i64, uint64_t>);
+  static_assert(CanShift<i64, uint64_t>);
   static_assert(CanShift<i64, ENUM(, uint8_t)>);
   static_assert(CanShift<i64, ENUM(, uint16_t)>);
   static_assert(CanShift<i64, ENUM(, uint32_t)>);
-  static_assert(CantShift<i64, ENUM(, uint64_t)>);
+  static_assert(CanShift<i64, ENUM(, uint64_t)>);
   static_assert(CantShift<i64, ENUM(class, uint8_t)>);
   static_assert(CantShift<i64, ENUM(class, uint16_t)>);
   static_assert(CantShift<i64, ENUM(class, uint32_t)>);

--- a/sus/num/i8_unittest.cc
+++ b/sus/num/i8_unittest.cc
@@ -431,11 +431,11 @@ TEST(i8, OperatorsWithPrimitives) {
   static_assert(CanShift<i8, uint8_t>);
   static_assert(CanShift<i8, uint16_t>);
   static_assert(CanShift<i8, uint32_t>);
-  static_assert(CantShift<i8, uint64_t>);
+  static_assert(CanShift<i8, uint64_t>);
   static_assert(CanShift<i8, ENUM(, uint8_t)>);
   static_assert(CanShift<i8, ENUM(, uint16_t)>);
   static_assert(CanShift<i8, ENUM(, uint32_t)>);
-  static_assert(CantShift<i8, ENUM(, uint64_t)>);
+  static_assert(CanShift<i8, ENUM(, uint64_t)>);
   static_assert(CantShift<i8, ENUM(class, uint8_t)>);
   static_assert(CantShift<i8, ENUM(class, uint16_t)>);
   static_assert(CantShift<i8, ENUM(class, uint32_t)>);

--- a/sus/num/isize_unittest.cc
+++ b/sus/num/isize_unittest.cc
@@ -480,11 +480,11 @@ TEST(isize, OperatorsWithPrimitives) {
   static_assert(CanShift<isize, uint8_t>);
   static_assert(CanShift<isize, uint16_t>);
   static_assert(CanShift<isize, uint32_t>);
-  static_assert(CantShift<isize, uint64_t>);
+  static_assert(CanShift<isize, uint64_t>);
   static_assert(CanShift<isize, ENUM(, uint8_t)>);
   static_assert(CanShift<isize, ENUM(, uint16_t)>);
   static_assert(CanShift<isize, ENUM(, uint32_t)>);
-  static_assert(CantShift<isize, ENUM(, uint64_t)>);
+  static_assert(CanShift<isize, ENUM(, uint64_t)>);
   static_assert(CantShift<isize, ENUM(class, uint8_t)>);
   static_assert(CantShift<isize, ENUM(class, uint16_t)>);
   static_assert(CantShift<isize, ENUM(class, uint32_t)>);

--- a/sus/num/signed_integer.h
+++ b/sus/num/signed_integer.h
@@ -177,38 +177,181 @@ constexpr inline T*& operator-=(T*& t, isize offset) {
 }
 
 /// Satisfies the [`Shl`]($sus::num::Shl) concept for signed primitive integers
-/// shifted by [`u32`]($sus::num::u32).
-/// #[doc.overloads=signed.prim.<<u32]
+/// shifted by [`u64`]($sus::num::u64).
+/// #[doc.overloads=signed.prim.<<u64]
 template <class P, Integer U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u32>)
+           std::convertible_to<U, u64>)
 [[nodiscard]] sus_pure_const constexpr inline P operator<<(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
-  return l << u32(r).primitive_value;
+  return l << u64(r).primitive_value;
 }
-/// #[doc.overloads=signed.prim.<<u32]
+/// #[doc.overloads=signed.prim.<<u64]
 template <class P, Integer U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u32>)
+           !std::convertible_to<U, u64>)
 constexpr inline P operator<<(P l, U r) noexcept = delete;
 
 /// Satisfies the [`Shr`]($sus::num::Shr) concept for signed primitive integers
-/// shifted by [`u32`]($sus::num::u32).
-/// #[doc.overloads=signed.prim.>>u32]
+/// shifted by [`u64`]($sus::num::u64).
+/// #[doc.overloads=signed.prim.>>u64]
 template <class P, Integer U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u32>)
+           std::convertible_to<U, u64>)
 [[nodiscard]] sus_pure_const constexpr inline P operator>>(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
-  return l >> u32(r).primitive_value;
+  return l >> u64(r).primitive_value;
 }
-/// #[doc.overloads=signed.prim.>>u32]
+/// #[doc.overloads=signed.prim.>>u64]
 template <class P, Integer U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u32>)
+           !std::convertible_to<U, u64>)
 constexpr inline P operator>>(P l, U r) noexcept = delete;
+
+/// Satisfies the [`Shl`]($sus::num::Shl) concept for signed integers.
+///
+/// This operation supports shifting with primitive signed or unsigned integers
+/// that convert to the safe numeric, as well as enums.
+/// However enum class is excluded as they require an explicit conversion to an
+/// integer.
+///
+/// Thus the bound is `std::convertible_to` (implicit conversion) instead of
+/// `sus::construct::From` (explicit conversion).
+///
+/// #[doc.overloads=signedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline i8 operator<<(
+    i8 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i8 operator<<(i8 l, U r) noexcept = delete;
+/// Satisfies the [`Shr`]($sus::num::Shr) concept for signed integers.
+///
+/// #[doc.overloads=signedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline i8 operator>>(
+    i8 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i8 operator>>(i8 l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline i16 operator<<(
+    i16 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i16 operator<<(i16 l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline i16 operator>>(
+    i16 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i16 operator>>(i16 l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline i32 operator<<(
+    i32 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i32 operator<<(i32 l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline i32 operator>>(
+    i32 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i32 operator>>(i32 l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline i64 operator<<(
+    i64 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i64 operator<<(i64 l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline i64 operator>>(
+    i64 l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline i64 operator>>(i64 l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline isize operator<<(
+    isize l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline isize operator<<(isize l, U r) noexcept = delete;
+/// #[doc.overloads=signedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline isize operator>>(
+    isize l, std::convertible_to<u64> auto r) noexcept {
+  const auto out =
+      __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(!out.overflow);
+  return out.value;
+}
+/// #[doc.overloads=signedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline isize operator>>(isize l, U r) noexcept = delete;
 
 }  // namespace sus::num
 

--- a/sus/num/u16_unittest.cc
+++ b/sus/num/u16_unittest.cc
@@ -438,11 +438,11 @@ TEST(u16, OperatorsWithPrimitives) {
   static_assert(CanShift<u16, uint8_t>);
   static_assert(CanShift<u16, uint16_t>);
   static_assert(CanShift<u16, uint32_t>);
-  static_assert(CantShift<u16, uint64_t>);
+  static_assert(CanShift<u16, uint64_t>);
   static_assert(CanShift<u16, ENUM(, uint8_t)>);
   static_assert(CanShift<u16, ENUM(, uint16_t)>);
   static_assert(CanShift<u16, ENUM(, uint32_t)>);
-  static_assert(CantShift<u16, ENUM(, uint64_t)>);
+  static_assert(CanShift<u16, ENUM(, uint64_t)>);
   static_assert(CantShift<u16, ENUM(class, uint8_t)>);
   static_assert(CantShift<u16, ENUM(class, uint16_t)>);
   static_assert(CantShift<u16, ENUM(class, uint32_t)>);

--- a/sus/num/u32_unittest.cc
+++ b/sus/num/u32_unittest.cc
@@ -453,11 +453,11 @@ TEST(u32, OperatorsWithPrimitives) {
   static_assert(CanShift<u32, uint8_t>);
   static_assert(CanShift<u32, uint16_t>);
   static_assert(CanShift<u32, uint32_t>);
-  static_assert(CantShift<u32, uint64_t>);
+  static_assert(CanShift<u32, uint64_t>);
   static_assert(CanShift<u32, ENUM(, uint8_t)>);
   static_assert(CanShift<u32, ENUM(, uint16_t)>);
   static_assert(CanShift<u32, ENUM(, uint32_t)>);
-  static_assert(CantShift<u32, ENUM(, uint64_t)>);
+  static_assert(CanShift<u32, ENUM(, uint64_t)>);
   static_assert(CantShift<u32, ENUM(class, uint8_t)>);
   static_assert(CantShift<u32, ENUM(class, uint16_t)>);
   static_assert(CantShift<u32, ENUM(class, uint32_t)>);

--- a/sus/num/u64_unittest.cc
+++ b/sus/num/u64_unittest.cc
@@ -444,11 +444,11 @@ TEST(u64, OperatorsWithPrimitives) {
   static_assert(CanShift<u64, uint8_t>);
   static_assert(CanShift<u64, uint16_t>);
   static_assert(CanShift<u64, uint32_t>);
-  static_assert(CantShift<u64, uint64_t>);
+  static_assert(CanShift<u64, uint64_t>);
   static_assert(CanShift<u64, ENUM(, uint8_t)>);
   static_assert(CanShift<u64, ENUM(, uint16_t)>);
   static_assert(CanShift<u64, ENUM(, uint32_t)>);
-  static_assert(CantShift<u64, ENUM(, uint64_t)>);
+  static_assert(CanShift<u64, ENUM(, uint64_t)>);
   static_assert(CantShift<u64, ENUM(class, uint8_t)>);
   static_assert(CantShift<u64, ENUM(class, uint16_t)>);
   static_assert(CantShift<u64, ENUM(class, uint32_t)>);
@@ -456,10 +456,10 @@ TEST(u64, OperatorsWithPrimitives) {
 
   static_assert(CantShift<u64, int8_t>);
 
-  static_assert(CantShift<int8_t, u64>);
-  static_assert(CantShift<uint8_t, u64>);
-  static_assert(CantShift<ENUM(, int8_t), u64>);
-  static_assert(CantShift<ENUM(, uint8_t), u64>);
+  static_assert(CanShift<int8_t, u64>);
+  static_assert(CanShift<uint8_t, u64>);
+  static_assert(CanShift<ENUM(, int8_t), u64>);
+  static_assert(CanShift<ENUM(, uint8_t), u64>);
   static_assert(CantShift<ENUM(class, int8_t), u64>);
   static_assert(CantShift<ENUM(class, uint8_t), u64>);
 }

--- a/sus/num/u8_unittest.cc
+++ b/sus/num/u8_unittest.cc
@@ -435,11 +435,11 @@ TEST(u8, OperatorsWithPrimitives) {
   static_assert(CanShift<u8, uint8_t>);
   static_assert(CanShift<u8, uint16_t>);
   static_assert(CanShift<u8, uint32_t>);
-  static_assert(CantShift<u8, uint64_t>);
+  static_assert(CanShift<u8, uint64_t>);
   static_assert(CanShift<u8, ENUM(, uint8_t)>);
   static_assert(CanShift<u8, ENUM(, uint16_t)>);
   static_assert(CanShift<u8, ENUM(, uint32_t)>);
-  static_assert(CantShift<u8, ENUM(, uint64_t)>);
+  static_assert(CanShift<u8, ENUM(, uint64_t)>);
   static_assert(CantShift<u8, ENUM(class, uint8_t)>);
   static_assert(CantShift<u8, ENUM(class, uint16_t)>);
   static_assert(CantShift<u8, ENUM(class, uint32_t)>);

--- a/sus/num/unsigned_integer.h
+++ b/sus/num/unsigned_integer.h
@@ -234,38 +234,187 @@ constexpr inline T*& operator-=(T*& t, usize offset) {
 }
 
 /// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned primitive
-/// integers shifted by [`u32`]($sus::num::u32).
-/// #[doc.overloads=unsigned.prim.<<u32]
+/// integers shifted by [`u64`]($sus::num::u64).
+/// #[doc.overloads=unsigned.prim.<<u64]
 template <class P, Integer U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u32>)
+           std::convertible_to<U, u64>)
 [[nodiscard]] sus_pure_const constexpr inline P operator<<(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
-  return l << u32(r).primitive_value;
+  return l << u64(r).primitive_value;
 }
-/// #[doc.overloads=unsigned.prim.<<u32]
+/// #[doc.overloads=unsigned.prim.<<u64]
 template <class P, Integer U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u32>)
+           !std::convertible_to<U, u64>)
 constexpr inline P operator<<(P l, U r) noexcept = delete;
 
 /// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned primitive
-/// integers shifted by [`u32`]($sus::num::u32).
-/// #[doc.overloads=unsigned.prim.>>u32]
+/// integers shifted by [`u64`]($sus::num::u64).
+/// #[doc.overloads=unsigned.prim.>>u64]
 template <class P, Integer U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u32>)
+           std::convertible_to<U, u64>)
 [[nodiscard]] sus_pure_const constexpr inline P operator>>(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
-  return l >> u32(r).primitive_value;
+  return l >> u64(r).primitive_value;
 }
-/// #[doc.overloads=unsigned.prim.>>u32]
+/// #[doc.overloads=unsigned.prim.>>u64]
 template <class P, Integer U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u32>)
+           !std::convertible_to<U, u64>)
 constexpr inline P operator>>(P l, U r) noexcept = delete;
+
+/// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned integers.
+///
+/// #[doc.overloads=unsignedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline u8 operator<<(
+    u8 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u8::BITS);
+  return u8(
+      __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u8 operator<<(u8 l, U r) noexcept = delete;
+/// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned integers.
+///
+/// #[doc.overloads=unsignedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline u8 operator>>(
+    u8 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u8::BITS);
+  return u8(
+      __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u8 operator>>(u8 l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline u16 operator<<(
+    u16 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u16::BITS);
+  return u16(
+      __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u16 operator<<(u16 l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline u16 operator>>(
+    u16 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u16::BITS);
+  return u16(
+      __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u16 operator>>(u16 l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline u32 operator<<(
+    u32 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u32::BITS);
+  return u32(
+      __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u32 operator<<(u32 l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline u32 operator>>(
+    u32 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u32::BITS);
+  return u32(
+      __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u32 operator>>(u32 l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline u64 operator<<(
+    u64 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u64::BITS);
+  return u64(
+      __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u64 operator<<(u64 l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline u64 operator>>(
+    u64 l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < u64::BITS);
+  return u64(
+      __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline u64 operator>>(u64 l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline usize operator<<(
+    usize l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < usize::BITS);
+  return usize(
+      __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline usize operator<<(usize l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline usize operator>>(
+    usize l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < usize::BITS);
+  return usize(
+      __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline usize operator>>(usize l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.<<]
+[[nodiscard]] sus_pure_const constexpr inline uptr operator<<(
+    uptr l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < uptr::BITS);
+  return uptr(
+      __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline uptr operator<<(uptr l, U r) noexcept = delete;
+/// #[doc.overloads=unsignedint.>>]
+[[nodiscard]] sus_pure_const constexpr inline uptr operator>>(
+    uptr l, std::convertible_to<u64> auto r) noexcept {
+  // TODO: Allow opting out of all overflow checks?
+  ::sus::check(r < uptr::BITS);
+  return uptr(
+      __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+}
+/// #[doc.overloads=unsignedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr inline uptr operator>>(uptr l, U r) noexcept = delete;
 
 }  // namespace sus::num
 

--- a/sus/num/uptr_unittest.cc
+++ b/sus/num/uptr_unittest.cc
@@ -465,11 +465,11 @@ TEST(uptr, OperatorsWithPrimitives) {
   static_assert(CanShift<uptr, uint8_t>);
   static_assert(CanShift<uptr, uint16_t>);
   static_assert(CanShift<uptr, uint32_t>);
-  static_assert(CantShift<uptr, uint64_t>);
+  static_assert(CanShift<uptr, uint64_t>);
   static_assert(CanShift<uptr, ENUM(, uint8_t)>);
   static_assert(CanShift<uptr, ENUM(, uint16_t)>);
   static_assert(CanShift<uptr, ENUM(, uint32_t)>);
-  static_assert(CantShift<uptr, ENUM(, uint64_t)>);
+  static_assert(CanShift<uptr, ENUM(, uint64_t)>);
   static_assert(CantShift<uptr, ENUM(class, uint8_t)>);
   static_assert(CantShift<uptr, ENUM(class, uint16_t)>);
   static_assert(CantShift<uptr, ENUM(class, uint32_t)>);
@@ -477,14 +477,12 @@ TEST(uptr, OperatorsWithPrimitives) {
 
   static_assert(CantShift<uptr, int8_t>);
 
-  static_assert(!(sizeof(uptr) <= sizeof(u32)) || CanShift<int8_t, uptr>);
-  static_assert(!(sizeof(uptr) > sizeof(u32)) || CantShift<int8_t, uptr>);
-  static_assert(!(sizeof(uptr) <= sizeof(u32)) || CanShift<uint8_t, uptr>);
-  static_assert(!(sizeof(uptr) > sizeof(u32)) || CantShift<uint8_t, uptr>);
-  static_assert(!(sizeof(uptr) <= sizeof(u32)) || CanShift<ENUM(, int8_t), uptr>);
-  static_assert(!(sizeof(uptr) > sizeof(u32)) || CantShift<ENUM(, uint8_t), uptr>);
-  static_assert(!(sizeof(uptr) <= sizeof(u32)) || CanShift<ENUM(class, int8_t), uptr>);
-  static_assert(!(sizeof(uptr) > sizeof(u32)) || CantShift<ENUM(class, uint8_t), uptr>);
+  static_assert(CanShift<int8_t, uptr>);
+  static_assert(CanShift<uint8_t, uptr>);
+  static_assert(CanShift<ENUM(, int8_t), uptr>);
+  static_assert(CanShift<ENUM(, uint8_t), uptr>);
+  static_assert(CantShift<ENUM(class, int8_t), uptr>);
+  static_assert(CantShift<ENUM(class, uint8_t), uptr>);
 }
 
 TEST(uptr, From) {

--- a/sus/num/usize_unittest.cc
+++ b/sus/num/usize_unittest.cc
@@ -472,11 +472,11 @@ TEST(usize, OperatorsWithPrimitives) {
   static_assert(CanShift<usize, uint8_t>);
   static_assert(CanShift<usize, uint16_t>);
   static_assert(CanShift<usize, uint32_t>);
-  static_assert(CantShift<usize, uint64_t>);
+  static_assert(CanShift<usize, uint64_t>);
   static_assert(CanShift<usize, ENUM(, uint8_t)>);
   static_assert(CanShift<usize, ENUM(, uint16_t)>);
   static_assert(CanShift<usize, ENUM(, uint32_t)>);
-  static_assert(CantShift<usize, ENUM(, uint64_t)>);
+  static_assert(CanShift<usize, ENUM(, uint64_t)>);
   static_assert(CantShift<usize, ENUM(class, uint8_t)>);
   static_assert(CantShift<usize, ENUM(class, uint16_t)>);
   static_assert(CantShift<usize, ENUM(class, uint32_t)>);
@@ -484,18 +484,12 @@ TEST(usize, OperatorsWithPrimitives) {
 
   static_assert(CantShift<usize, int8_t>);
 
-  static_assert(!(sizeof(usize) <= sizeof(u32)) || CanShift<int8_t, usize>);
-  static_assert(!(sizeof(usize) > sizeof(u32)) || CantShift<int8_t, usize>);
-  static_assert(!(sizeof(usize) <= sizeof(u32)) || CanShift<uint8_t, usize>);
-  static_assert(!(sizeof(usize) > sizeof(u32)) || CantShift<uint8_t, usize>);
-  static_assert(!(sizeof(usize) <= sizeof(u32)) ||
-                CanShift<ENUM(, int8_t), usize>);
-  static_assert(!(sizeof(usize) > sizeof(u32)) ||
-                CantShift<ENUM(, uint8_t), usize>);
-  static_assert(!(sizeof(usize) <= sizeof(u32)) ||
-                CanShift<ENUM(class, int8_t), usize>);
-  static_assert(!(sizeof(usize) > sizeof(u32)) ||
-                CantShift<ENUM(class, uint8_t), usize>);
+  static_assert(CanShift<int8_t, usize>);
+  static_assert(CanShift<uint8_t, usize>);
+  static_assert(CanShift<ENUM(, int8_t), usize>);
+  static_assert(CanShift<ENUM(, uint8_t), usize>);
+  static_assert(CantShift<ENUM(class, int8_t), usize>);
+  static_assert(CantShift<ENUM(class, uint8_t), usize>);
 }
 
 TEST(usize, From) {


### PR DESCRIPTION
Rust shift operators take a rhs value of u32, which we emulated, however this introduces a sharp edge in C++ where you shift by something like a `sizeof()` expression. That evaluates to a `size_t` which used to implicitly narrow to unsigned in order to shift. But with safer types there is no implicit narrowing and you need to write

  u32::try_from(shift).unwrap()

Which is then fed to the shift operator which will check (again) that the shift amount is in range.

Nowhere near the full range of values of `u32` is in range for a shift operation, so the size of the type is somewhat arbitrary. So the value inside must be checked regardless.

By allowing u64/usize types to be used on the rhs of the shift, we avoid having to write conversions where they aren't holding weight.

> This makes the C++ operators accept things that the Rust operators do
> not. Why is C++ different here?

The answer here is that
1) casting in rust is much simpler, a `sizeof<T>() as u32` expression is
   simpler than the noise introduced by conversions in C++ like
   `sus::cast<u23>(sizeof(T))`
2) we need to rewrite a lot of code that already assumes it's fine to
   shift by a size_t
3) Rust type deduction allows Rust code to avoid naming the type of
   things at all and it can pick a u32, whereas C++ will need to pick a
   type and it will often have picked a size_t/usize.

> What mitigates this difference?

And the extra expressivity does not allow C++ to do different things or change expectations wrt the behaviour of the shift operators.