### PR TITLE
Tell the optimizer the value in unwrap_unchecked

### DIFF
--- a/sus/option/option.h
+++ b/sus/option/option.h
@@ -847,7 +847,14 @@ class Option final {
   /// verified the value appropriately before use in order to not panic.
   constexpr inline T unwrap_unchecked(
       ::sus::marker::UnsafeFnMarker) && noexcept {
-    return t_.take_and_set_none();
+    if (t_.state() == Some) {
+      return t_.take_and_set_none();
+    } else {
+      // Result::unwrap_unchecked benefits from telling the compiler explicitly
+      // that the other states are never set. Match that here until shown it's
+      // actually not useful.
+      sus::unreachable_unchecked(::sus::marker::unsafe_fn);
+    }
   }
   constexpr inline T unwrap_unchecked(
       ::sus::marker::UnsafeFnMarker) const& noexcept


### PR DESCRIPTION
Result::unwrap_unchecked writes to state_ but also assumes it is always an Ok value. The optimizer fails to remove branches that construct the Result currently, but succeeds if we tell it that the state_ is an Ok value before clobbering it.

Repeat the same thing in Result::unwrap_err_unchecked and in Option::unwrap_unchecked for good measure.

The difference can be seen in here:
https://godbolt.org/z/Gax47shsb

Without it, the signed code generation is terrible. But with the optimizer hint, it's as good as working with ints directly.