### PR TITLE
Prevent clobbering of data in Result's tail padding internally and externally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,22 +12,22 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          #- {
-          #    name: "Windows MSVC",
-          #    artifact: "Windows-MSVC.tar.xz",
-          #    # MSVC 17.6.3 can no longer build Subspace. 16 doesn't work either.
-          #    # https://developercommunity.visualstudio.com/t/Update-to-1763-now-rejects-valid-C-i/10394500
-          #    os: windows-latest,
-          #    build_type: "Release",
-          #    cc: "cl",
-          #    cxx: "cl",
-          #    environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-          #  }
-          #- {
-          #    name: "Windows MinGW", artifact: "Windows-MinGW.tar.xz",
-          #    os: windows-latest,
-          #    build_type: "Release", cc: "gcc", cxx: "g++"
-          #  }
+        # MSVC is broken: https://github.com/chromium/subspace/issues/267
+        #- {
+        #    name: "Windows MSVC",
+        #    artifact: "Windows-MSVC.tar.xz",
+        #    os: windows-latest,
+        #    build_type: "Release",
+        #    cc: "cl",
+        #    cxx: "cl",
+        #    environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+        #  }
+
+        #- {
+        #    name: "Windows MinGW", artifact: "Windows-MinGW.tar.xz",
+        #    os: windows-latest,
+        #    build_type: "Release", cc: "gcc", cxx: "g++"
+        #  }
 
         - {
             name: "Ubuntu Clang-16 Debug",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
             build_type: "Release",
             cc: "gcc-13",
             cxx: "g++-13",
-            clang_version: 18,
+            clang_version: 17,
             installed_clang_version: 14
           }
 

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -78,7 +78,7 @@ jobs:
             build_type: "Release",
             cc: "gcc-13",
             cxx: "g++-13",
-            clang_version: 18,
+            clang_version: 17,
             installed_clang_version: 14
           }
 

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -15,83 +15,83 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          #- {
-          #    name: "Windows MSVC",
-          #    artifact: "Windows-MSVC.tar.xz",
-          #    # MSVC 17.6.3 can no longer build Subspace. 16 doesn't work either.
-          #    # https://developercommunity.visualstudio.com/t/Update-to-1763-now-rejects-valid-C-i/10394500
-          #    os: windows-latest,
-          #    build_type: "Release",
-          #    cc: "cl",
-          #    cxx: "cl",
-          #    environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
-          #  }
-          #- {
-          #    name: "Windows MinGW", artifact: "Windows-MinGW.tar.xz",
-          #    os: windows-latest,
-          #    build_type: "Release", cc: "gcc", cxx: "g++"
-          #  }
+        # MSVC is broken: https://github.com/chromium/subspace/issues/267
+        #- {
+        #    name: "Windows MSVC",
+        #    artifact: "Windows-MSVC.tar.xz",
+        #    os: windows-latest,
+        #    build_type: "Release",
+        #    cc: "cl",
+        #    cxx: "cl",
+        #    environment_script: "C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/Auxiliary/Build/vcvars64.bat",
+        #  }
 
-          - {
-              name: "Ubuntu Clang-16 Debug",
-              os: ubuntu-latest,
-              build_type: "Debug",
-              cc: "clang-16",
-              cxx: "clang++-16",
-              clang_version: 16,
-              installed_clang_version: 14
-            }
+        #- {
+        #    name: "Windows MinGW", artifact: "Windows-MinGW.tar.xz",
+        #    os: windows-latest,
+        #    build_type: "Release", cc: "gcc", cxx: "g++"
+        #  }
 
-          - {
-              name: "Ubuntu Clang-17 Debug",
-              os: ubuntu-latest,
-              build_type: "Debug",
-              cc: "clang-17",
-              cxx: "clang++-17",
-              clang_version: 17,
-              installed_clang_version: 14
-            }
+        - {
+            name: "Ubuntu Clang-16 Debug",
+            os: ubuntu-latest,
+            build_type: "Debug",
+            cc: "clang-16",
+            cxx: "clang++-16",
+            clang_version: 16,
+            installed_clang_version: 14
+          }
 
-          - {
-              name: "Ubuntu Clang-17 Sanitizer",
-              os: ubuntu-latest,
-              build_type: "Release",
-              cc: "clang-17",
-              cxx: "clang++-17",
-              clang_version: 17,
-              installed_clang_version: 14
-            }
+        - {
+            name: "Ubuntu Clang-17 Debug",
+            os: ubuntu-latest,
+            build_type: "Debug",
+            cc: "clang-17",
+            cxx: "clang++-17",
+            clang_version: 17,
+            installed_clang_version: 14
+          }
 
-          - {
-              name: "Ubuntu Clang-18 Debug",
-              os: ubuntu-latest,
-              build_type: "Debug",
-              cc: "clang-18",
-              cxx: "clang++-18",
-              clang_version: 18,
-              installed_clang_version: 14
-            }
+        - {
+            name: "Ubuntu Clang-17 Sanitizer",
+            os: ubuntu-latest,
+            build_type: "Release",
+            cc: "clang-17",
+            cxx: "clang++-17",
+            clang_version: 17,
+            installed_clang_version: 14
+          }
 
-          - {
-              name: "Ubuntu GCC",
-              os: ubuntu-latest,
-              build_type: "Release",
-              cc: "gcc-13",
-              cxx: "g++-13",
-              clang_version: 18,
-              installed_clang_version: 14
-            }
+        - {
+            name: "Ubuntu Clang-18 Debug",
+            os: ubuntu-latest,
+            build_type: "Debug",
+            cc: "clang-18",
+            cxx: "clang++-18",
+            clang_version: 18,
+            installed_clang_version: 14
+          }
 
-          # Clang doesn't have good enough C++20 support to compile this library
-          # yet.
-          #- {
-          #    name: "macOS Latest Clang",
-          #    artifact: "macOS.tar.xz",
-          #    os: macos-latest,
-          #    build_type: "Release",
-          #    cc: "clang",
-          #    cxx: "clang++",
-          #  }
+        - {
+            name: "Ubuntu GCC",
+            os: ubuntu-latest,
+            build_type: "Release",
+            cc: "gcc-13",
+            cxx: "g++-13",
+            clang_version: 18,
+            installed_clang_version: 14
+          }
+
+        # Clang doesn't have good enough C++20 support to compile this library
+        # yet.
+        #- {
+        #    name: "macOS Latest Clang",
+        #    artifact: "macOS.tar.xz",
+        #    os: macos-latest,
+        #    build_type: "Release",
+        #    cc: "clang",
+        #    cxx: "clang++",
+        #  }
 
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ check out which compiler versions are used by the
 |------------|---------|
 | **Clang:** | 16 and up |
 | **GCC**:   | 13 and up |
-| **MSVC**:   | 17.4.2 (not [newer versions](https://github.com/chromium/subspace/issues/267)) |
+| **MSVC**:   | VS2022 17.8.1 (Build 17.8.34316.72) and up |
 
 We attempt to work around bugs when reasonable, to widen compiler version
 support. See [compiler_bugs.h](sus/macros/__private/compiler_bugs.h) for

--- a/sus/collections/array.h
+++ b/sus/collections/array.h
@@ -54,9 +54,8 @@ namespace __private {
 
 template <class T, size_t N>
 struct Storage final {
-  sus_msvc_bug_10416202_else(
-      [[sus_no_unique_address]]) sus::iter::IterRefCounter iter_refs_;
-  T data_[N];
+  [[sus_no_unique_address]] sus::iter::IterRefCounter iter_refs_;
+  [[sus_no_unique_address]] T data_[N];
 };
 
 template <class T>

--- a/sus/collections/invalidation_off_size_unittest.cc
+++ b/sus/collections/invalidation_off_size_unittest.cc
@@ -24,9 +24,7 @@ using sus::Slice;
 
 constexpr usize array_padding = 0u
     // No support for no_unique_address in clang-cl.
-    sus_clang_bug_49358(+sizeof(i32))
-    // MSVC bug with no_unique_address and arrays, so not used here.
-    sus_clang_bug_49358_else(sus_msvc_bug_10416202(+sizeof(i32)));
+    sus_clang_bug_49358(+sizeof(i32));
 
 static_assert(alignof(Array<i32, 5>) == alignof(i32));
 static_assert(sizeof(Array<i32, 5>) == sizeof(i32) * 5 + array_padding);

--- a/sus/env/var.h
+++ b/sus/env/var.h
@@ -31,7 +31,7 @@ struct VarError {
 
   /// This struct acts as a proxy for the Reason enum, so it can be implicitly
   /// constructed from the reason value.
-  VarError(Reason r) : reason(r) {}
+  constexpr VarError(Reason r) : reason(r) {}
 
   Reason reason;
 

--- a/sus/macros/__private/compiler_bugs.h
+++ b/sus/macros/__private/compiler_bugs.h
@@ -98,8 +98,7 @@
 // TODO: https://github.com/llvm/llvm-project/issues/49358
 // Clang-cl doesn't support either [[no_unique_address]] nor
 // [[msvc::no_unique_address]]
-#if _MSC_VER && defined(__clang__) && \
-    __clang_major__ > 0  // TODO: Update when the bug is fixed.
+#if _MSC_VER && defined(__clang__) && __clang_major__ <= 17
 #define sus_clang_bug_49358(...) __VA_ARGS__
 #define sus_clang_bug_49358_else(...)
 #else

--- a/sus/mem/copy.h
+++ b/sus/mem/copy.h
@@ -84,4 +84,10 @@ concept TrivialCopy =
 template <class T>
 concept CopyOrRef = Copy<T> || std::is_reference_v<T>;
 
+/// Matches types which are [`CopyOrRef`]($sus::mem::CopyOrRef) or are `void`.
+///
+/// A helper for genertic types which can hold void as a type.
+template <class T>
+concept CopyOrRefOrVoid = CopyOrRef<T> || std::is_void_v<T>;
+
 }  // namespace sus::mem

--- a/sus/mem/move.h
+++ b/sus/mem/move.h
@@ -63,6 +63,12 @@ concept Move =
 template <class T>
 concept MoveOrRef = Move<T> || std::is_reference_v<T>;
 
+/// Matches types which are [`MoveOrRef`]($sus::mem::MoveOrRef) or are `void`.
+///
+/// A helper for genertic types which can hold void as a type.
+template <class T>
+concept MoveOrRefOrVoid = MoveOrRef<T> || std::is_void_v<T>;
+
 /// Cast `t` to an r-value reference so that it can be used to construct or be
 /// assigned to a (non-reference) object of type `T`.
 ///

--- a/sus/option/__private/storage.h
+++ b/sus/option/__private/storage.h
@@ -161,6 +161,11 @@ struct Storage<T, false> final {
 
  private:
   union {
+    // TODO: We can make this T [[no_unique_address]], however then
+    // we can not construct_at on it. Instead, we would need to only
+    // construct_at the Storage class, and have the ctor set them both.
+    //
+    // See also https://github.com/llvm/llvm-project/issues/70494
     T val_;
   };
   State state_ = None;

--- a/sus/option/option.h
+++ b/sus/option/option.h
@@ -1991,6 +1991,10 @@ class Option final {
   using StorageType =
       std::conditional_t<std::is_reference_v<U>, Storage<StoragePointer<U>>,
                          Storage<U>>;
+  // TODO: We can make this no_unique_address, however... if StorageType<T> has
+  // tail padding and Option was marked with no_unique_address, then
+  // constructing T may clobber stuff OUTSIDE the Option. So this can only be
+  // no_unique_address when StorageType<T> has no tail padding.
   StorageType<T> t_;
 
   sus_class_trivially_relocatable_if_types(::sus::marker::unsafe_fn,

--- a/sus/result/__private/storage.h
+++ b/sus/result/__private/storage.h
@@ -509,8 +509,8 @@ struct StorageNonVoid {
       {}
 
       Union(const Union&)
-        requires(std::is_trivially_copy_assignable_v<T> &&
-                 std::is_trivially_copy_assignable_v<E>)
+        requires(std::is_trivially_copy_constructible_v<T> &&
+                 std::is_trivially_copy_constructible_v<E>)
       = default;
       Union& operator=(const Union&)
         requires(std::is_trivially_copy_assignable_v<T> &&

--- a/sus/result/__private/storage.h
+++ b/sus/result/__private/storage.h
@@ -17,66 +17,524 @@
 #pragma once
 
 #include <concepts>
+#include <cstdint>
 
+#include "sus/cmp/ord.h"
 #include "sus/macros/no_unique_address.h"
 #include "sus/mem/copy.h"
 #include "sus/mem/move.h"
+#include "sus/mem/take.h"
 
 namespace sus::result::__private {
 
-enum WithT { kWithT };
-enum WithE { kWithE };
+enum WithT { WITH_T };
+enum WithE { WITH_E };
 
-template <class T, class E>
-union Storage {
-  constexpr Storage() {}
+template <class T, bool no_unique_address>
+struct MaybeNoUniqueAddress {
+  template <class... U>
+  constexpr MaybeNoUniqueAddress(WithT, U&&... v) noexcept
+      : v(WITH_T, ::sus::forward<U>(v)...) {}
+  template <class... U>
+  constexpr MaybeNoUniqueAddress(WithE, U&&... v) noexcept
+      : v(WITH_E, ::sus::forward<U>(v)...) {}
 
-  template <std::convertible_to<T> U>
-  constexpr Storage(WithT, const U& t) noexcept
-    requires(sus::mem::Copy<T>)
-      : ok_(t) {}
-  template <std::convertible_to<T> U>
-  constexpr Storage(WithT, U&& t) noexcept : ok_(::sus::move(t)) {}
-  constexpr Storage(WithE, const E& e) noexcept
-    requires(sus::mem::Copy<E>)
-      : err_(e) {}
-  constexpr Storage(WithE, E&& e) noexcept : err_(::sus::move(e)) {}
+  T v;
+};
+template <class T>
+struct MaybeNoUniqueAddress<T, true> {
+  template <class... U>
+  constexpr MaybeNoUniqueAddress(WithT, U&&... v) noexcept
+      : v(WITH_T, ::sus::forward<U>(v)...) {}
+  template <class... U>
+  constexpr MaybeNoUniqueAddress(WithE, U&&... v) noexcept
+      : v(WITH_E, ::sus::forward<U>(v)...) {}
 
-  constexpr ~Storage()
-    requires(std::is_trivially_destructible_v<T> &&
-             std::is_trivially_destructible_v<E>)
-  = default;
-  constexpr ~Storage()
-    requires(!(std::is_trivially_destructible_v<T> &&
-               std::is_trivially_destructible_v<E>))
-  {
-    // Destruction is handled in Result in this case, but a destructor needs to
-    // exist here.
+  [[sus_no_unique_address]] T v;
+};
+
+template <class E>
+struct StorageVoid {
+  enum State { Ok, Err, Moved };
+
+  constexpr StorageVoid(WithT) noexcept : inner_(WITH_T) {}
+  constexpr StorageVoid(WithE, const E& e) noexcept
+    requires(std::is_copy_constructible_v<E>)
+      : inner_(WITH_E, e) {}
+  constexpr StorageVoid(WithE, E&& e) noexcept
+    requires(std::is_move_constructible_v<E>)
+      : inner_(WITH_E, ::sus::move(e)) {}
+
+  constexpr ~StorageVoid() noexcept = default;
+
+  constexpr StorageVoid(const StorageVoid&) noexcept = default;
+  constexpr StorageVoid& operator=(const StorageVoid&) noexcept = default;
+  constexpr StorageVoid(StorageVoid&&) noexcept = default;
+  constexpr StorageVoid& operator=(StorageVoid&&) noexcept = default;
+
+  constexpr bool is_moved() const noexcept { return inner_.v.state == Moved; }
+  constexpr bool is_ok() const noexcept { return inner_.v.state == Ok; }
+  constexpr bool is_err() const noexcept { return inner_.v.state == Err; }
+
+  template <class As>
+  constexpr void get_ok() const noexcept {}
+  constexpr const E& get_err() const noexcept {
+    return inner_.v.u.err;  //
   }
 
-  constexpr Storage(const Storage&) noexcept
-    requires(std::is_trivially_copy_constructible_v<T> &&
-             std::is_trivially_copy_constructible_v<E>)
-  = default;
-  constexpr Storage& operator=(const Storage&)
-    requires(std::is_trivially_copy_assignable_v<T> &&
-             std::is_trivially_copy_assignable_v<E>)
-  = default;
+  template <class As>
+  constexpr void get_ok_mut() & noexcept {}
+  constexpr E& get_err_mut() & noexcept {
+    return inner_.v.u.err;  //
+  }
 
-  constexpr Storage(Storage&&)
-    requires(std::is_trivially_move_constructible_v<T> &&
-             std::is_trivially_move_constructible_v<E>)
-  = default;
-  constexpr Storage& operator=(Storage&&)
-    requires(std::is_trivially_move_assignable_v<T> &&
-             std::is_trivially_move_assignable_v<E>)
-  = default;
+  template <class As>
+  constexpr void take_ok() & noexcept {
+    inner_.v.state = Moved;  //
+  }
+  constexpr E take_err() & noexcept
+    requires(::sus::mem::Move<E>)
+  {
+    inner_.v.state = Moved;
+    return ::sus::mem::take_and_destruct(::sus::marker::unsafe_fn,
+                                         inner_.v.u.err);
+  }
 
-  constexpr inline void destroy_ok() noexcept { ok_.~T(); }
-  constexpr inline void destroy_err() noexcept { err_.~E(); }
+  constexpr void drop_ok() & noexcept {
+    inner_.v.state = Moved;  //
+  }
+  constexpr void drop_err() & noexcept {
+    inner_.v.state = Moved;
+    std::destroy_at(&inner_.v.u.err);
+  }
 
-  [[sus_no_unique_address]] T ok_;
-  [[sus_no_unique_address]] E err_;
+ private:
+  struct Inner {
+    constexpr explicit Inner(WithT) : u(WITH_T), state(Ok) {}
+    template <class U>
+    constexpr Inner(WithE, U&& err)
+        : u(WITH_E, ::sus::forward<U>(err)), state(Err) {}
+
+    constexpr ~Inner() noexcept
+      requires(std::is_trivially_destructible_v<E>)
+    = default;
+    constexpr ~Inner() noexcept
+      requires(!std::is_trivially_destructible_v<E>)
+    {
+      switch (state) {
+        case Ok: break;
+        case Err: std::destroy_at(&u.err); break;
+        case Moved: break;
+      }
+    }
+
+    constexpr Inner(const Inner&)
+      requires(std::is_trivially_copy_constructible_v<E>)
+    = default;
+    constexpr Inner(const Inner& o)
+      requires(!std::is_trivially_copy_constructible_v<E>)
+    {
+      switch (o.state) {
+        case Ok: break;
+        case Err: std::construct_at(&u.err, o.u.err); break;
+        case Moved: panic_with_message("Result used after move");
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = o.state;
+    }
+
+    constexpr Inner& operator=(const Inner&)
+      requires(std::is_trivially_copy_assignable_v<E>)
+    = default;
+    constexpr Inner& operator=(const Inner& o)
+      requires(!std::is_trivially_copy_assignable_v<E>)
+    {
+      check_with_message(o.state != Moved, "Result used after move");
+      if (state == o.state) {
+        switch (state) {
+          case Ok: break;
+          case Err: u.err = o.u.err; break;
+          case Moved: break;
+        }
+      } else {
+        switch (state) {
+          case Ok: break;
+          case Err: std::destroy_at(&u.err); break;
+          case Moved: break;
+        }
+        // If this trips, it means the destructor in this Result moved out
+        // of the Result that is being assigned from.
+        check_with_message(o.state != Moved, "Result used after move");
+        switch (o.state) {
+          case Ok: break;
+          case Err: std::construct_at(&u.err, o.u.err); break;
+          case Moved: sus::unreachable_unchecked(::sus::marker::unsafe_fn);
+        }
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = o.state;
+      return *this;
+    }
+
+    constexpr Inner(Inner&&)
+      requires(std::is_trivially_move_constructible_v<E>)
+    = default;
+    constexpr Inner(Inner&& o)
+      requires(!std::is_trivially_move_constructible_v<E>)
+    {
+      switch (o.state) {
+        case Ok: break;
+        case Err: std::construct_at(&u.err, ::sus::move(o.u.err)); break;
+        case Moved: panic_with_message("Result used after move");
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = ::sus::mem::replace(o.state, Moved);
+    }
+
+    constexpr Inner& operator=(Inner&&)
+      requires(std::is_trivially_move_assignable_v<E>)
+    = default;
+    constexpr Inner& operator=(Inner&& o)
+      requires(!std::is_trivially_move_assignable_v<E>)
+    {
+      check_with_message(o.state != Moved, "Result used after move");
+      if (state == o.state) {
+        switch (state) {
+          case Ok: break;
+          case Err: u.err = ::sus::move(o.u.err); break;
+          case Moved: break;
+        }
+      } else {
+        switch (state) {
+          case Ok: break;
+          case Err: std::destroy_at(&u.err); break;
+          case Moved: break;
+        }
+        // If this trips, it means the destructor in this Result moved out
+        // of the Result that is being assigned from.
+        check_with_message(o.state != Moved, "Result used after move");
+        switch (o.state) {
+          case Ok: break;
+          case Err:
+            std::construct_at(&u.err, ::sus::move(o.u.err));
+            std::destroy_at(&o.u.err);
+            break;
+          case Moved: sus::unreachable_unchecked(::sus::marker::unsafe_fn);
+        }
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = ::sus::mem::replace(o.state, Moved);
+      return *this;
+    }
+
+    union Union {
+      constexpr Union() noexcept {}
+
+      constexpr Union(WithT) noexcept {}
+      template <class U>
+      constexpr Union(WithE, U&& err) noexcept : err(::sus::forward<U>(err)) {}
+
+      constexpr ~Union() noexcept
+        requires(std::is_trivially_destructible_v<E>)
+      = default;
+      constexpr ~Union() noexcept
+        requires(!std::is_trivially_destructible_v<E>)
+      {}
+
+      Union(const Union&)
+        requires(std::is_trivially_copy_constructible_v<E>)
+      = default;
+      Union& operator=(const Union&)
+        requires(std::is_trivially_copy_assignable_v<E>)
+      = default;
+      Union(Union&&)
+        requires(std::is_trivially_move_constructible_v<E>)
+      = default;
+      Union& operator=(Union&&)
+        requires(std::is_trivially_move_assignable_v<E>)
+      = default;
+
+      [[no_unique_address]] E err;
+    };
+    [[no_unique_address]] Union u;
+    [[no_unique_address]] State state;
+  };
+  static constexpr bool union_cant_clobber_outside_inner =
+      ::sus::mem::data_size_of<E>() == ::sus::mem::size_of<E>();
+
+  [[no_unique_address]] MaybeNoUniqueAddress<Inner,
+                                             union_cant_clobber_outside_inner>
+      inner_;
+
+  sus_class_trivially_relocatable_if_types(::sus::marker::unsafe_fn,
+                                           decltype(inner_.v.u.err),
+                                           decltype(inner_.v.state));
+};
+
+template <class T, class E>
+struct StorageNonVoid {
+  enum State { Ok, Err, Moved };
+
+  constexpr StorageNonVoid(WithT, const T& t) noexcept
+    requires(std::is_copy_constructible_v<T>)
+      : inner_(WITH_T, t) {}
+  constexpr StorageNonVoid(WithT, T&& t) noexcept
+    requires(std::is_move_constructible_v<T>)
+      : inner_(WITH_T, ::sus::move(t)) {}
+  constexpr StorageNonVoid(WithE, const E& e) noexcept
+    requires(std::is_copy_constructible_v<E>)
+      : inner_(WITH_E, e) {}
+  constexpr StorageNonVoid(WithE, E&& e) noexcept
+    requires(std::is_move_constructible_v<E>)
+      : inner_(WITH_E, ::sus::move(e)) {}
+
+  constexpr ~StorageNonVoid() noexcept = default;
+
+  constexpr StorageNonVoid(const StorageNonVoid& o) noexcept = default;
+  constexpr StorageNonVoid& operator=(const StorageNonVoid&) noexcept = default;
+  constexpr StorageNonVoid(StorageNonVoid&&) noexcept = default;
+  constexpr StorageNonVoid& operator=(StorageNonVoid&&) noexcept = default;
+
+  constexpr bool is_moved() const noexcept { return inner_.v.state == Moved; }
+  constexpr bool is_ok() const noexcept { return inner_.v.state == Ok; }
+  constexpr bool is_err() const noexcept { return inner_.v.state == Err; }
+
+  template <class As>
+  constexpr const std::remove_reference_t<As>& get_ok() const noexcept {
+    return inner_.v.u.ok;  //
+  }
+  constexpr const E& get_err() const noexcept {
+    return inner_.v.u.err;  //
+  }
+
+  template <class As>
+  constexpr As& get_ok_mut() & noexcept {
+    return inner_.v.u.ok;  //
+  }
+  constexpr E& get_err_mut() & noexcept {
+    return inner_.v.u.err;  //
+  }
+
+  template <class As>
+  constexpr As take_ok() & noexcept
+    requires(::sus::mem::Move<T>)
+  {
+    inner_.v.state = Moved;
+    return ::sus::mem::take_and_destruct(::sus::marker::unsafe_fn,
+                                         inner_.v.u.ok);
+  }
+  constexpr E take_err() & noexcept
+    requires(::sus::mem::Move<E>)
+  {
+    inner_.v.state = Moved;
+    return ::sus::mem::take_and_destruct(::sus::marker::unsafe_fn,
+                                         inner_.v.u.err);
+  }
+
+  constexpr void drop_ok() & noexcept {
+    inner_.v.state = Moved;  //
+    std::destroy_at(&inner_.v.u.ok);
+  }
+  constexpr void drop_err() & noexcept {
+    inner_.v.state = Moved;
+    std::destroy_at(&inner_.v.u.err);
+  }
+
+ private:
+ public:
+  struct Inner {
+    template <class U>
+    constexpr Inner(WithT, U&& ok)
+        : u(WITH_T, ::sus::forward<U>(ok)), state(Ok) {}
+    template <class U>
+    constexpr Inner(WithE, U&& err)
+        : u(WITH_E, ::sus::forward<U>(err)), state(Err) {}
+
+    constexpr ~Inner() noexcept
+      requires(std::is_trivially_destructible_v<T> &&
+               std::is_trivially_destructible_v<E>)
+    = default;
+    constexpr ~Inner() noexcept
+      requires(!std::is_trivially_destructible_v<T> ||
+               !std::is_trivially_destructible_v<E>)
+    {
+      switch (state) {
+        case Ok: std::destroy_at(&u.ok); break;
+        case Err: std::destroy_at(&u.err); break;
+        case Moved: break;
+      }
+    }
+
+    constexpr Inner(const Inner&)
+      requires(std::is_trivially_copy_constructible_v<T> &&
+               std::is_trivially_copy_constructible_v<E>)
+    = default;
+    constexpr Inner(const Inner& o)
+      requires(!std::is_trivially_copy_constructible_v<T> ||
+               !std::is_trivially_copy_constructible_v<E>)
+    {
+      switch (o.state) {
+        case Ok: std::construct_at(&u.ok, o.u.ok); break;
+        case Err: std::construct_at(&u.err, o.u.err); break;
+        case Moved: panic_with_message("Result used after move");
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = o.state;
+    }
+
+    constexpr Inner& operator=(const Inner&)
+      requires(std::is_trivially_copy_assignable_v<T> &&
+               std::is_trivially_copy_assignable_v<E>)
+    = default;
+    constexpr Inner& operator=(const Inner& o)
+      requires(!std::is_trivially_copy_assignable_v<T> ||
+               !std::is_trivially_copy_assignable_v<E>)
+    {
+      check_with_message(o.state != Moved, "Result used after move");
+      if (state == o.state) {
+        switch (state) {
+          case Ok: u.ok = o.u.ok; break;
+          case Err: u.err = o.u.err; break;
+          case Moved: break;
+        }
+      } else {
+        switch (state) {
+          case Ok: std::destroy_at(&u.ok); break;
+          case Err: std::destroy_at(&u.err); break;
+          case Moved: break;
+        }
+        // If this trips, it means the destructor in this Result moved out
+        // of the Result that is being assigned from.
+        check_with_message(o.state != Moved, "Result used after move");
+        switch (o.state) {
+          case Ok: std::construct_at(&u.ok, o.u.ok); break;
+          case Err: std::construct_at(&u.err, o.u.err); break;
+          case Moved: sus::unreachable_unchecked(::sus::marker::unsafe_fn);
+        }
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = o.state;
+      return *this;
+    }
+
+    constexpr Inner(Inner&&)
+      requires(std::is_trivially_move_constructible_v<T> &&
+               std::is_trivially_move_constructible_v<E>)
+    = default;
+    constexpr Inner(Inner&& o)
+      requires(!std::is_trivially_move_constructible_v<T> ||
+               !std::is_trivially_move_constructible_v<E>)
+    {
+      switch (o.state) {
+        case Ok: std::construct_at(&u.ok, ::sus::move(o.u.ok)); break;
+        case Err: std::construct_at(&u.err, ::sus::move(o.u.err)); break;
+        case Moved: panic_with_message("Result used after move");
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = ::sus::mem::replace(o.state, Moved);
+    }
+
+    constexpr Inner& operator=(Inner&&)
+      requires(std::is_trivially_move_assignable_v<T> &&
+               std::is_trivially_move_assignable_v<E>)
+    = default;
+    constexpr Inner& operator=(Inner&& o)
+      requires(!std::is_trivially_move_assignable_v<T> ||
+               !std::is_trivially_move_assignable_v<E>)
+    {
+      check_with_message(o.state != Moved, "Result used after move");
+      if (state == o.state) {
+        switch (state) {
+          case Ok: u.ok = ::sus::move(o.u.ok); break;
+          case Err: u.err = ::sus::move(o.u.err); break;
+          case Moved: break;
+        }
+      } else {
+        switch (state) {
+          case Ok: std::destroy_at(&u.ok); break;
+          case Err: std::destroy_at(&u.err); break;
+          case Moved: break;
+        }
+        // If this trips, it means the destructor in this Result moved out
+        // of the Result that is being assigned from.
+        check_with_message(o.state != Moved, "Result used after move");
+        switch (o.state) {
+          case Ok:
+            std::construct_at(&u.ok, ::sus::move(o.u.ok));
+            std::destroy_at(&o.u.ok);
+            break;
+          case Err:
+            std::construct_at(&u.err, ::sus::move(o.u.err));
+            std::destroy_at(&o.u.err);
+            break;
+          case Moved: sus::unreachable_unchecked(::sus::marker::unsafe_fn);
+        }
+      }
+      // After construct_at since it may write into the field if it's in tail
+      // padding.
+      state = ::sus::mem::replace(o.state, Moved);
+      return *this;
+    }
+
+    union Union {
+      constexpr Union() noexcept {}
+
+      template <class U>
+      constexpr Union(WithT, U&& ok) : ok(::sus::forward<U>(ok)) {}
+      template <class U>
+      constexpr Union(WithE, U&& err) : err(::sus::forward<U>(err)) {}
+
+      constexpr ~Union() noexcept
+        requires(std::is_trivially_destructible_v<T> &&
+                 std::is_trivially_destructible_v<E>)
+      = default;
+      constexpr ~Union() noexcept
+        requires(!std::is_trivially_destructible_v<T> ||
+                 !std::is_trivially_destructible_v<E>)
+      {}
+
+      Union(const Union&)
+        requires(std::is_trivially_copy_assignable_v<T> &&
+                 std::is_trivially_copy_assignable_v<E>)
+      = default;
+      Union& operator=(const Union&)
+        requires(std::is_trivially_copy_assignable_v<T> &&
+                 std::is_trivially_copy_assignable_v<E>)
+      = default;
+      Union(Union&&)
+        requires(std::is_trivially_move_constructible_v<T> &&
+                 std::is_trivially_move_constructible_v<E>)
+      = default;
+      Union& operator=(Union&&)
+        requires(std::is_trivially_move_assignable_v<T> &&
+                 std::is_trivially_move_assignable_v<E>)
+      = default;
+
+      [[no_unique_address]] T ok;
+      [[no_unique_address]] E err;
+    };
+    [[no_unique_address]] Union u;
+    [[no_unique_address]] State state;
+  };
+  static constexpr bool union_cant_clobber_outside_inner =
+      (::sus::mem::data_size_of<T>() == ::sus::mem::size_of<T>() &&
+       ::sus::mem::data_size_of<E>() == ::sus::mem::size_of<E>());
+
+  [[no_unique_address]] MaybeNoUniqueAddress<Inner,
+                                             union_cant_clobber_outside_inner>
+      inner_;
+
+  sus_class_trivially_relocatable_if_types(::sus::marker::unsafe_fn,
+                                           decltype(inner_.v.u.ok),
+                                           decltype(inner_.v.u.err),
+                                           decltype(inner_.v.state));
 };
 
 }  // namespace sus::result::__private

--- a/sus/test/behaviour_types.h
+++ b/sus/test/behaviour_types.h
@@ -68,7 +68,7 @@ struct TriviallyMoveableNotDestructible final {
       TriviallyMoveableNotDestructible&&) = default;
   constexpr TriviallyMoveableNotDestructible& operator=(
       TriviallyMoveableNotDestructible&&) = default;
-  constexpr ~TriviallyMoveableNotDestructible(){};
+  constexpr ~TriviallyMoveableNotDestructible() {}
   constexpr TriviallyMoveableNotDestructible(int i) : i(i) {}
   int i;
 };


### PR DESCRIPTION
https://github.com/llvm/llvm-project/issues/70494 points out that `[[no_unique_address]]` on a union member can cause its placement-new construction to clobber data in its tail padding, as ctors can and do write their entire `sizeof()` size, not just their data-size.

So we do some wild things to prevent this from occurring:

The `T` and `E` union are grouped with the state into a struct, which we call `Inner`. This structure is always constructed together as a group when changing the state to Ok or Err. This ensures that we construct `T` or `E` and then set the state (which follows in the struct) thus avoiding clobbering of the state.

Second, the Inner struct needs to be protected from clobbering other things in its tail padding. So it is wrapped in another struct that conditionally applies `[[no_unique_address]]` to it, which we call `MaybeNoUniqueAddress`.

We mark `Inner` as `[[no_unique_address]]` only when there is no tail padding in `T` or `E`. Then the tail padding of `Inner` which is introduced by the state flag can be used by things external to the `Result`.

All of this is put into the outermost structure `StorageVoid` or `StorageNonVoid` for a void `T` or not, respectively. Everything is marked `[[no_unique_address]]` except `Inner` which is conditionally marked as mentioned above.

In order to do this, we've rewritten the entire implementation of Result's storage. In the process, copy/move operations and destructors are all trivial if the same for both `T` and `E` are trivial, which fixes #403.

The Clang 18 and GCC builds are failing due to the Clang-18 apt package not including libclang: https://github.com/llvm/llvm-project/issues/73402