### PR TITLE
Make class variables and global variables use long layout

### DIFF
--- a/subdoc/gen_tests/struct-complex/S.html
+++ b/subdoc/gen_tests/struct-complex/S.html
@@ -121,22 +121,22 @@
         <div class="section-header">
           <a name="static-data-members" href="#static-data-members">Static Data Members</a>
         </div>
-        <ul class="section-items item-table">
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.static_bool_member"></a><span class="static">static</span> bool <a class="field-name" href="S.html#field.static_bool_member">static_bool_member</a></div></div>
-            <div class="description short">
+        <div class="section-items">
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.static_bool_member"></a><span class="static">static</span> bool <a class="field-name" href="S.html#field.static_bool_member">static_bool_member</a></div>
+            <div class="description long">
               <p>Comment headline static_bool_member</p>
 
             </div>
-          </li>
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.static_type_member"></a><span class="static">static</span> <span class="volatile">volatile</span> <a class="type-name" href="OtherType.html" title="OtherType">OtherType</a> <a class="field-name" href="S.html#field.static_type_member">static_type_member</a></div></div>
-            <div class="description short">
+          </div>
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.static_type_member"></a><span class="static">static</span> <span class="volatile">volatile</span> <a class="type-name" href="OtherType.html" title="OtherType">OtherType</a> <a class="field-name" href="S.html#field.static_type_member">static_type_member</a></div>
+            <div class="description long">
               <p>Comment headline static_type_member</p>
 
             </div>
-          </li>
-        </ul>
+          </div>
+        </div>
       </div>
       <div class="section methods static">
         <div class="section-header">
@@ -230,22 +230,22 @@
         <div class="section-header">
           <a name="data-members" href="#data-members">Data Members</a>
         </div>
-        <ul class="section-items item-table">
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.bool_field"></a>bool <a class="field-name" href="S.html#field.bool_field">bool_field</a></div></div>
-            <div class="description short">
+        <div class="section-items">
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.bool_field"></a>bool <a class="field-name" href="S.html#field.bool_field">bool_field</a></div>
+            <div class="description long">
               <p>Comment headline bool_field</p>
 
             </div>
-          </li>
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.type_field"></a><span class="const">const</span> <a class="type-name" href="OtherType.html" title="OtherType">OtherType</a> <a class="field-name" href="S.html#field.type_field">type_field</a></div></div>
-            <div class="description short">
+          </div>
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.type_field"></a><span class="const">const</span> <a class="type-name" href="OtherType.html" title="OtherType">OtherType</a> <a class="field-name" href="S.html#field.type_field">type_field</a></div>
+            <div class="description long">
               <p>Comment headline type_field</p>
 
             </div>
-          </li>
-        </ul>
+          </div>
+        </div>
       </div>
     </div>
   </main>

--- a/subdoc/gen_tests/subdoc-test-style.css
+++ b/subdoc/gen_tests/subdoc-test-style.css
@@ -302,7 +302,13 @@ code {
     padding-bottom: 0.2rem;
 }
 
-.record .section-items :is(.type-signature, .function-signature) {
+/* These types have long descriptions inline in the context's page. */
+.record .section-items :is(.type-signature, .function-signature, .member-signature) {
+    background-color: rgba(43, 43, 43, 1.0);
+    padding: 0.5rem;
+    margin-bottom: 0.2rem;
+}
+.namespace .section-items :is(.member-signature) {
     background-color: rgba(43, 43, 43, 1.0);
     padding: 0.5rem;
     margin-bottom: 0.2rem;

--- a/subdoc/gen_tests/templates/TemplateMethods.html
+++ b/subdoc/gen_tests/templates/TemplateMethods.html
@@ -113,13 +113,13 @@
         <div class="section-header">
           <a name="static-data-members" href="#static-data-members">Static Data Members</a>
         </div>
-        <ul class="section-items item-table">
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.member"></a><div class="template">template &lt;class U&gt;</div><span class="static">static</span> U <a class="field-name" href="TemplateMethods.html#field.member">member</a></div></div>
-            <div class="description short">
+        <div class="section-items">
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.member"></a><div class="template">template &lt;class U&gt;</div><span class="static">static</span> U <a class="field-name" href="TemplateMethods.html#field.member">member</a></div>
+            <div class="description long">
             </div>
-          </li>
-        </ul>
+          </div>
+        </div>
       </div>
       <div class="section methods static">
         <div class="section-header">
@@ -210,13 +210,13 @@
         <div class="section-header">
           <a name="data-members" href="#data-members">Data Members</a>
         </div>
-        <ul class="section-items item-table">
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.template_field"></a><a class="type-name" href="S.html" title="S">S</a>&lt;<a class="type-name" href="S.html" title="S">S</a>&lt;int&gt;&gt; <a class="field-name" href="TemplateMethods.html#field.template_field">template_field</a></div></div>
-            <div class="description short">
+        <div class="section-items">
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.template_field"></a><a class="type-name" href="S.html" title="S">S</a>&lt;<a class="type-name" href="S.html" title="S">S</a>&lt;int&gt;&gt; <a class="field-name" href="TemplateMethods.html#field.template_field">template_field</a></div>
+            <div class="description long">
             </div>
-          </li>
-        </ul>
+          </div>
+        </div>
       </div>
     </div>
   </main>

--- a/subdoc/gen_tests/typenames-across-paths/n-HoldS.html
+++ b/subdoc/gen_tests/typenames-across-paths/n-HoldS.html
@@ -82,24 +82,24 @@
         <div class="section-header">
           <a name="data-members" href="#data-members">Data Members</a>
         </div>
-        <ul class="section-items item-table">
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.nested"></a><a class="type-name" href="other-subother-S-FirstNested-Nested.html" title="other::subother::S::FirstNested::Nested">Nested</a> <a class="field-name" href="n-HoldS.html#field.nested">nested</a></div></div>
-            <div class="description short">
+        <div class="section-items">
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.nested"></a><a class="type-name" href="other-subother-S-FirstNested-Nested.html" title="other::subother::S::FirstNested::Nested">Nested</a> <a class="field-name" href="n-HoldS.html#field.nested">nested</a></div>
+            <div class="description long">
               <p>Should show <code>Nested</code> as the field type, not the full path, and link to
 <code>other::subother::S::FirstNested::Nested</code>.</p>
 
             </div>
-          </li>
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="field.s"></a><a class="type-name" href="other-subother-S.html" title="other::subother::S">S</a> <a class="field-name" href="n-HoldS.html#field.s">s</a></div></div>
-            <div class="description short">
+          </div>
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="field.s"></a><a class="type-name" href="other-subother-S.html" title="other::subother::S">S</a> <a class="field-name" href="n-HoldS.html#field.s">s</a></div>
+            <div class="description long">
               <p>Should show <code>S</code> as the field type, not the full path, and link to
 <code>other::subother::S</code>.</p>
 
             </div>
-          </li>
-        </ul>
+          </div>
+        </div>
       </div>
     </div>
   </main>

--- a/subdoc/gen_tests/typenames-across-paths/other-namespace.subother.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-namespace.subother.html
@@ -132,15 +132,15 @@
         <div class="section-header">
           <a name="variables" href="#variables">Variables</a>
         </div>
-        <ul class="section-items item-table">
-          <li class="section-item">
-            <div class="item-name"><div class="member-signature"><a name="variable.var"></a>int <a class="field-name" href="other-namespace.subother.html#variable.var">var</a></div></div>
-            <div class="description short">
+        <div class="section-items">
+          <div class="section-item">
+            <div class="item-name member-signature"><a name="variable.var"></a>int <a class="field-name" href="other-namespace.subother.html#variable.var">var</a></div>
+            <div class="description long">
               <p>Deduces to <code>int var</code>.</p>
 
             </div>
-          </li>
-        </ul>
+          </div>
+        </div>
       </div>
       <div class="section concepts">
         <div class="section-header">

--- a/subdoc/lib/gen/generate_namespace.cc
+++ b/subdoc/lib/gen/generate_namespace.cc
@@ -525,14 +525,13 @@ sus::Result<void, MarkdownToHtmlError> generate_variable_references(
     header_name.write_text("Variables");
   }
   {
-    auto items_list = section_div.open_ul();
-    items_list.add_class("section-items");
-    items_list.add_class("item-table");
+    auto items_div = section_div.open_div();
+    items_div.add_class("section-items");
 
     for (const SortedVariableByName& sorted_var : variables) {
       const FieldElement& fe = field_element_from_sorted(element, sorted_var);
       if (auto result = generate_field_reference(
-              items_list, fe, /*static_fields=*/false, page_state);
+              items_div, fe, /*static_fields=*/false, page_state);
           result.is_err()) {
         return sus::err(sus::move(result).unwrap_err());
       }

--- a/subdoc/lib/gen/generate_record.cc
+++ b/subdoc/lib/gen/generate_record.cc
@@ -212,14 +212,13 @@ sus::Result<void, MarkdownToHtmlError> generate_record_fields(
     }
   }
   {
-    auto items_ul = section_div.open_ul();
-    items_ul.add_class("section-items");
-    items_ul.add_class("item-table");
+    auto items_div = section_div.open_div();
+    items_div.add_class("section-items");
 
     for (auto&& [name, sort_key, field_unique_symbol] : fields) {
       const FieldElement& fe = element.fields.at(field_unique_symbol);
       if (auto result =
-              generate_field_reference(items_ul, fe, static_fields, page_state);
+              generate_field_reference(items_div, fe, static_fields, page_state);
           result.is_err()) {
         return sus::err(sus::move(result).unwrap_err());
       }
@@ -587,16 +586,14 @@ sus::Result<void, MarkdownToHtmlError> generate_record_reference(
 }
 
 sus::Result<void, MarkdownToHtmlError> generate_field_reference(
-    HtmlWriter::OpenUl& ul, const FieldElement& element, bool static_fields,
+    HtmlWriter::OpenDiv& div, const FieldElement& element, bool static_fields,
     ParseMarkdownPageState& page_state) noexcept {
-  auto li = ul.open_li();
-  li.add_class("section-item");
+  auto item_div = div.open_div();
+  item_div.add_class("section-item");
 
   {
-    auto name_div = li.open_div(HtmlWriter::SingleLine);
-    name_div.add_class("item-name");
-
-    auto sig_div = name_div.open_div(HtmlWriter::SingleLine);
+    auto sig_div = item_div.open_div(HtmlWriter::SingleLine);
+    sig_div.add_class("item-name");
     sig_div.add_class("member-signature");
 
     {
@@ -632,9 +629,9 @@ sus::Result<void, MarkdownToHtmlError> generate_field_reference(
             })));
   }
   {
-    auto desc_div = li.open_div();
+    auto desc_div = item_div.open_div();
     desc_div.add_class("description");
-    desc_div.add_class("short");
+    desc_div.add_class("long");
     if (auto comment = element.get_comment(); comment.is_some()) {
       if (auto md_html = markdown_to_html(comment.as_value(), page_state);
           md_html.is_err()) {

--- a/subdoc/lib/gen/generate_record.h
+++ b/subdoc/lib/gen/generate_record.h
@@ -34,7 +34,7 @@ sus::Result<void, MarkdownToHtmlError> generate_record_reference(
     ParseMarkdownPageState& page_state) noexcept;
 
 sus::Result<void, MarkdownToHtmlError> generate_field_reference(
-    HtmlWriter::OpenUl& div, const FieldElement& element,
+    HtmlWriter::OpenDiv& div, const FieldElement& element,
     bool static_fields,
     ParseMarkdownPageState& page_state) noexcept;
 


### PR DESCRIPTION
Since they don't link to another page, they need the full description present, and the full type. This means they take more space and should have the long form layout.