### PR TITLE
Remove CMake modmap files from command line in Subdoc

### DIFF
--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     paths-ignore:
       - "**.md"
-      - "**.txt"
       - ".vscode/**"
 
 jobs:

--- a/subdoc/lib/run.cc
+++ b/subdoc/lib/run.cc
@@ -91,10 +91,12 @@ sus::Result<Database, DiagnosticResults> run_files(
       // requires this define in order to use offsetof() from constant
       // expressions, which subspace uses for the never-value optimization.
       args.push_back("/D_CRT_USE_BUILTIN_OFFSETOF");
+#if CLANG_VERSION_MAJOR <= 16
       // TODO: https://github.com/llvm/llvm-project/issues/60347 the
       // source_location header on windows requires this to be defined. As
       // Clang's C++20 support includes consteval, let's define it.
       args.push_back("/D__cpp_consteval");
+#endif
       // Turn off warnings in code, clang-cl finds a lot of warnings that we
       // don't get when building with regular clang.
       args.push_back("/w");


### PR DESCRIPTION
This makes Subdoc work with compile_commands.json files generated by CMake 3.28, as long as no C++20 modules are actually used.

Fixes #437