### PR TITLE
Find and insert the resource dir when the compiler was Clang

### DIFF
--- a/subdoc/CMakeLists.txt
+++ b/subdoc/CMakeLists.txt
@@ -45,6 +45,8 @@ target_sources(subdoc_lib PUBLIC
     "lib/gen/markdown_to_html.cc"
     "lib/gen/markdown_to_html.h"
     "lib/gen/options.h"
+    "lib/clang_resource_dir.cc"
+    "lib/clang_resource_dir.h"
     "lib/database.h"
     "lib/friendly_names.h"
     "lib/linked_type.cc"

--- a/subdoc/lib/clang_resource_dir.cc
+++ b/subdoc/lib/clang_resource_dir.cc
@@ -1,0 +1,82 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "subdoc/lib/clang_resource_dir.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include "subdoc/llvm.h"
+
+namespace subdoc {
+
+Option<std::string> ClangResourceDir::find_resource_dir(std::string_view tool) {
+  if (auto it = cache_.find(tool); it != cache_.end()) {
+    return sus::some(it->second);
+  }
+
+  std::filesystem::path tool_path(tool);
+  std::string stem = tool_path.stem().string();
+  if (!stem.starts_with("clang")) return sus::none();
+
+  if (!std::filesystem::exists(tool_path)) {
+    fmt::println(stderr, "WARNING: can't find clang compiler at '{}'", tool);
+    return sus::none();
+  }
+
+  std::array<llvm::StringRef, 2> args = {tool, "-print-resource-dir"};
+  if (stem.starts_with("clang-cl")) {
+    args[1] = "/clang:-print-resource-dir";
+  }
+
+  llvm::SmallString<100> out;
+  {
+    std::error_code code =
+        llvm::sys::fs::createTemporaryFile("stdout", "txt", out);
+    if (code) {
+      fmt::println(stderr, "WARNING: unable to make temp file: {}",
+                   code.message());
+      return sus::none();
+    }
+  }
+  std::array<std::optional<llvm::StringRef>, 3> redirects = {std::nullopt, out,
+                                                             std::nullopt};
+  {
+    i32 code =
+        llvm::sys::ExecuteAndWait(tool, args, /*env=*/std::nullopt, redirects);
+    if (code != 0) {
+      fmt::println(
+          stderr, "WARNING: failed to run clang compiler at '{}', exit code {}",
+          tool, code);
+      return sus::none();
+    }
+  }
+
+  auto out_file = std::ifstream(out.c_str());
+  std::string resource_dir;
+  if (!std::getline(out_file, resource_dir)) {
+    fmt::println(stderr,
+                 "WARNING: 'clang -print-resource-dir' did not return anything "
+                 "for clang compiler at '{}'",
+                 tool);
+    return sus::none();
+  }
+
+  auto trimmed_resource_dir = llvm::StringRef(resource_dir).trim();
+
+  cache_.emplace(tool, std::string(trimmed_resource_dir));
+  return sus::some(std::string(trimmed_resource_dir));
+}
+
+}  // namespace subdoc

--- a/subdoc/lib/clang_resource_dir.h
+++ b/subdoc/lib/clang_resource_dir.h
@@ -1,0 +1,43 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <map>
+#include <string>
+#include <string_view>
+
+#include "sus/prelude.h"
+
+namespace subdoc {
+
+/// Find, store, and return the "resource dir" for finding system headers from
+/// Clang.
+///
+/// Clang tools need to know where the "resource dir" is in order to find
+/// system headers there, if Clang was the compiler that's being used for
+/// building the target.
+///
+/// For other compilers, the headers come from the system header location, but
+/// Clang has a resource dir that is known to the compiler, and which Subdoc
+/// can't know apriori. So it has to query the Clang compiler to get it.
+class ClangResourceDir {
+ public:
+  Option<std::string> find_resource_dir(std::string_view tool);
+
+  std::map<std::string /* tool */, std::string /* resource_dir */, std::less<>>
+      cache_;
+};
+
+}  // namespace subdoc

--- a/subdoc/llvm.h
+++ b/subdoc/llvm.h
@@ -58,6 +58,7 @@
 #include "llvm/Support/Error.h"
 #include "llvm/Support/InitLLVM.h"
 #include "llvm/Support/MemoryBuffer.h"
+#include "llvm/Support/Program.h"
 #include "llvm/Support/SHA1.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/VirtualFileSystem.h"


### PR DESCRIPTION
If the compiler used to compile the source file from compile_commmands.json was Clang, then Subdoc (a Clang tool itself) needs to know where the "resource dir" is that Clang would have used, since Clang goes through the resource dir to find system headers.

To do this, we execute the Clang compiler with -print-resource-dir and return the directory given by it. Then we append this to the Subdoc execution of ClangTool with -resource-dir.