### PR TITLE
Fix search on Safari and handle errors and `::` queries

### DIFF
--- a/subdoc/gen_tests/function-overloads/index.html
+++ b/subdoc/gen_tests/function-overloads/index.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -238,7 +269,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -254,7 +285,7 @@
           <div class="section overview">
             <h1 class="section-header">
               <div>
-                <a class="project-name" data-pagefind-weight="0" href="#">PROJECT NAME</a>
+                <a class="project-name" href="#">PROJECT NAME</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/function-overloads/n-fn.multiple.0.html
+++ b/subdoc/gen_tests/function-overloads/n-fn.multiple.0.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Function with overloads"></meta>
     <meta property="og:description" content="Function with overloads"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,11 +281,11 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.n.html">n</a>
+              <a class="namespace-name" href="namespace.n.html">n</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">multiple</a>
+              <a class="function-name" href="#">multiple</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/function-overloads/n-fn.multiple.1.html
+++ b/subdoc/gen_tests/function-overloads/n-fn.multiple.1.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Separated overload"></meta>
     <meta property="og:description" content="Separated overload"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,11 +281,11 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.n.html">n</a>
+              <a class="namespace-name" href="namespace.n.html">n</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">multiple</a>
+              <a class="function-name" href="#">multiple</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/function-overloads/namespace.n.html
+++ b/subdoc/gen_tests/function-overloads/namespace.n.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -241,7 +272,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -261,9 +292,9 @@
                 <span>
                   Namespace
                 </span>
-                <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+                <a class="project-name" href="index.html">PROJECT NAME</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="10" href="#">n</a>
+                <a class="namespace-name" href="#">n</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/markdown/N.html
+++ b/subdoc/gen_tests/markdown/N.html
@@ -10,6 +10,7 @@
     <meta name="description" content="The summary has newlines in it."></meta>
     <meta property="og:description" content="The summary has newlines in it."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">N</a>
+              <a class="type-name" href="#">N</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#10">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/markdown/S.html
+++ b/subdoc/gen_tests/markdown/S.html
@@ -10,6 +10,7 @@
     <meta name="description" content="The summary has html tags in it."></meta>
     <meta property="og:description" content="The summary has html tags in it."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">S</a>
+              <a class="type-name" href="#">S</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#5">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/markdown/Syntax.html
+++ b/subdoc/gen_tests/markdown/Syntax.html
@@ -10,6 +10,7 @@
     <meta name="description" content="A code block with syntax highlighting."></meta>
     <meta property="og:description" content="A code block with syntax highlighting."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">Syntax</a>
+              <a class="type-name" href="#">Syntax</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#23">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/markdown/index.html
+++ b/subdoc/gen_tests/markdown/index.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -244,7 +275,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -260,7 +291,7 @@
           <div class="section overview">
             <h1 class="section-header">
               <div>
-                <a class="project-name" data-pagefind-weight="0" href="#">PROJECT NAME</a>
+                <a class="project-name" href="#">PROJECT NAME</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/nested-namespace/index.html
+++ b/subdoc/gen_tests/nested-namespace/index.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -238,7 +269,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -254,7 +285,7 @@
           <div class="section overview">
             <h1 class="section-header">
               <div>
-                <a class="project-name" data-pagefind-weight="0" href="#">PROJECT NAME</a>
+                <a class="project-name" href="#">PROJECT NAME</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/nested-namespace/namespace.outer_namespace.html
+++ b/subdoc/gen_tests/nested-namespace/namespace.outer_namespace.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Outer namespace"></meta>
     <meta property="og:description" content="Outer namespace"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -244,7 +275,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -264,9 +295,9 @@
                 <span>
                   Namespace
                 </span>
-                <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+                <a class="project-name" href="index.html">PROJECT NAME</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="10" href="#">outer_namespace</a>
+                <a class="namespace-name" href="#">outer_namespace</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/nested-namespace/outer_namespace-fn.outer.html
+++ b/subdoc/gen_tests/nested-namespace/outer_namespace-fn.outer.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Outer function"></meta>
     <meta property="og:description" content="Outer function"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,11 +281,11 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.outer_namespace.html">outer_namespace</a>
+              <a class="namespace-name" href="namespace.outer_namespace.html">outer_namespace</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">outer</a>
+              <a class="function-name" href="#">outer</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/nested-namespace/outer_namespace-inner_namespace-fn.inner.html
+++ b/subdoc/gen_tests/nested-namespace/outer_namespace-inner_namespace-fn.inner.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Inner function"></meta>
     <meta property="og:description" content="Inner function"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,13 +281,13 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.outer_namespace.html">outer_namespace</a>
+              <a class="namespace-name" href="namespace.outer_namespace.html">outer_namespace</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="outer_namespace-namespace.inner_namespace.html">inner_namespace</a>
+              <a class="namespace-name" href="outer_namespace-namespace.inner_namespace.html">inner_namespace</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">inner</a>
+              <a class="function-name" href="#">inner</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/nested-namespace/outer_namespace-namespace.empty.html
+++ b/subdoc/gen_tests/nested-namespace/outer_namespace-namespace.empty.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Empty namespace"></meta>
     <meta property="og:description" content="Empty namespace"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -252,11 +283,11 @@
                 <span>
                   Namespace
                 </span>
-                <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+                <a class="project-name" href="index.html">PROJECT NAME</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="1" href="namespace.outer_namespace.html">outer_namespace</a>
+                <a class="namespace-name" href="namespace.outer_namespace.html">outer_namespace</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="10" href="#">empty</a>
+                <a class="namespace-name" href="#">empty</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/nested-namespace/outer_namespace-namespace.inner_namespace.html
+++ b/subdoc/gen_tests/nested-namespace/outer_namespace-namespace.inner_namespace.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Inner namespace"></meta>
     <meta property="og:description" content="Inner namespace"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -238,7 +269,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -258,11 +289,11 @@
                 <span>
                   Namespace
                 </span>
-                <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+                <a class="project-name" href="index.html">PROJECT NAME</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="1" href="namespace.outer_namespace.html">outer_namespace</a>
+                <a class="namespace-name" href="namespace.outer_namespace.html">outer_namespace</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="10" href="#">inner_namespace</a>
+                <a class="namespace-name" href="#">inner_namespace</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/struct-basic/S.html
+++ b/subdoc/gen_tests/struct-basic/S.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Comment headline S"></meta>
     <meta property="og:description" content="Comment headline S"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">S</a>
+              <a class="type-name" href="#">S</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#5">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/struct-basic/index.html
+++ b/subdoc/gen_tests/struct-basic/index.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -238,7 +269,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -254,7 +285,7 @@
           <div class="section overview">
             <h1 class="section-header">
               <div>
-                <a class="project-name" data-pagefind-weight="0" href="#">PROJECT NAME</a>
+                <a class="project-name" href="#">PROJECT NAME</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/struct-complex/Base.html
+++ b/subdoc/gen_tests/struct-complex/Base.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -238,7 +269,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -256,9 +287,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">Base</a>
+              <a class="type-name" href="#">Base</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#20">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/struct-complex/OtherType.html
+++ b/subdoc/gen_tests/struct-complex/OtherType.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">OtherType</a>
+              <a class="type-name" href="#">OtherType</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#16">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/struct-complex/S.html
+++ b/subdoc/gen_tests/struct-complex/S.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Comment headline S"></meta>
     <meta property="og:description" content="Comment headline S"></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -280,7 +311,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -298,9 +329,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">S</a>
+              <a class="type-name" href="#">S</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#26">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/struct-complex/index.html
+++ b/subdoc/gen_tests/struct-complex/index.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -253,7 +284,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -269,7 +300,7 @@
           <div class="section overview">
             <h1 class="section-header">
               <div>
-                <a class="project-name" data-pagefind-weight="0" href="#">PROJECT NAME</a>
+                <a class="project-name" href="#">PROJECT NAME</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/struct-complex/macro.sus_macro_for_test.html
+++ b/subdoc/gen_tests/struct-complex/macro.sus_macro_for_test.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Comment headline on sus_macro_for_test."></meta>
     <meta property="og:description" content="Comment headline on sus_macro_for_test."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Macro
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="macro-name" data-pagefind-weight="20" href="#">sus_macro_for_test</a>
+              <a class="macro-name" href="#">sus_macro_for_test</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/struct-complex/macro.sus_macro_for_test_fn.html
+++ b/subdoc/gen_tests/struct-complex/macro.sus_macro_for_test_fn.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Comment headline on sus_macro_for_test_fn."></meta>
     <meta property="og:description" content="Comment headline on sus_macro_for_test_fn."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Macro
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="macro-name" data-pagefind-weight="20" href="#">sus_macro_for_test_fn</a>
+              <a class="macro-name" href="#">sus_macro_for_test_fn</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/subdoc-test-style.css
+++ b/subdoc/gen_tests/subdoc-test-style.css
@@ -549,7 +549,7 @@ ul.item-table .item-name {
 }
 .search-results .search-results-type {
     font-size: 90%;
-    width: 15ex;
+    width: 18ex;
     flex-grow: 0;
 }
 .search-results .search-results-name {

--- a/subdoc/gen_tests/templates/Concept.html
+++ b/subdoc/gen_tests/templates/Concept.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Concept
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="concept-name" data-pagefind-weight="20" href="#">Concept</a>
+              <a class="concept-name" href="#">Concept</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#7">source</a></div><pre class="template">template &lt;class T, class... U&gt;</pre><span class="concept">
                 concept

--- a/subdoc/gen_tests/templates/S.html
+++ b/subdoc/gen_tests/templates/S.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">S</a>
+              <a class="type-name" href="#">S</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#10">source</a></div><pre class="template">template &lt;class T&gt;</pre><span class="struct">
                 struct

--- a/subdoc/gen_tests/templates/TemplateMethods.html
+++ b/subdoc/gen_tests/templates/TemplateMethods.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -274,7 +305,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -292,9 +323,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">TemplateMethods</a>
+              <a class="type-name" href="#">TemplateMethods</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#13">source</a></div><pre class="template">template &lt;class T&gt;</pre><span class="struct">
                 struct

--- a/subdoc/gen_tests/templates/TemplateStruct.html
+++ b/subdoc/gen_tests/templates/TemplateStruct.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">TemplateStruct</a>
+              <a class="type-name" href="#">TemplateStruct</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#4">source</a></div><pre class="template">template &lt;class Type, auto AutoValue, class TypeWithDefault = int, TypeWithDefault ValueOfDependentType = 90210, class... Pack&gt;</pre><span class="struct">
                 struct

--- a/subdoc/gen_tests/templates/fn.requires_overload.html
+++ b/subdoc/gen_tests/templates/fn.requires_overload.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Has two overloads."></meta>
     <meta property="og:description" content="Has two overloads."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">requires_overload</a>
+              <a class="function-name" href="#">requires_overload</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/templates/fn.return_template.html
+++ b/subdoc/gen_tests/templates/fn.return_template.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Returns template instantiation."></meta>
     <meta property="og:description" content="Returns template instantiation."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">return_template</a>
+              <a class="function-name" href="#">return_template</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/templates/fn.template_function.html
+++ b/subdoc/gen_tests/templates/fn.template_function.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,9 +281,9 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">template_function</a>
+              <a class="function-name" href="#">template_function</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/templates/index.html
+++ b/subdoc/gen_tests/templates/index.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -262,7 +293,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -278,7 +309,7 @@
           <div class="section overview">
             <h1 class="section-header">
               <div>
-                <a class="project-name" data-pagefind-weight="0" href="#">PROJECT NAME</a>
+                <a class="project-name" href="#">PROJECT NAME</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/typenames-across-paths/index.html
+++ b/subdoc/gen_tests/typenames-across-paths/index.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -241,7 +272,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -257,7 +288,7 @@
           <div class="section overview">
             <h1 class="section-header">
               <div>
-                <a class="project-name" data-pagefind-weight="0" href="#">PROJECT NAME</a>
+                <a class="project-name" href="#">PROJECT NAME</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/typenames-across-paths/n-FunctionParams.html
+++ b/subdoc/gen_tests/typenames-across-paths/n-FunctionParams.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -268,7 +299,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -286,11 +317,11 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.n.html">n</a>
+              <a class="namespace-name" href="namespace.n.html">n</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">FunctionParams</a>
+              <a class="type-name" href="#">FunctionParams</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#97">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/typenames-across-paths/n-HoldS.html
+++ b/subdoc/gen_tests/typenames-across-paths/n-HoldS.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -241,7 +272,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -259,11 +290,11 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.n.html">n</a>
+              <a class="namespace-name" href="namespace.n.html">n</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">HoldS</a>
+              <a class="type-name" href="#">HoldS</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#88">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/typenames-across-paths/n-fn.pass_s.html
+++ b/subdoc/gen_tests/typenames-across-paths/n-fn.pass_s.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Should show S as the paramter type, not the full path."></meta>
     <meta property="og:description" content="Should show S as the paramter type, not the full path."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,11 +281,11 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.n.html">n</a>
+              <a class="namespace-name" href="namespace.n.html">n</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">pass_s</a>
+              <a class="function-name" href="#">pass_s</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/typenames-across-paths/n-fn.return_nested.html
+++ b/subdoc/gen_tests/typenames-across-paths/n-fn.return_nested.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Should show Nested as the return type, not the full path."></meta>
     <meta property="og:description" content="Should show Nested as the return type, not the full path."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,11 +281,11 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.n.html">n</a>
+              <a class="namespace-name" href="namespace.n.html">n</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">return_nested</a>
+              <a class="function-name" href="#">return_nested</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/typenames-across-paths/n-fn.return_s.html
+++ b/subdoc/gen_tests/typenames-across-paths/n-fn.return_s.html
@@ -10,6 +10,7 @@
     <meta name="description" content="Should show S as the return type, not the full path."></meta>
     <meta property="og:description" content="Should show S as the return type, not the full path."></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,11 +281,11 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.n.html">n</a>
+              <a class="namespace-name" href="namespace.n.html">n</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">return_s</a>
+              <a class="function-name" href="#">return_s</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/typenames-across-paths/namespace.n.html
+++ b/subdoc/gen_tests/typenames-across-paths/namespace.n.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -298,7 +329,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -318,9 +349,9 @@
                 <span>
                   Namespace
                 </span>
-                <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+                <a class="project-name" href="index.html">PROJECT NAME</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="10" href="#">n</a>
+                <a class="namespace-name" href="#">n</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/typenames-across-paths/namespace.other.html
+++ b/subdoc/gen_tests/typenames-across-paths/namespace.other.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -238,7 +269,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -258,9 +289,9 @@
                 <span>
                   Namespace
                 </span>
-                <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+                <a class="project-name" href="index.html">PROJECT NAME</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="10" href="#">other</a>
+                <a class="namespace-name" href="#">other</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/typenames-across-paths/other-namespace.subother.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-namespace.subother.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -259,7 +290,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -279,11 +310,11 @@
                 <span>
                   Namespace
                 </span>
-                <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+                <a class="project-name" href="index.html">PROJECT NAME</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="1" href="namespace.other.html">other</a>
+                <a class="namespace-name" href="namespace.other.html">other</a>
                 <span class="namespace-dots">::</span>
-                <a class="namespace-name" data-pagefind-weight="10" href="#">subother</a>
+                <a class="namespace-name" href="#">subother</a>
               </div>
             </h1>
             <div class="description long">

--- a/subdoc/gen_tests/typenames-across-paths/other-subother-C.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-subother-C.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,13 +281,13 @@
               <span>
                 Concept
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.other.html">other</a>
+              <a class="namespace-name" href="namespace.other.html">other</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="other-namespace.subother.html">subother</a>
+              <a class="namespace-name" href="other-namespace.subother.html">subother</a>
               <span class="namespace-dots">::</span>
-              <a class="concept-name" data-pagefind-weight="20" href="#">C</a>
+              <a class="concept-name" href="#">C</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#9">source</a></div><pre class="template">template &lt;class T&gt;</pre><span class="concept">
                 concept

--- a/subdoc/gen_tests/typenames-across-paths/other-subother-S-FirstNested-Nested.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-subother-S-FirstNested-Nested.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,17 +281,17 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.other.html">other</a>
+              <a class="namespace-name" href="namespace.other.html">other</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="other-namespace.subother.html">subother</a>
+              <a class="namespace-name" href="other-namespace.subother.html">subother</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="1" href="other-subother-S.html">S</a>
+              <a class="type-name" href="other-subother-S.html">S</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="1" href="other-subother-S-FirstNested.html">FirstNested</a>
+              <a class="type-name" href="other-subother-S-FirstNested.html">FirstNested</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">Nested</a>
+              <a class="type-name" href="#">Nested</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#4">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/typenames-across-paths/other-subother-S-FirstNested.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-subother-S-FirstNested.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,15 +281,15 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.other.html">other</a>
+              <a class="namespace-name" href="namespace.other.html">other</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="other-namespace.subother.html">subother</a>
+              <a class="namespace-name" href="other-namespace.subother.html">subother</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="1" href="other-subother-S.html">S</a>
+              <a class="type-name" href="other-subother-S.html">S</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">FirstNested</a>
+              <a class="type-name" href="#">FirstNested</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#3">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/typenames-across-paths/other-subother-S.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-subother-S.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,13 +281,13 @@
               <span>
                 Struct
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.other.html">other</a>
+              <a class="namespace-name" href="namespace.other.html">other</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="other-namespace.subother.html">subother</a>
+              <a class="namespace-name" href="other-namespace.subother.html">subother</a>
               <span class="namespace-dots">::</span>
-              <a class="type-name" data-pagefind-weight="20" href="#">S</a>
+              <a class="type-name" href="#">S</a>
             </h1>
             <div class="type-signature"><div class="src rightside"><a href="test.cc#2">source</a></div><span class="struct">
                 struct

--- a/subdoc/gen_tests/typenames-across-paths/other-subother-fn.subother_func.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-subother-fn.subother_func.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,13 +281,13 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.other.html">other</a>
+              <a class="namespace-name" href="namespace.other.html">other</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="other-namespace.subother.html">subother</a>
+              <a class="namespace-name" href="other-namespace.subother.html">subother</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">subother_func</a>
+              <a class="function-name" href="#">subother_func</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/gen_tests/typenames-across-paths/other-subother-fn.subother_func_with_overload.hasanoverload.html
+++ b/subdoc/gen_tests/typenames-across-paths/other-subother-fn.subother_func_with_overload.hasanoverload.html
@@ -10,6 +10,7 @@
     <meta name="description" content=""></meta>
     <meta property="og:description" content=""></meta>
     <script src="https://unpkg.com/lunr/lunr.js"></script>
+    <script src="./search_db.js"></script>
     <script>
       
         // Delayed loading of whatever was in the search box.
@@ -31,7 +32,7 @@
           searchDelayLoad = null;
 
           let without_search =
-              window.location.href.replace(window.location.search, '');
+              window.location.origin + window.location.pathname;
           if (query) {
             window.history.replaceState(null, "",
               without_search + "?" + `search=${query}`);
@@ -53,8 +54,15 @@
               e.preventDefault();
             }
           };
+          var searchPlaceholder;
           document.querySelector(".search-input").onfocus = (e) => {
+            searchPlaceholder = e.target.placeholder;
+            e.target.placeholder = "Type your search here.";
             navigateToSearch(e.target.value);
+          };
+          document.querySelector(".search-input").onblur = (e) => {
+            e.target.placeholder = searchPlaceholder;
+            searchPlaceholder = null;
           };
         });
 
@@ -80,24 +88,32 @@
           const search_db = loaded.search_db;
           const idx = loaded.idx;
 
-          const results = idx.search(searchQuery());
+          // lunrjs treats `:` specially and `::` breaks the query syntax, so
+          // just split into two words.
+          const query = searchQuery().split("::").join(" ");
           let content = '';
-          for (r of results) {
-            const item = search_db[r.ref];
-            
-            const type = item.type;
-            const url = item.url;
-            const name = item.name;
-            const full_name = item.full_name;
-            const summmary = item.summary ? item.summary : "";
-            
-            content += `\
-              <a class="search-results-link" href="${url}">
-                <span class="search-results-type">${type}</span>\
-                <span class="search-results-name">${full_name}</span>\
-                <span class="search-results-summary">${summmary}</span>\
-              </a>\
-              `
+          try {
+            const results = idx.search(query);
+            for (r of results) {
+              const item = search_db[r.ref];
+
+              const type = item.type;
+              const url = item.url;
+              const name = item.name;
+              const full_name = item.full_name;
+              const summmary = item.summary ? item.summary : "";
+
+              content += `\
+                <a class="search-results-link" href="${url}">
+                  <span class="search-results-type">${type}</span>\
+                  <span class="search-results-name">${full_name}</span>\
+                  <span class="search-results-summary">${summmary}</span>\
+                </a>\
+                `
+            }
+          } catch (err) {
+            content +=
+                `<div class="search-error">Search error: ${err.message}</div>`;
           }
 
           let content_elem = document.querySelector(".search-results-content");
@@ -117,12 +133,14 @@
         // - idx: the lunr search index.
         //   Documented at https://lunrjs.com/docs/lunr.Index.html.
         async function loadSearchIndex() {
-          async function load_search_db() {
-            let x = await import('./search.json', {
-              assert: {type: 'json'}
-            });
-            return x.default;
-          }
+          // This is not widely supported yet (not on Safari), so instead we
+          // turned the json file into a js file that sets a global variable. :|
+          //async function load_search_db() {
+          //  let x = await import('./search.json', {
+          //    with: {type: 'json'}
+          //  });
+          //  return x.default;
+          //}
 
           async function load_idx(search_db) {
             let idx = lunr(function () {
@@ -146,6 +164,16 @@
               // No stemming?
               // this.pipeline = new lunr.Pipeline();
 
+              this.use(builder => {
+                function splitColons(token) {
+                  return token.toString().split("::").map(str => {
+                    return token.clone().update(() => { return str })
+                  })
+                }
+                lunr.Pipeline.registerFunction(splitColons, 'splitColons')
+                builder.searchPipeline.before(lunr.stemmer, splitColons)
+              });
+
               search_db.forEach(item => {
                 this.add(item, {
                   'boost': item.weight
@@ -159,7 +187,7 @@
           };
 
           if (!cache_idx) {
-            cache_idx = await load_search_db().then(load_idx);
+            cache_idx = await load_idx(g_search_db);
           }
           return cache_idx;
         }
@@ -178,6 +206,9 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "Loading search results...";
 
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
+
             loadSearchIndex().then(populateSearchResults)
           } else {
             showHide(".main-content", true);
@@ -185,8 +216,8 @@
             let header_elem = document.querySelector(".search-results-header");
             header_elem.innerText = "";
 
-            let content_elem = document.querySelector(".search-results-content");
-            content_elem.innerText = "";
+            let content_ele = document.querySelector(".search-results-content");
+            content_ele.innerText = "";
           }
         }
 
@@ -232,7 +263,7 @@
     <main>
       <nav class="search-nav">
         <form class="search-form">
-          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search..." onblur="this.placeholder = 'Click or press \'S\' to search...'" onfocus="this.placeholder = 'Type your search here.'">
+          <input class="search-input" name="search" autocomplete="off" spellcheck="false" placeholder="Click or press 'S' to search...">
           </input>
         </form>
       </nav>
@@ -250,13 +281,13 @@
               <span>
                 Function
               </span>
-              <a class="project-name" data-pagefind-weight="1" href="index.html">PROJECT NAME</a>
+              <a class="project-name" href="index.html">PROJECT NAME</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="namespace.other.html">other</a>
+              <a class="namespace-name" href="namespace.other.html">other</a>
               <span class="namespace-dots">::</span>
-              <a class="namespace-name" data-pagefind-weight="1" href="other-namespace.subother.html">subother</a>
+              <a class="namespace-name" href="other-namespace.subother.html">subother</a>
               <span class="namespace-dots">::</span>
-              <a class="function-name" data-pagefind-weight="20" href="#">subother_func_with_overload</a>
+              <a class="function-name" href="#">subother_func_with_overload</a>
             </h1>
             <div class="overload-set">
               <div class="overload">

--- a/subdoc/lib/gen/generate.cc
+++ b/subdoc/lib/gen/generate.cc
@@ -77,9 +77,10 @@ sus::result::Result<void, sus::Box<sus::error::DynError>> generate(
 
   {
     std::filesystem::path search_json_path = options.output_root;
-    search_json_path.append("search.json");
+    search_json_path.append("search_db.js");
     auto json_writer =
-        JsonWriter(open_file_for_writing(search_json_path).unwrap());
+        JsonWriter(sus::some("g_search_db"),
+                   open_file_for_writing(search_json_path).unwrap());
     auto search_documents = json_writer.open_array();
 
     if (auto result = generate_namespace(db, db.global, sus::empty,

--- a/subdoc/lib/gen/generate_concept.cc
+++ b/subdoc/lib/gen/generate_concept.cc
@@ -65,7 +65,6 @@ void generate_concept_overview(HtmlWriter::OpenDiv& record_div,
           span.write_text("::");
         }
         auto ancestor_anchor = header.open_a();
-        ancestor_anchor.add_search_weight(e.search_weight);
         ancestor_anchor.add_class([&e]() {
           switch (e.type) {
             case CppPathProject: return "project-name";

--- a/subdoc/lib/gen/generate_cpp_path.cc
+++ b/subdoc/lib/gen/generate_cpp_path.cc
@@ -140,6 +140,15 @@ Vec<CppPathElement> generate_cpp_path_for_function(
                                  sus::Slice<const RecordElement*>(), options);
 }
 
+Vec<CppPathElement> generate_cpp_path_for_alias(
+    const AliasElement& element,
+    sus::Slice<const NamespaceElement*> namespace_ancestors,
+    const Options& options) noexcept {
+  return generate_with_ancestors(element.name, CppPathFunction,
+                                 namespace_ancestors,
+                                 sus::Slice<const RecordElement*>(), options);
+}
+
 Vec<CppPathElement> generate_cpp_path_for_macro(
     const MacroElement& element,
     sus::Slice<const NamespaceElement*> namespace_ancestors,

--- a/subdoc/lib/gen/generate_cpp_path.h
+++ b/subdoc/lib/gen/generate_cpp_path.h
@@ -59,6 +59,11 @@ Vec<CppPathElement> generate_cpp_path_for_function(
     sus::Slice<const NamespaceElement*> namespace_ancestors,
     const Options& options) noexcept;
 
+Vec<CppPathElement> generate_cpp_path_for_alias(
+    const AliasElement& element,
+    sus::Slice<const NamespaceElement*> namespace_ancestors,
+    const Options& options) noexcept;
+
 Vec<CppPathElement> generate_cpp_path_for_macro(
     const MacroElement& element,
     sus::Slice<const NamespaceElement*> namespace_ancestors,

--- a/subdoc/lib/gen/generate_function.cc
+++ b/subdoc/lib/gen/generate_function.cc
@@ -299,7 +299,6 @@ sus::Result<void, MarkdownToHtmlError> generate_function(
           span.write_text("::");
         }
         auto ancestor_anchor = header.open_a();
-        ancestor_anchor.add_search_weight(e.search_weight);
         ancestor_anchor.add_class([&e]() {
           switch (e.type) {
             case CppPathProject: return "project-name";

--- a/subdoc/lib/gen/generate_macro.cc
+++ b/subdoc/lib/gen/generate_macro.cc
@@ -129,7 +129,6 @@ sus::Result<void, MarkdownToHtmlError> generate_macro(
           span.write_text("::");
         }
         auto ancestor_anchor = header.open_a();
-        ancestor_anchor.add_search_weight(e.search_weight);
         ancestor_anchor.add_class([&e]() {
           switch (e.type) {
             case CppPathProject: return "project-name";

--- a/subdoc/lib/gen/generate_record.cc
+++ b/subdoc/lib/gen/generate_record.cc
@@ -123,7 +123,6 @@ void generate_record_overview(HtmlWriter::OpenDiv& record_div,
           span.write_text("::");
         }
         auto ancestor_anchor = header.open_a();
-        ancestor_anchor.add_search_weight(e.search_weight);
         ancestor_anchor.add_class([&e]() {
           switch (e.type) {
             case CppPathProject: return "project-name";
@@ -334,6 +333,139 @@ sus::Result<void, MarkdownToHtmlError> generate_record(
     }
     json.add_string("full_name", full_name);
     json.add_string("split_name", split_for_search(full_name));
+  }
+  {
+    std::string type_cpp_path;
+    for (CppPathElement e : generate_cpp_path_for_type(element, namespaces,
+                                                       type_ancestors, options)
+                                .into_iter()) {
+      if (e.type != CppPathProject) {
+        if (type_cpp_path.size() > 0u) type_cpp_path += std::string_view("::");
+        type_cpp_path += e.name;
+      }
+    }
+    for (const auto& [id, sub_element] : element.fields) {
+      if (sub_element.hidden()) continue;
+
+      i32 index = search_documents.len();
+      auto json = search_documents.open_object();
+      json.add_int("index", index);
+      json.add_string("type", "field");
+      json.add_string("url", construct_html_url_for_field(sub_element));
+      json.add_string("weight", "0.9");
+      json.add_string("name", sub_element.name);
+      std::string full_name =
+          type_cpp_path + std::string("::") + sub_element.name;
+      json.add_string("full_name", full_name);
+      json.add_string("split_name", split_for_search(full_name));
+    }
+    for (const auto& [id, sub_element] : element.deductions) {
+      if (sub_element.hidden()) continue;
+
+      i32 index = search_documents.len();
+      auto json = search_documents.open_object();
+      json.add_int("index", index);
+      json.add_string("type", "deduction guide");
+      json.add_string("url", construct_html_url_for_function(sub_element));
+      json.add_string("name", sub_element.name);
+      std::string full_name =
+          type_cpp_path + std::string("::") + sub_element.name;
+      json.add_string("full_name", full_name);
+      json.add_string("split_name", split_for_search(full_name));
+    }
+    for (const auto& [id, sub_element] : element.ctors) {
+      if (sub_element.hidden()) continue;
+
+      i32 index = search_documents.len();
+      auto json = search_documents.open_object();
+      json.add_int("index", index);
+      json.add_string("type", "constructor");
+      json.add_string("url", construct_html_url_for_function(sub_element));
+      json.add_string("name", sub_element.name);
+      std::string full_name =
+          type_cpp_path + std::string("::") + sub_element.name;
+      json.add_string("full_name", full_name);
+      json.add_string("split_name", split_for_search(full_name));
+    }
+    for (const auto& [id, sub_element] : element.dtors) {
+      if (sub_element.hidden()) continue;
+
+      i32 index = search_documents.len();
+      auto json = search_documents.open_object();
+      json.add_int("index", index);
+      json.add_string("type", "destructor");
+      json.add_string("url", construct_html_url_for_function(sub_element));
+      json.add_string("name", sub_element.name);
+      std::string full_name =
+          type_cpp_path + std::string("::") + sub_element.name;
+      json.add_string("full_name", full_name);
+      json.add_string("split_name", split_for_search(full_name));
+    }
+    for (const auto& [id, sub_element] : element.conversions) {
+      if (sub_element.hidden()) continue;
+
+      i32 index = search_documents.len();
+      auto json = search_documents.open_object();
+      json.add_int("index", index);
+      json.add_string("type", "conversion");
+      json.add_string("url", construct_html_url_for_function(sub_element));
+      json.add_string("name", sub_element.name);
+      std::string full_name =
+          type_cpp_path + std::string("::") + sub_element.name;
+      json.add_string("full_name", full_name);
+      json.add_string("split_name", split_for_search(full_name));
+    }
+    for (const auto& [id, sub_element] : element.methods) {
+      if (sub_element.hidden()) continue;
+
+      i32 index = search_documents.len();
+      auto json = search_documents.open_object();
+      json.add_int("index", index);
+      json.add_string("type", "method");
+      json.add_string("url", construct_html_url_for_function(sub_element));
+      json.add_string("name", sub_element.name);
+      std::string full_name =
+          type_cpp_path + std::string("::") + sub_element.name;
+      json.add_string("full_name", full_name);
+      json.add_string("split_name", split_for_search(full_name));
+    }
+    for (const auto& [id, sub_element] : element.aliases) {
+      if (sub_element.hidden()) continue;
+
+      if (Option<std::string> url = construct_html_url_for_alias(sub_element);
+          url.is_some()) {
+        i32 index = search_documents.len();
+        auto json = search_documents.open_object();
+        json.add_int("index", index);
+        switch (sub_element.target) {
+          case AliasTarget::Tag::AliasOfType:
+            json.add_string("type", "type alias");
+            break;
+          case AliasTarget::Tag::AliasOfConcept:
+            json.add_string("type", "concept alias");
+            break;
+          case AliasTarget::Tag::AliasOfFunction:
+            json.add_string("type", "function alias");
+            break;
+          case AliasTarget::Tag::AliasOfMethod:
+            json.add_string("type", "method alias");
+            break;
+          case AliasTarget::Tag::AliasOfEnumConstant:
+            json.add_string("type", "enum value alias");
+            break;
+          case AliasTarget::Tag::AliasOfVariable:
+            json.add_string("type", "variable alias");
+            break;
+        }
+        json.add_string("url", url.as_value());
+        json.add_string("weight", "0.8");
+        json.add_string("name", sub_element.name);
+        std::string full_name =
+            type_cpp_path + std::string("::") + sub_element.name;
+        json.add_string("full_name", full_name);
+        json.add_string("split_name", split_for_search(full_name));
+      }
+    }
   }
 
   ParseMarkdownPageState page_state(db, options);

--- a/subdoc/lib/gen/html_writer.h
+++ b/subdoc/lib/gen/html_writer.h
@@ -44,12 +44,6 @@ class HtmlWriter {
           .value = std::string(id),
       });
     }
-    void add_search_weight(f32 weight) noexcept {
-      attributes_.push(HtmlAttribute{
-          .name = std::string("data-pagefind-weight"),
-          .value = fmt::to_string(weight),
-      });
-    }
 
     void write_text(std::string_view text) noexcept {
       write_open();

--- a/subdoc/lib/gen/json_writer.h
+++ b/subdoc/lib/gen/json_writer.h
@@ -131,8 +131,13 @@ class JsonWriter {
     JsonWriter* writer_;
   };
 
-  explicit JsonWriter(std::ofstream stream) noexcept
-      : stream_(sus::move(stream)) {}
+  explicit JsonWriter(Option<std::string> varname,
+                      std::ofstream stream) noexcept
+      : stream_(sus::move(stream)) {
+    if (varname.is_some()) {
+      stream_ << "const " << varname.as_value() << " = ";
+    }
+  }
   ~JsonWriter() noexcept = default;
 
   JsonArray open_array() noexcept {


### PR DESCRIPTION
`::` needs to be escaped to a space, since `:` is handled specially by lunrjs.

Errors during search get displayed on the page.

Avoid import for json files as Safari doens't support it. Instead write a JS file which sets a variable, and load it through a script tag.

Generate search index items for things without pages of their own:
- fields
- methods
- aliases