### PR TITLE
makes most operators hidden friends

### DIFF
--- a/sus/boxed/box.h
+++ b/sus/boxed/box.h
@@ -656,6 +656,9 @@ class [[_sus_trivial_abi]] Box final : public __private::BoxBase<Box<T>, T> {
     return {};
   }
 
+  // Stream support.
+  _sus_format_to_stream(Box)
+
  private:
   enum FromPointer { FROM_POINTER };
   constexpr explicit Box(FromPointer, T* t) noexcept : t_(t) {}
@@ -707,9 +710,6 @@ struct fmt::formatter<::sus::boxed::Box<T>, Char> {
  private:
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::boxed, Box, T);
 
 // Promote `Box` into the `sus` namespace.
 namespace sus {

--- a/sus/boxed/box.h
+++ b/sus/boxed/box.h
@@ -657,7 +657,7 @@ class [[_sus_trivial_abi]] Box final : public __private::BoxBase<Box<T>, T> {
   }
 
   // Stream support.
-  _sus_format_to_stream(Box)
+  _sus_format_to_stream(Box);
 
  private:
   enum FromPointer { FROM_POINTER };

--- a/sus/choice/choice.h
+++ b/sus/choice/choice.h
@@ -911,7 +911,8 @@ class Choice<__private::TypeList<Ts...>, Tags...> final {
       delete;
 
   // Stream support
-  _sus_format_to_stream(Choice)
+  _sus_format_to_stream(Choice);
+
  private:
   constexpr explicit Choice(IndexType i) noexcept : index_(i) {}
 

--- a/sus/choice/choice.h
+++ b/sus/choice/choice.h
@@ -910,6 +910,8 @@ class Choice<__private::TypeList<Ts...>, Tags...> final {
       const Choice<__private::TypeList<RhsTs...>, RhsTag, RhsTags...>& r) =
       delete;
 
+  // Stream support
+  _sus_format_to_stream(Choice)
  private:
   constexpr explicit Choice(IndexType i) noexcept : index_(i) {}
 
@@ -1000,18 +1002,6 @@ struct fmt::formatter<
     }
   }
 };
-
-// Stream support (written out manually due to use of template specialization).
-namespace sus::choice_type {
-template <class... Ts, auto... Tags,
-          ::sus::string::__private::StreamCanReceiveString<char> StreamType>
-inline StreamType& operator<<(
-    StreamType& stream,
-    const Choice<__private::TypeList<Ts...>, Tags...>& value) {
-  return ::sus::string::__private::format_to_stream(stream,
-                                                    fmt::to_string(value));
-}
-}  // namespace sus::choice_type
 
 // Promote Choice into the `sus` namespace.
 namespace sus {

--- a/sus/choice/choice.h
+++ b/sus/choice/choice.h
@@ -910,7 +910,7 @@ class Choice<__private::TypeList<Ts...>, Tags...> final {
       const Choice<__private::TypeList<RhsTs...>, RhsTag, RhsTags...>& r) =
       delete;
 
-  // Stream support
+  // Stream support.
   _sus_format_to_stream(Choice);
 
  private:

--- a/sus/collections/array.h
+++ b/sus/collections/array.h
@@ -61,9 +61,6 @@ struct Storage final {
 template <class T>
 struct Storage<T, 0> final {};
 
-}  // namespace __private
-
-namespace __private {
 template <size_t I>
 constexpr bool array_cmp_impl(sus::cmp::Ordering auto& val, const auto& l,
                               const auto& r) noexcept {
@@ -437,7 +434,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.array]
   template <class U>
     requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
-  constexpr friend std::strong_ordering operator<=>(
+  friend constexpr std::strong_ordering operator<=>(
       const Array& l, const Array<U, N>& r) noexcept {
     return __private::array_cmp(std::strong_ordering::equivalent, l, r,
                                 std::make_index_sequence<N>());
@@ -445,7 +442,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.array]
   template <class U>
     requires(::sus::cmp::ExclusiveOrd<T, U>)
-  constexpr friend std::weak_ordering operator<=>(
+  friend constexpr std::weak_ordering operator<=>(
       const Array& l, const Array<U, N>& r) noexcept {
     return __private::array_cmp(std::weak_ordering::equivalent, l, r,
                                 std::make_index_sequence<N>());
@@ -453,7 +450,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.array]
   template <class U>
     requires(::sus::cmp::ExclusivePartialOrd<T, U>)
-  constexpr friend std::partial_ordering operator<=>(
+  friend constexpr std::partial_ordering operator<=>(
       const Array& l, const Array<U, N>& r) noexcept {
     return __private::array_cmp(std::partial_ordering::equivalent, l, r,
                                 std::make_index_sequence<N>());
@@ -471,7 +468,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.slice]
   template <class U>
     requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
-  constexpr friend std::strong_ordering operator<=>(
+  friend constexpr std::strong_ordering operator<=>(
       const Array& l, const Slice<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::strong_ordering::equivalent, l, r,
@@ -480,7 +477,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.slice]
   template <class U>
     requires(::sus::cmp::ExclusiveOrd<T, U>)
-  constexpr friend std::weak_ordering operator<=>(const Array& l,
+  friend constexpr std::weak_ordering operator<=>(const Array& l,
                                                   const Slice<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::weak_ordering::equivalent, l, r,
@@ -489,7 +486,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.slice]
   template <class U>
     requires(::sus::cmp::ExclusivePartialOrd<T, U>)
-  constexpr friend std::partial_ordering operator<=>(
+  friend constexpr std::partial_ordering operator<=>(
       const Array& l, const Slice<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::partial_ordering::equivalent, l, r,
@@ -508,7 +505,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.slicemut]
   template <class U>
     requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
-  constexpr friend std::strong_ordering operator<=>(
+  friend constexpr std::strong_ordering operator<=>(
       const Array& l, const SliceMut<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::strong_ordering::equivalent, l, r,
@@ -517,7 +514,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.slicemut]
   template <class U>
     requires(::sus::cmp::ExclusiveOrd<T, U>)
-  constexpr friend std::weak_ordering operator<=>(
+  friend constexpr std::weak_ordering operator<=>(
       const Array& l, const SliceMut<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::weak_ordering::equivalent, l, r,
@@ -526,7 +523,7 @@ class Array final {
   /// #[doc.overloads=array.cmp.slicemut]
   template <class U>
     requires(::sus::cmp::ExclusivePartialOrd<T, U>)
-  constexpr friend std::partial_ordering operator<=>(
+  friend constexpr std::partial_ordering operator<=>(
       const Array& l, const SliceMut<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::partial_ordering::equivalent, l, r,

--- a/sus/collections/array.h
+++ b/sus/collections/array.h
@@ -533,7 +533,7 @@ class Array final {
                                 std::make_index_sequence<N>());
   }
 
-  // Stream support
+  // Stream support.
   _sus_format_to_stream(Array);
 
  private:

--- a/sus/collections/array.h
+++ b/sus/collections/array.h
@@ -63,6 +63,28 @@ struct Storage<T, 0> final {};
 
 }  // namespace __private
 
+namespace __private {
+template <size_t I>
+constexpr bool array_cmp_impl(sus::cmp::Ordering auto& val,
+                                     const auto& l, const auto& r) noexcept {
+  auto cmp = l.get_unchecked(::sus::marker::unsafe_fn, I) <=>
+             r.get_unchecked(::sus::marker::unsafe_fn, I);
+  // Allow downgrading from equal to equivalent, but not the inverse.
+  if (cmp != 0) val = cmp;
+  // Short circuit by returning true when we find a difference.
+  return val == 0;
+}
+
+template <size_t... Is>
+constexpr auto array_cmp(sus::cmp::Ordering auto equal, const auto& l,
+                                const auto& r,
+                                std::index_sequence<Is...>) noexcept {
+  auto val = equal;
+  (true && ... && (array_cmp_impl<Is>(val, l, r)));
+  return val;
+}
+}
+
 /// A collection of objects of type `T`, with a fixed size `N`.
 ///
 /// An Array can not be larger than [`isize::MAX`]($sus::num::isize::MAX), as
@@ -335,10 +357,10 @@ class Array final {
   /// Satisfies the [`Eq<Array<T, N>, Array<U, N>>`]($sus::cmp::Eq) concept.
   template <class U>
     requires(::sus::cmp::Eq<T, U>)
-  constexpr bool operator==(const Array<U, N>& r) const& noexcept
+  friend constexpr bool operator==(const Array& l, const Array<U, N>& r) noexcept
     requires(::sus::cmp::Eq<T>)
   {
-    return eq_impl(r, std::make_index_sequence<N>());
+    return l.eq_impl(r, std::make_index_sequence<N>());
   }
 
   /// Satisfies the [`Eq<Array<T, N>, Slice<U>>`]($sus::cmp::Eq) concept.
@@ -405,6 +427,114 @@ class Array final {
         sus::iter::IterRefCounter::empty_for_view(), storage_.data_, N);
   }
 
+  /// Compares two Arrays.
+  ///
+  /// Satisfies sus::cmp::StrongOrd<Array<T, N>> if sus::cmp::StrongOrd<T>.
+  ///
+  /// Satisfies sus::cmp::Ord<Array<T, N>> if sus::cmp::Ord<T>.
+  ///
+  /// Satisfies sus::cmp::PartialOrd<Array<T, N>> if sus::cmp::PartialOrd<T>.
+  /// #[doc.overloads=array.cmp.array]
+  template <class U>
+    requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
+  constexpr friend std::strong_ordering operator<=>(
+      const Array& l, const Array<U, N>& r) noexcept {
+    return __private::array_cmp(std::strong_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+  /// #[doc.overloads=array.cmp.array]
+  template <class U>
+    requires(::sus::cmp::ExclusiveOrd<T, U>)
+  constexpr friend std::weak_ordering operator<=>(const Array& l,
+                                                  const Array<U, N>& r) noexcept {
+    return __private::array_cmp(std::weak_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+  /// #[doc.overloads=array.cmp.array]
+  template <class U>
+    requires(::sus::cmp::ExclusivePartialOrd<T, U>)
+  constexpr friend std::partial_ordering operator<=>(
+      const Array& l, const Array<U, N>& r) noexcept {
+    return __private::array_cmp(std::partial_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+
+  /// Compares an Array and a Slice.
+  ///
+  /// Satisfies sus::cmp::StrongOrd<Array<T, N>, Slice<T>> if
+  /// sus::cmp::StrongOrd<T>.
+  ///
+  /// Satisfies sus::cmp::Ord<Array<T, N>, Slice<T>> if sus::cmp::Ord<T>.
+  ///
+  /// Satisfies sus::cmp::PartialOrd<Array<T, N>, Slice<T>> if
+  /// sus::cmp::PartialOrd<T>.
+  /// #[doc.overloads=array.cmp.slice]
+  template <class U>
+    requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
+  constexpr friend std::strong_ordering operator<=>(const Array& l,
+                                                    const Slice<U>& r) noexcept {
+    if (r.len() != N) return r.len() <=> N;
+    return __private::array_cmp(std::strong_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+  /// #[doc.overloads=array.cmp.slice]
+  template <class U>
+    requires(::sus::cmp::ExclusiveOrd<T, U>)
+  constexpr friend std::weak_ordering operator<=>(const Array& l,
+                                                  const Slice<U>& r) noexcept {
+    if (r.len() != N) return r.len() <=> N;
+    return __private::array_cmp(std::weak_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+  /// #[doc.overloads=array.cmp.slice]
+  template <class U>
+    requires(::sus::cmp::ExclusivePartialOrd<T, U>)
+  constexpr friend std::partial_ordering operator<=>(const Array& l,
+                                                    const Slice<U>& r) noexcept {
+    if (r.len() != N) return r.len() <=> N;
+    return __private::array_cmp(std::partial_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+
+  /// Compares an Array and a SliceMut.
+  ///
+  /// Satisfies sus::cmp::StrongOrd<Array<T, N>, SliceMut<T>> if
+  /// sus::cmp::StrongOrd<T>.
+  ///
+  /// Satisfies sus::cmp::Ord<Array<T, N>, SliceMut<T>> if sus::cmp::Ord<T>.
+  ///
+  /// Satisfies sus::cmp::PartialOrd<Array<T, N>, SliceMut<T>> if
+  /// sus::cmp::PartialOrd<T>.
+  /// #[doc.overloads=array.cmp.slicemut]
+  template <class U>
+    requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
+  constexpr friend std::strong_ordering operator<=>(
+      const Array& l, const SliceMut<U>& r) noexcept {
+    if (r.len() != N) return r.len() <=> N;
+    return __private::array_cmp(std::strong_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+  /// #[doc.overloads=array.cmp.slicemut]
+  template <class U>
+    requires(::sus::cmp::ExclusiveOrd<T, U>)
+  constexpr friend std::weak_ordering operator<=>(const Array& l,
+                                                  const SliceMut<U>& r) noexcept {
+    if (r.len() != N) return r.len() <=> N;
+    return __private::array_cmp(std::weak_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+  /// #[doc.overloads=array.cmp.slicemut]
+  template <class U>
+    requires(::sus::cmp::ExclusivePartialOrd<T, U>)
+  constexpr friend std::partial_ordering operator<=>(
+      const Array& l, const SliceMut<U>& r) noexcept {
+    if (r.len() != N) return r.len() <=> N;
+    return __private::array_cmp(std::partial_ordering::equivalent, l, r,
+                                std::make_index_sequence<N>());
+  }
+
+  // Stream support
+  _sus_format_to_stream(Array)
  private:
   enum WithDefault { WITH_DEFAULT };
   template <size_t... Is>
@@ -466,136 +596,6 @@ template <class T, class... Ts>
   requires((... &&
             std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<Ts>>))
 Array(T&&, Ts&&...) -> Array<std::remove_cvref_t<T>, 1u + sizeof...(Ts)>;
-
-namespace __private {
-
-template <size_t I>
-constexpr inline bool array_cmp_impl(sus::cmp::Ordering auto& val,
-                                     const auto& l, const auto& r) noexcept {
-  auto cmp = l.get_unchecked(::sus::marker::unsafe_fn, I) <=>
-             r.get_unchecked(::sus::marker::unsafe_fn, I);
-  // Allow downgrading from equal to equivalent, but not the inverse.
-  if (cmp != 0) val = cmp;
-  // Short circuit by returning true when we find a difference.
-  return val == 0;
-};
-
-template <size_t... Is>
-constexpr inline auto array_cmp(sus::cmp::Ordering auto equal, const auto& l,
-                                const auto& r,
-                                std::index_sequence<Is...>) noexcept {
-  auto val = equal;
-  (true && ... && (array_cmp_impl<Is>(val, l, r)));
-  return val;
-};
-
-}  // namespace __private
-
-/// Compares two Arrays.
-///
-/// Satisfies sus::cmp::StrongOrd<Array<T, N>> if sus::cmp::StrongOrd<T>.
-///
-/// Satisfies sus::cmp::Ord<Array<T, N>> if sus::cmp::Ord<T>.
-///
-/// Satisfies sus::cmp::PartialOrd<Array<T, N>> if sus::cmp::PartialOrd<T>.
-/// #[doc.overloads=array.cmp.array]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
-constexpr inline std::strong_ordering operator<=>(
-    const Array<T, N>& l, const Array<U, N>& r) noexcept {
-  return __private::array_cmp(std::strong_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-/// #[doc.overloads=array.cmp.array]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusiveOrd<T, U>)
-constexpr inline std::weak_ordering operator<=>(const Array<T, N>& l,
-                                                const Array<U, N>& r) noexcept {
-  return __private::array_cmp(std::weak_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-/// #[doc.overloads=array.cmp.array]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusivePartialOrd<T, U>)
-constexpr inline std::partial_ordering operator<=>(
-    const Array<T, N>& l, const Array<U, N>& r) noexcept {
-  return __private::array_cmp(std::partial_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-
-/// Compares an Array and a Slice.
-///
-/// Satisfies sus::cmp::StrongOrd<Array<T, N>, Slice<T>> if
-/// sus::cmp::StrongOrd<T>.
-///
-/// Satisfies sus::cmp::Ord<Array<T, N>, Slice<T>> if sus::cmp::Ord<T>.
-///
-/// Satisfies sus::cmp::PartialOrd<Array<T, N>, Slice<T>> if
-/// sus::cmp::PartialOrd<T>.
-/// #[doc.overloads=array.cmp.slice]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
-constexpr inline std::strong_ordering operator<=>(const Array<T, N>& l,
-                                                  const Slice<U>& r) noexcept {
-  if (r.len() != N) return r.len() <=> N;
-  return __private::array_cmp(std::strong_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-/// #[doc.overloads=array.cmp.slice]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusiveOrd<T, U>)
-constexpr inline std::weak_ordering operator<=>(const Array<T, N>& l,
-                                                const Slice<U>& r) noexcept {
-  if (r.len() != N) return r.len() <=> N;
-  return __private::array_cmp(std::weak_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-/// #[doc.overloads=array.cmp.slice]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusivePartialOrd<T, U>)
-constexpr inline std::partial_ordering operator<=>(const Array<T, N>& l,
-                                                   const Slice<U>& r) noexcept {
-  if (r.len() != N) return r.len() <=> N;
-  return __private::array_cmp(std::partial_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-
-/// Compares an Array and a SliceMut.
-///
-/// Satisfies sus::cmp::StrongOrd<Array<T, N>, SliceMut<T>> if
-/// sus::cmp::StrongOrd<T>.
-///
-/// Satisfies sus::cmp::Ord<Array<T, N>, SliceMut<T>> if sus::cmp::Ord<T>.
-///
-/// Satisfies sus::cmp::PartialOrd<Array<T, N>, SliceMut<T>> if
-/// sus::cmp::PartialOrd<T>.
-/// #[doc.overloads=array.cmp.slicemut]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
-constexpr inline std::strong_ordering operator<=>(
-    const Array<T, N>& l, const SliceMut<U>& r) noexcept {
-  if (r.len() != N) return r.len() <=> N;
-  return __private::array_cmp(std::strong_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-/// #[doc.overloads=array.cmp.slicemut]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusiveOrd<T, U>)
-constexpr inline std::weak_ordering operator<=>(const Array<T, N>& l,
-                                                const SliceMut<U>& r) noexcept {
-  if (r.len() != N) return r.len() <=> N;
-  return __private::array_cmp(std::weak_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
-/// #[doc.overloads=array.cmp.slicemut]
-template <class T, class U, size_t N>
-  requires(::sus::cmp::ExclusivePartialOrd<T, U>)
-constexpr inline std::partial_ordering operator<=>(
-    const Array<T, N>& l, const SliceMut<U>& r) noexcept {
-  if (r.len() != N) return r.len() <=> N;
-  return __private::array_cmp(std::partial_ordering::equivalent, l, r,
-                              std::make_index_sequence<N>());
-}
 
 /// Support for using structured bindings with `Array`.
 /// #[doc.overloads=array.structured.bindings]
@@ -663,17 +663,6 @@ struct fmt::formatter<::sus::collections::Array<T, N>, Char> {
  private:
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
-
-// Stream support (written out manually due to size_t template param).
-namespace sus::collections {
-template <class T, size_t N,
-          ::sus::string::__private::StreamCanReceiveString<char> StreamType>
-inline StreamType& operator<<(StreamType& stream, const Array<T, N>& value) {
-  return ::sus::string::__private::format_to_stream(stream,
-                                                    fmt::to_string(value));
-}
-
-}  // namespace sus::collections
 
 namespace sus::collections {
 // Documented in vec.h

--- a/sus/collections/array.h
+++ b/sus/collections/array.h
@@ -65,8 +65,8 @@ struct Storage<T, 0> final {};
 
 namespace __private {
 template <size_t I>
-constexpr bool array_cmp_impl(sus::cmp::Ordering auto& val,
-                                     const auto& l, const auto& r) noexcept {
+constexpr bool array_cmp_impl(sus::cmp::Ordering auto& val, const auto& l,
+                              const auto& r) noexcept {
   auto cmp = l.get_unchecked(::sus::marker::unsafe_fn, I) <=>
              r.get_unchecked(::sus::marker::unsafe_fn, I);
   // Allow downgrading from equal to equivalent, but not the inverse.
@@ -77,13 +77,12 @@ constexpr bool array_cmp_impl(sus::cmp::Ordering auto& val,
 
 template <size_t... Is>
 constexpr auto array_cmp(sus::cmp::Ordering auto equal, const auto& l,
-                                const auto& r,
-                                std::index_sequence<Is...>) noexcept {
+                         const auto& r, std::index_sequence<Is...>) noexcept {
   auto val = equal;
   (true && ... && (array_cmp_impl<Is>(val, l, r)));
   return val;
 }
-}
+}  // namespace __private
 
 /// A collection of objects of type `T`, with a fixed size `N`.
 ///
@@ -357,7 +356,8 @@ class Array final {
   /// Satisfies the [`Eq<Array<T, N>, Array<U, N>>`]($sus::cmp::Eq) concept.
   template <class U>
     requires(::sus::cmp::Eq<T, U>)
-  friend constexpr bool operator==(const Array& l, const Array<U, N>& r) noexcept
+  friend constexpr bool operator==(const Array& l,
+                                   const Array<U, N>& r) noexcept
     requires(::sus::cmp::Eq<T>)
   {
     return l.eq_impl(r, std::make_index_sequence<N>());
@@ -445,8 +445,8 @@ class Array final {
   /// #[doc.overloads=array.cmp.array]
   template <class U>
     requires(::sus::cmp::ExclusiveOrd<T, U>)
-  constexpr friend std::weak_ordering operator<=>(const Array& l,
-                                                  const Array<U, N>& r) noexcept {
+  constexpr friend std::weak_ordering operator<=>(
+      const Array& l, const Array<U, N>& r) noexcept {
     return __private::array_cmp(std::weak_ordering::equivalent, l, r,
                                 std::make_index_sequence<N>());
   }
@@ -471,8 +471,8 @@ class Array final {
   /// #[doc.overloads=array.cmp.slice]
   template <class U>
     requires(::sus::cmp::ExclusiveStrongOrd<T, U>)
-  constexpr friend std::strong_ordering operator<=>(const Array& l,
-                                                    const Slice<U>& r) noexcept {
+  constexpr friend std::strong_ordering operator<=>(
+      const Array& l, const Slice<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::strong_ordering::equivalent, l, r,
                                 std::make_index_sequence<N>());
@@ -489,8 +489,8 @@ class Array final {
   /// #[doc.overloads=array.cmp.slice]
   template <class U>
     requires(::sus::cmp::ExclusivePartialOrd<T, U>)
-  constexpr friend std::partial_ordering operator<=>(const Array& l,
-                                                    const Slice<U>& r) noexcept {
+  constexpr friend std::partial_ordering operator<=>(
+      const Array& l, const Slice<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::partial_ordering::equivalent, l, r,
                                 std::make_index_sequence<N>());
@@ -517,8 +517,8 @@ class Array final {
   /// #[doc.overloads=array.cmp.slicemut]
   template <class U>
     requires(::sus::cmp::ExclusiveOrd<T, U>)
-  constexpr friend std::weak_ordering operator<=>(const Array& l,
-                                                  const SliceMut<U>& r) noexcept {
+  constexpr friend std::weak_ordering operator<=>(
+      const Array& l, const SliceMut<U>& r) noexcept {
     if (r.len() != N) return r.len() <=> N;
     return __private::array_cmp(std::weak_ordering::equivalent, l, r,
                                 std::make_index_sequence<N>());
@@ -534,7 +534,8 @@ class Array final {
   }
 
   // Stream support
-  _sus_format_to_stream(Array)
+  _sus_format_to_stream(Array);
+
  private:
   enum WithDefault { WITH_DEFAULT };
   template <size_t... Is>

--- a/sus/collections/slice.h
+++ b/sus/collections/slice.h
@@ -249,7 +249,7 @@ class [[_sus_trivial_abi]] Slice final {
   }
 
   // Stream support.
-  _sus_format_to_stream(Slice)
+  _sus_format_to_stream(Slice);
 
 #define _ptr_expr data_
 #define _len_expr len_

--- a/sus/collections/slice.h
+++ b/sus/collections/slice.h
@@ -248,6 +248,9 @@ class [[_sus_trivial_abi]] Slice final {
     iter_refs_ = ::sus::iter::IterRefCounter::empty_for_view();
   }
 
+  // Stream support.
+  _sus_format_to_stream(Slice)
+
 #define _ptr_expr data_
 #define _len_expr len_
 #define _iter_refs_expr iter_refs_.to_iter_from_view()
@@ -471,6 +474,9 @@ class [[_sus_trivial_abi]] SliceMut final {
     slice_.iter_refs_ = ::sus::iter::IterRefCounter::empty_for_view();
   }
 
+  // Stream support.
+  _sus_format_to_stream(SliceMut);
+
 #define _ptr_expr slice_.data_
 #define _len_expr slice_.len_
 #define _iter_refs_expr slice_.iter_refs_.to_iter_from_view()
@@ -540,9 +546,6 @@ struct fmt::formatter<::sus::collections::Slice<T>, Char> {
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
 
-// Stream support.
-_sus_format_to_stream(sus::collections, Slice, T);
-
 // fmt support.
 template <class T, class Char>
 struct fmt::formatter<::sus::collections::SliceMut<T>, Char> {
@@ -567,9 +570,6 @@ struct fmt::formatter<::sus::collections::SliceMut<T>, Char> {
  private:
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::collections, SliceMut, T);
 
 // Promote Slice into the `sus` namespace.
 namespace sus {

--- a/sus/collections/vec.h
+++ b/sus/collections/vec.h
@@ -829,6 +829,9 @@ class Vec final {
         ::sus::marker::unsafe_fn, iter_refs_.to_view_from_owner(), data_, len_);
   }
 
+  // Stream support.
+  _sus_format_to_stream(Vec)
+
 #define _ptr_expr data_
 #define _len_expr len_
 #define _iter_refs_expr iter_refs_.to_iter_from_owner()
@@ -1093,9 +1096,6 @@ struct fmt::formatter<::sus::collections::Vec<T>, Char> {
  private:
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::collections, Vec, T);
 
 namespace sus::collections {
 /// Implicit for-ranged loop iteration for all collections via the `iter`

--- a/sus/collections/vec.h
+++ b/sus/collections/vec.h
@@ -830,7 +830,7 @@ class Vec final {
   }
 
   // Stream support.
-  _sus_format_to_stream(Vec)
+  _sus_format_to_stream(Vec);
 
 #define _ptr_expr data_
 #define _len_expr len_

--- a/sus/env/var.h
+++ b/sus/env/var.h
@@ -36,7 +36,7 @@ struct VarError {
   Reason reason;
 
   /// Satisfies the [`Eq`]($sus::cmp::Eq) concept.
-  constexpr bool operator==(const VarError& rhs) const noexcept = default;
+  constexpr friend bool operator==(const VarError& lhs, const VarError& rhs) noexcept = default;
 };
 
 /// Fetches the environment variable `key` from the current process.

--- a/sus/env/var.h
+++ b/sus/env/var.h
@@ -36,7 +36,7 @@ struct VarError {
   Reason reason;
 
   /// Satisfies the [`Eq`]($sus::cmp::Eq) concept.
-  constexpr friend bool operator==(const VarError& lhs,
+  friend constexpr bool operator==(const VarError& lhs,
                                    const VarError& rhs) noexcept = default;
 };
 

--- a/sus/env/var.h
+++ b/sus/env/var.h
@@ -36,7 +36,8 @@ struct VarError {
   Reason reason;
 
   /// Satisfies the [`Eq`]($sus::cmp::Eq) concept.
-  constexpr friend bool operator==(const VarError& lhs, const VarError& rhs) noexcept = default;
+  constexpr friend bool operator==(const VarError& lhs,
+                                   const VarError& rhs) noexcept = default;
 };
 
 /// Fetches the environment variable `key` from the current process.

--- a/sus/iter/generator.h
+++ b/sus/iter/generator.h
@@ -123,7 +123,7 @@ class [[nodiscard]] [[_sus_trivial_abi]] GeneratorLoop {
       : generator_(generator) {}
 
   friend constexpr bool operator==(
-      const GeneratorLoop& l,
+      const GeneratorLoop& loop,
       const ::sus::iter::__private::IteratorEnd&) noexcept {
     return l.generator_.co_handle_.done();
   }

--- a/sus/iter/generator.h
+++ b/sus/iter/generator.h
@@ -125,7 +125,7 @@ class [[nodiscard]] [[_sus_trivial_abi]] GeneratorLoop {
   friend constexpr bool operator==(
       const GeneratorLoop& loop,
       const ::sus::iter::__private::IteratorEnd&) noexcept {
-    return l.generator_.co_handle_.done();
+    return loop.generator_.co_handle_.done();
   }
   constexpr GeneratorLoop& operator++() & noexcept {
     // UB occurs if this is called after GeneratorLoop == IteratorEnd. This

--- a/sus/iter/generator.h
+++ b/sus/iter/generator.h
@@ -122,7 +122,7 @@ class [[nodiscard]] [[_sus_trivial_abi]] GeneratorLoop {
   constexpr GeneratorLoop(Generator& generator sus_lifetimebound) noexcept
       : generator_(generator) {}
 
-  constexpr friend bool operator==(
+  friend constexpr bool operator==(
       const GeneratorLoop& l,
       const ::sus::iter::__private::IteratorEnd&) noexcept {
     return l.generator_.co_handle_.done();

--- a/sus/iter/generator.h
+++ b/sus/iter/generator.h
@@ -122,7 +122,8 @@ class [[nodiscard]] [[_sus_trivial_abi]] GeneratorLoop {
   constexpr GeneratorLoop(Generator& generator sus_lifetimebound) noexcept
       : generator_(generator) {}
 
-  constexpr friend bool operator==(const GeneratorLoop& l,
+  constexpr friend bool operator==(
+      const GeneratorLoop& l,
       const ::sus::iter::__private::IteratorEnd&) noexcept {
     return l.generator_.co_handle_.done();
   }

--- a/sus/iter/generator.h
+++ b/sus/iter/generator.h
@@ -122,9 +122,9 @@ class [[nodiscard]] [[_sus_trivial_abi]] GeneratorLoop {
   constexpr GeneratorLoop(Generator& generator sus_lifetimebound) noexcept
       : generator_(generator) {}
 
-  constexpr bool operator==(
+  constexpr friend bool operator==(const GeneratorLoop& l,
       const ::sus::iter::__private::IteratorEnd&) noexcept {
-    return generator_.co_handle_.done();
+    return l.generator_.co_handle_.done();
   }
   constexpr GeneratorLoop& operator++() & noexcept {
     // UB occurs if this is called after GeneratorLoop == IteratorEnd. This

--- a/sus/iter/iterator_loop.h
+++ b/sus/iter/iterator_loop.h
@@ -31,7 +31,7 @@ class [[nodiscard]] IteratorLoop final {
   constexpr IteratorLoop(Iter&& iter) noexcept
       : iter_(::sus::forward<Iter>(iter)), item_(iter_.next()) {}
 
-  friend constexpr bool operator==(const IteratorLoop& x,
+  friend constexpr bool operator==(const IteratorLoop& loop,
                                    __private::IteratorEnd) noexcept {
     return x.item_.is_none();
   }

--- a/sus/iter/iterator_loop.h
+++ b/sus/iter/iterator_loop.h
@@ -31,8 +31,8 @@ class [[nodiscard]] IteratorLoop final {
   constexpr IteratorLoop(Iter&& iter) noexcept
       : iter_(::sus::forward<Iter>(iter)), item_(iter_.next()) {}
 
-  constexpr inline bool operator==(__private::IteratorEnd) const noexcept {
-    return item_.is_none();
+  constexpr friend bool operator==(const IteratorLoop& x, __private::IteratorEnd) noexcept {
+    return x.item_.is_none();
   }
   constexpr inline void operator++() & noexcept { item_ = iter_.next(); }
   constexpr inline Item operator*() & noexcept {

--- a/sus/iter/iterator_loop.h
+++ b/sus/iter/iterator_loop.h
@@ -33,7 +33,7 @@ class [[nodiscard]] IteratorLoop final {
 
   friend constexpr bool operator==(const IteratorLoop& loop,
                                    __private::IteratorEnd) noexcept {
-    return x.item_.is_none();
+    return loop.item_.is_none();
   }
   constexpr inline void operator++() & noexcept { item_ = iter_.next(); }
   constexpr inline Item operator*() & noexcept {

--- a/sus/iter/iterator_loop.h
+++ b/sus/iter/iterator_loop.h
@@ -31,7 +31,7 @@ class [[nodiscard]] IteratorLoop final {
   constexpr IteratorLoop(Iter&& iter) noexcept
       : iter_(::sus::forward<Iter>(iter)), item_(iter_.next()) {}
 
-  constexpr friend bool operator==(const IteratorLoop& x,
+  friend constexpr bool operator==(const IteratorLoop& x,
                                    __private::IteratorEnd) noexcept {
     return x.item_.is_none();
   }

--- a/sus/iter/iterator_loop.h
+++ b/sus/iter/iterator_loop.h
@@ -31,7 +31,8 @@ class [[nodiscard]] IteratorLoop final {
   constexpr IteratorLoop(Iter&& iter) noexcept
       : iter_(::sus::forward<Iter>(iter)), item_(iter_.next()) {}
 
-  constexpr friend bool operator==(const IteratorLoop& x, __private::IteratorEnd) noexcept {
+  constexpr friend bool operator==(const IteratorLoop& x,
+                                   __private::IteratorEnd) noexcept {
     return x.item_.is_none();
   }
   constexpr inline void operator++() & noexcept { item_ = iter_.next(); }

--- a/sus/iter/size_hint.h
+++ b/sus/iter/size_hint.h
@@ -18,6 +18,7 @@
 
 #include "sus/num/unsigned_integer.h"
 #include "sus/option/option.h"
+#include "sus/string/__private/format_to_stream.h"
 
 namespace sus::iter {
 
@@ -27,6 +28,21 @@ struct SizeHint {
 
   friend constexpr bool operator==(const SizeHint& lhs,
                                    const SizeHint& rhs) noexcept = default;
+
+  // Stream support.
+  _sus_format_to_stream(SizeHint)
 };
 
 }  // namespace sus::iter
+
+// fmt support.
+template <class Char>
+struct fmt::formatter<::sus::iter::SizeHint, Char> {
+  template <class ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  FormatContext::iterator format(const ::sus::iter::SizeHint& t, FormatContext& ctx) const;
+};

--- a/sus/iter/size_hint.h
+++ b/sus/iter/size_hint.h
@@ -30,7 +30,7 @@ struct SizeHint {
                                    const SizeHint& rhs) noexcept = default;
 
   // Stream support.
-  _sus_format_to_stream(SizeHint)
+  _sus_format_to_stream(SizeHint);
 };
 
 }  // namespace sus::iter
@@ -44,5 +44,6 @@ struct fmt::formatter<::sus::iter::SizeHint, Char> {
   }
 
   template <class FormatContext>
-  FormatContext::iterator format(const ::sus::iter::SizeHint& t, FormatContext& ctx) const;
+  FormatContext::iterator format(const ::sus::iter::SizeHint& t,
+                                 FormatContext& ctx) const;
 };

--- a/sus/iter/size_hint_impl.h
+++ b/sus/iter/size_hint_impl.h
@@ -25,7 +25,7 @@
 // fmt support.
 template <class Char>
 template <class FormatContext>
- FormatContext::iterator fmt::formatter<::sus::iter::SizeHint, Char>::format(const ::sus::iter::SizeHint& t,
-                        FormatContext& ctx) const {
-    return fmt::format_to(ctx.out(), "SizeHint({}, {})", t.lower, t.upper);
-  }
+FormatContext::iterator fmt::formatter<::sus::iter::SizeHint, Char>::format(
+    const ::sus::iter::SizeHint& t, FormatContext& ctx) const {
+  return fmt::format_to(ctx.out(), "SizeHint({}, {})", t.lower, t.upper);
+}

--- a/sus/iter/size_hint_impl.h
+++ b/sus/iter/size_hint_impl.h
@@ -24,18 +24,8 @@
 
 // fmt support.
 template <class Char>
-struct fmt::formatter<::sus::iter::SizeHint, Char> {
-  template <class ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
-  }
-
-  template <class FormatContext>
-  constexpr auto format(const ::sus::iter::SizeHint& t,
+template <class FormatContext>
+ FormatContext::iterator fmt::formatter<::sus::iter::SizeHint, Char>::format(const ::sus::iter::SizeHint& t,
                         FormatContext& ctx) const {
     return fmt::format_to(ctx.out(), "SizeHint({}, {})", t.lower, t.upper);
   }
-};
-
-// Stream support.
-_sus_format_to_stream(sus::iter, SizeHint);

--- a/sus/marker/empty.h
+++ b/sus/marker/empty.h
@@ -43,11 +43,6 @@ constexpr inline auto empty = EmptyMarker();
 
 }  // namespace sus::marker
 
-// Promote `empty` into the `sus` namespace.
-namespace sus {
-using sus::marker::empty;
-}
-
 // fmt support.
 template <class Char>
 struct fmt::formatter<::sus::marker::EmptyMarker, Char> {

--- a/sus/marker/empty.h
+++ b/sus/marker/empty.h
@@ -62,3 +62,8 @@ struct fmt::formatter<::sus::marker::EmptyMarker, Char> {
     return fmt::format_to(ctx.out(), "empty");
   }
 };
+
+// Promote `empty` into the `sus` namespace.
+namespace sus {
+using sus::marker::empty;
+}

--- a/sus/marker/empty.h
+++ b/sus/marker/empty.h
@@ -20,7 +20,7 @@
 #include "sus/string/__private/format_to_stream.h"
 
 namespace sus::marker {
-  struct EmptyMarker;
+struct EmptyMarker;
 }
 
 // fmt support.
@@ -52,7 +52,7 @@ struct EmptyMarker {
   explicit consteval EmptyMarker() {}
 
   // Stream support.
-  _sus_format_to_stream(EmptyMarker)
+  _sus_format_to_stream(EmptyMarker);
 };
 
 /// The global [`EmptyMarker`]($sus::marker::EmptyMarker) which can be passed to

--- a/sus/marker/empty.h
+++ b/sus/marker/empty.h
@@ -20,25 +20,6 @@
 #include "sus/string/__private/format_to_stream.h"
 
 namespace sus::marker {
-struct EmptyMarker;
-}
-
-// fmt support.
-template <class Char>
-struct fmt::formatter<::sus::marker::EmptyMarker, Char> {
-  template <class ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
-  }
-
-  template <class FormatContext>
-  constexpr auto format(const ::sus::marker::EmptyMarker&,
-                        FormatContext& ctx) const {
-    return fmt::format_to(ctx.out(), "empty");
-  }
-};
-
-namespace sus::marker {
 
 /// A marker that designates emptinesss, for constructing an empty collection.
 ///
@@ -66,3 +47,18 @@ constexpr inline auto empty = EmptyMarker();
 namespace sus {
 using sus::marker::empty;
 }
+
+// fmt support.
+template <class Char>
+struct fmt::formatter<::sus::marker::EmptyMarker, Char> {
+  template <class ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  constexpr auto format(const ::sus::marker::EmptyMarker&,
+                        FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "empty");
+  }
+};

--- a/sus/marker/empty.h
+++ b/sus/marker/empty.h
@@ -20,25 +20,8 @@
 #include "sus/string/__private/format_to_stream.h"
 
 namespace sus::marker {
-
-/// A marker that designates emptinesss, for constructing an empty collection.
-///
-/// To use this type as an argument, use the global [`empty`](
-/// $sus::marker::empty).
-struct EmptyMarker {
-  /// `explicit` prevents `{}` or `{any values...}` from being used to construct
-  /// an `Empty`. The marker should only be used as [`empty`](
-  /// $sus::marker::empty).
-  /// #[doc.hidden]
-  explicit consteval EmptyMarker() {}
-};
-
-/// The global [`EmptyMarker`]($sus::marker::EmptyMarker) which can be passed to
-/// constructors to allow type deduction instead of having to write out the full
-/// default constructor.
-constexpr inline auto empty = EmptyMarker();
-
-}  // namespace sus::marker
+  struct EmptyMarker;
+}
 
 // fmt support.
 template <class Char>
@@ -55,8 +38,29 @@ struct fmt::formatter<::sus::marker::EmptyMarker, Char> {
   }
 };
 
-// Stream support.
-_sus_format_to_stream(sus::marker, EmptyMarker);
+namespace sus::marker {
+
+/// A marker that designates emptinesss, for constructing an empty collection.
+///
+/// To use this type as an argument, use the global [`empty`](
+/// $sus::marker::empty).
+struct EmptyMarker {
+  /// `explicit` prevents `{}` or `{any values...}` from being used to construct
+  /// an `Empty`. The marker should only be used as [`empty`](
+  /// $sus::marker::empty).
+  /// #[doc.hidden]
+  explicit consteval EmptyMarker() {}
+
+  // Stream support.
+  _sus_format_to_stream(EmptyMarker)
+};
+
+/// The global [`EmptyMarker`]($sus::marker::EmptyMarker) which can be passed to
+/// constructors to allow type deduction instead of having to write out the full
+/// default constructor.
+constexpr inline auto empty = EmptyMarker();
+
+}  // namespace sus::marker
 
 // Promote `empty` into the `sus` namespace.
 namespace sus {

--- a/sus/marker/unsafe.h
+++ b/sus/marker/unsafe.h
@@ -23,7 +23,7 @@ namespace sus {
 /// Marker types, such as for accessing unsafe APIs, for overload resolution,
 /// or type elision.
 namespace marker {
-  struct UnsafeFnMarker;
+struct UnsafeFnMarker;
 }
 }  // namespace sus
 
@@ -70,7 +70,7 @@ struct UnsafeFnMarker {
   explicit consteval UnsafeFnMarker() {}
 
   // Stream support.
-  _sus_format_to_stream(UnsafeFnMarker)
+  _sus_format_to_stream(UnsafeFnMarker);
 };
 
 /// The global [`UnsafeFnMarker`]($sus::marker::UnsafeFnMarker) which can be

--- a/sus/marker/unsafe.h
+++ b/sus/marker/unsafe.h
@@ -22,25 +22,8 @@
 namespace sus {
 /// Marker types, such as for accessing unsafe APIs, for overload resolution,
 /// or type elision.
-namespace marker {
-struct UnsafeFnMarker;
-}
+namespace marker {}
 }  // namespace sus
-
-// fmt support.
-template <class Char>
-struct fmt::formatter<::sus::marker::UnsafeFnMarker, Char> {
-  template <class ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
-  }
-
-  template <class FormatContext>
-  constexpr auto format(const ::sus::marker::UnsafeFnMarker&,
-                        FormatContext& ctx) const {
-    return fmt::format_to(ctx.out(), "unsafe_fn");
-  }
-};
 
 namespace sus::marker {
 
@@ -79,3 +62,18 @@ struct UnsafeFnMarker {
 constexpr inline auto unsafe_fn = UnsafeFnMarker();
 
 }  // namespace sus::marker
+
+// fmt support.
+template <class Char>
+struct fmt::formatter<::sus::marker::UnsafeFnMarker, Char> {
+  template <class ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  constexpr auto format(const ::sus::marker::UnsafeFnMarker&,
+                        FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "unsafe_fn");
+  }
+};

--- a/sus/marker/unsafe.h
+++ b/sus/marker/unsafe.h
@@ -22,8 +22,25 @@
 namespace sus {
 /// Marker types, such as for accessing unsafe APIs, for overload resolution,
 /// or type elision.
-namespace marker {}
+namespace marker {
+  struct UnsafeFnMarker;
+}
 }  // namespace sus
+
+// fmt support.
+template <class Char>
+struct fmt::formatter<::sus::marker::UnsafeFnMarker, Char> {
+  template <class ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  constexpr auto format(const ::sus::marker::UnsafeFnMarker&,
+                        FormatContext& ctx) const {
+    return fmt::format_to(ctx.out(), "unsafe_fn");
+  }
+};
 
 namespace sus::marker {
 
@@ -51,6 +68,9 @@ struct UnsafeFnMarker {
   /// $sus::marker::unsafe_fn).
   /// #[doc.hidden]
   explicit consteval UnsafeFnMarker() {}
+
+  // Stream support.
+  _sus_format_to_stream(UnsafeFnMarker)
 };
 
 /// The global [`UnsafeFnMarker`]($sus::marker::UnsafeFnMarker) which can be
@@ -59,21 +79,3 @@ struct UnsafeFnMarker {
 constexpr inline auto unsafe_fn = UnsafeFnMarker();
 
 }  // namespace sus::marker
-
-// fmt support.
-template <class Char>
-struct fmt::formatter<::sus::marker::UnsafeFnMarker, Char> {
-  template <class ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
-  }
-
-  template <class FormatContext>
-  constexpr auto format(const ::sus::marker::UnsafeFnMarker&,
-                        FormatContext& ctx) const {
-    return fmt::format_to(ctx.out(), "unsafe_fn");
-  }
-};
-
-// Stream support.
-_sus_format_to_stream(sus::marker, UnsafeFnMarker);

--- a/sus/num/__private/float_methods.inc
+++ b/sus/num/__private/float_methods.inc
@@ -1158,7 +1158,7 @@ _sus_pure static _self from_ne_bytes(
         bytes) noexcept;
 
 // Stream support.
-_sus_format_to_stream(_self)
+_sus_format_to_stream(_self);
 
 #undef _self
 #undef _primitive

--- a/sus/num/__private/float_methods.inc
+++ b/sus/num/__private/float_methods.inc
@@ -1157,6 +1157,9 @@ _sus_pure static _self from_ne_bytes(
     const ::sus::collections::Array<u8, ::sus::mem::size_of<_primitive>()>&
         bytes) noexcept;
 
+// Stream support.
+_sus_format_to_stream(_self)
+
 #undef _self
 #undef _primitive
 #undef _unsigned

--- a/sus/num/__private/float_methods_impl.inc
+++ b/sus/num/__private/float_methods_impl.inc
@@ -95,9 +95,6 @@ struct fmt::formatter<::sus::num::_self, Char> {
   formatter<_primitive, Char> underlying_;
 };
 
-// Stream support.
-_sus_format_to_stream(sus::num, _self);
-
 #undef _self
 #undef _primitive
 #undef _unsigned

--- a/sus/num/__private/signed_integer_methods.inc
+++ b/sus/num/__private/signed_integer_methods.inc
@@ -2083,6 +2083,9 @@ _sus_pure static constexpr _self from_ne_bytes(
     const ::sus::collections::Array<u8, ::sus::mem::size_of<_primitive>()>&
         bytes) noexcept;
 
+// Stream support.
+_sus_format_to_stream(_self)
+
 #undef _self
 #undef _primitive
 #undef _unsigned

--- a/sus/num/__private/signed_integer_methods.inc
+++ b/sus/num/__private/signed_integer_methods.inc
@@ -2102,7 +2102,7 @@ _sus_pure static constexpr _self from_ne_bytes(
 /// behaviour.
 ///
 /// #[doc.overloads=signedint.<<]
-[[nodiscard]] __sus_pure_const constexpr friend _self operator<<(
+[[nodiscard]] __sus_pure_const friend constexpr _self operator<<(
     _self l, std::convertible_to<u64> auto r) noexcept {
   if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
     const auto out = __private::shl_with_overflow(l.primitive_value,
@@ -2118,7 +2118,7 @@ _sus_pure static constexpr _self from_ne_bytes(
 /// #[doc.overloads=signedint.<<]
 template <class U>
   requires(!std::convertible_to<U, u64>)
-constexpr friend _self operator<<(_self l, U r) noexcept = delete;
+friend constexpr _self operator<<(_self l, U r) noexcept = delete;
 
 /// Satisfies the [`Shr`]($sus::num::Shr) concept for signed integers.
 ///
@@ -2133,7 +2133,7 @@ constexpr friend _self operator<<(_self l, U r) noexcept = delete;
 /// behaviour.
 ///
 /// #[doc.overloads=signedint.>>]
-[[nodiscard]] __sus_pure_const constexpr friend _self operator>>(
+[[nodiscard]] __sus_pure_const friend constexpr _self operator>>(
     _self l, std::convertible_to<u64> auto r) noexcept {
   if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
     const auto out = __private::shr_with_overflow(l.primitive_value,
@@ -2149,7 +2149,7 @@ constexpr friend _self operator<<(_self l, U r) noexcept = delete;
 /// #[doc.overloads=signedint.>>]
 template <class U>
   requires(!std::convertible_to<U, u64>)
-constexpr friend _self operator>>(_self l, U r) noexcept = delete;
+friend constexpr _self operator>>(_self l, U r) noexcept = delete;
 
 /// Satisfies the [`Shl`]($sus::num::Shl) concept for signed primitive integers
 /// shifted by [`u64`]($sus::num::u64).
@@ -2157,7 +2157,7 @@ constexpr friend _self operator>>(_self l, U r) noexcept = delete;
 template <class P, class U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, U r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator<<(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l << u64(r).primitive_value;
@@ -2166,7 +2166,7 @@ template <class P, class U>
 template <class P, class U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && !std::convertible_to<U, u64>)
-constexpr friend P operator<<(P l, U r) noexcept = delete;
+friend constexpr P operator<<(P l, U r) noexcept = delete;
 
 /// Satisfies the [`Shr`]($sus::num::Shr) concept for signed primitive integers
 /// shifted by [`u64`]($sus::num::u64).
@@ -2176,7 +2176,7 @@ constexpr friend P operator<<(P l, U r) noexcept = delete;
 template <class P, class U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, U r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator>>(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l >> u64(r).primitive_value;
@@ -2185,13 +2185,13 @@ template <class P, class U>
 template <class P, class U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && !std::convertible_to<U, u64>)
-constexpr friend P operator>>(P l, U r) noexcept = delete;
+friend constexpr P operator>>(P l, U r) noexcept = delete;
 
 /// #[doc.overloads=unsigned.prim.<<u64]
 template <class P, class U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, U r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator<<(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l << u64(r).primitive_value;
@@ -2201,13 +2201,13 @@ template <class P, class U>
 template <class P, class U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && !std::convertible_to<U, u64>)
-constexpr friend P operator<<(P l, U r) noexcept = delete;
+friend constexpr P operator<<(P l, U r) noexcept = delete;
 
 /// #[doc.overloads=unsigned.prim.>>u64]
 template <class P, class U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, U r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator>>(P l, U r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l >> u64(r).primitive_value;
@@ -2217,7 +2217,7 @@ template <class P, class U>
 template <class P, class U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
            std::same_as<U, _self> && !std::convertible_to<U, u64>)
-constexpr friend P operator>>(P l, U r) noexcept = delete;
+friend constexpr P operator>>(P l, U r) noexcept = delete;
 
 // Stream support.
 _sus_format_to_stream(_self);

--- a/sus/num/__private/signed_integer_methods.inc
+++ b/sus/num/__private/signed_integer_methods.inc
@@ -2084,7 +2084,7 @@ _sus_pure static constexpr _self from_ne_bytes(
         bytes) noexcept;
 
 // Stream support.
-_sus_format_to_stream(_self)
+_sus_format_to_stream(_self);
 
 #undef _self
 #undef _primitive

--- a/sus/num/__private/signed_integer_methods.inc
+++ b/sus/num/__private/signed_integer_methods.inc
@@ -2083,6 +2083,142 @@ _sus_pure static constexpr _self from_ne_bytes(
     const ::sus::collections::Array<u8, ::sus::mem::size_of<_primitive>()>&
         bytes) noexcept;
 
+/// Satisfies the [`Shl`]($sus::num::Shl) concept for signed integers.
+///
+/// This operation supports shifting with primitive signed or unsigned integers
+/// that convert to the safe numeric, as well as enums.
+/// However enum class is excluded as they require an explicit conversion to an
+/// integer.
+///
+/// Thus the bound is `std::convertible_to` (implicit conversion) instead of
+/// `sus::construct::From` (explicit conversion).
+///
+/// # Panics
+/// This function will panic when `r` is not less than the number of bits in `l`
+/// if overflow checks are enabled (they are by default) and will perform a
+/// wrapping shift if overflow checks are disabled (not the default).
+///
+/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+/// behaviour.
+///
+/// #[doc.overloads=signedint.<<]
+[[nodiscard]] __sus_pure_const constexpr friend _self operator<<(
+    _self l, std::convertible_to<u64> auto r) noexcept {
+  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+    const auto out = __private::shl_with_overflow(l.primitive_value,
+                                                  u64(r).primitive_value);
+    sus_check_with_message(!out.overflow,
+                            "attempt to shift left with overflow");
+    return out.value;
+  } else {
+    return l.wrapping_shl(u64(r).primitive_value);
+  }
+}
+
+/// #[doc.overloads=signedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr friend _self operator<<(_self l, U r) noexcept = delete;
+
+/// Satisfies the [`Shr`]($sus::num::Shr) concept for signed integers.
+///
+/// Performs sign extension, copying the sign bit to the right if its set.
+///
+/// # Panics
+/// This function will panic when `r` is not less than the number of bits in `l`
+/// if overflow checks are enabled (they are by default) and will perform a
+/// wrapping shift if overflow checks are disabled (not the default).
+///
+/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+/// behaviour.
+///
+/// #[doc.overloads=signedint.>>]
+[[nodiscard]] __sus_pure_const constexpr friend _self operator>>(
+    _self l, std::convertible_to<u64> auto r) noexcept {
+  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+    const auto out = __private::shr_with_overflow(l.primitive_value,
+                                                  u64(r).primitive_value);
+    sus_check_with_message(!out.overflow,
+                            "attempt to shift right with overflow");
+    return out.value;
+  } else {
+    return l.wrapping_shr(u64(r).primitive_value);
+  }
+}
+
+/// #[doc.overloads=signedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr friend _self operator>>(_self l, U r) noexcept = delete;
+
+/// Satisfies the [`Shl`]($sus::num::Shl) concept for signed primitive integers
+/// shifted by [`u64`]($sus::num::u64).
+/// #[doc.overloads=signed.prim.<<u64]
+template <class P, class U>
+  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && std::convertible_to<U, u64>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, U r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l << u64(r).primitive_value;
+}
+/// #[doc.overloads=signed.prim.<<u64]
+template <class P, class U>
+  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && !std::convertible_to<U, u64>)
+constexpr friend P operator<<(P l, U r) noexcept = delete;
+
+/// Satisfies the [`Shr`]($sus::num::Shr) concept for signed primitive integers
+/// shifted by [`u64`]($sus::num::u64).
+///
+/// Performs sign extension, copying the sign bit to the right if its set.
+/// #[doc.overloads=signed.prim.>>u64]
+template <class P, class U>
+  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && std::convertible_to<U, u64>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, U r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l >> u64(r).primitive_value;
+}
+/// #[doc.overloads=signed.prim.>>u64]
+template <class P, class U>
+  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && !std::convertible_to<U, u64>)
+constexpr friend P operator>>(P l, U r) noexcept = delete;
+
+/// #[doc.overloads=unsigned.prim.<<u64]
+template <class P, class U>
+  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && std::convertible_to<U, u64>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, U r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l << u64(r).primitive_value;
+}
+
+/// #[doc.overloads=unsigned.prim.<<u64]
+template <class P, class U>
+  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && !std::convertible_to<U, u64>)
+constexpr friend P operator<<(P l, U r) noexcept = delete;
+
+/// #[doc.overloads=unsigned.prim.>>u64]
+template <class P, class U>
+  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && std::convertible_to<U, u64>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, U r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l >> u64(r).primitive_value;
+}
+
+/// #[doc.overloads=unsigned.prim.>>u64]
+template <class P, class U>
+  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
+           std::same_as<U, _self> && !std::convertible_to<U, u64>)
+constexpr friend P operator>>(P l, U r) noexcept = delete;
+
 // Stream support.
 _sus_format_to_stream(_self);
 

--- a/sus/num/__private/signed_integer_methods_impl.inc
+++ b/sus/num/__private/signed_integer_methods_impl.inc
@@ -265,9 +265,6 @@ struct fmt::formatter<::sus::num::_self, Char> {
   formatter<_primitive, Char> underlying_;
 };
 
-// Stream support.
-_sus_format_to_stream(sus::num, _self);
-
 #undef _self
 #undef _primitive
 #undef _unsigned

--- a/sus/num/__private/unsigned_integer_methods.inc
+++ b/sus/num/__private/unsigned_integer_methods.inc
@@ -2422,7 +2422,7 @@ to_ne_bytes() const& noexcept;
         bytes) noexcept;
 
 // Stream support.
-_sus_format_to_stream(_self)
+_sus_format_to_stream(_self);
 
 #if _pointer
 

--- a/sus/num/__private/unsigned_integer_methods.inc
+++ b/sus/num/__private/unsigned_integer_methods.inc
@@ -2424,6 +2424,118 @@ to_ne_bytes() const& noexcept;
 // Stream support.
 _sus_format_to_stream(_self);
 
+/// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned integers.
+///
+/// # Panics
+/// This function will panic when `r` is not less than the number of bits in `l`
+/// if overflow checks are enabled (they are by default) and will perform a
+/// wrapping shift if overflow checks are disabled (not the default).
+///
+/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+/// behaviour.
+///
+/// #[doc.overloads=unsignedint.<<]
+[[nodiscard]] __sus_pure_const constexpr friend _self operator<<(
+    _self l, std::convertible_to<u64> auto r) noexcept {
+  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+    sus_check_with_message(r < _self::BITS,
+                            "attempt to shift left with overflow");
+    return _self(
+        __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+  } else {
+    return _self(__private::shl_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                    .value);
+  }
+}
+
+/// #[doc.overloads=unsignedint.<<]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr friend _self operator<<(_self l, U r) noexcept = delete;
+
+/// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned integers.
+///
+/// # Panics
+/// This function will panic when `r` is not less than the number of bits in `l`
+/// if overflow checks are enabled (they are by default) and will perform a
+/// wrapping shift if overflow checks are disabled (not the default).
+///
+/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+/// behaviour.
+///
+/// #[doc.overloads=unsignedint.>>]
+[[nodiscard]] __sus_pure_const constexpr friend _self operator>>(
+    _self l, std::convertible_to<u64> auto r) noexcept {
+  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+    sus_check_with_message(r < _self::BITS,
+                            "attempt to shift right with overflow");
+    return _self(
+        __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+  } else {
+    return _self(__private::shr_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                    .value);
+  }
+}
+
+/// #[doc.overloads=unsignedint.>>]
+template <class U>
+  requires(!std::convertible_to<U, u64>)
+constexpr friend _self operator>>(_self l, U r) noexcept = delete;
+
+/// Satisfies the [`Add`]($sus::num::Add) concept for pointers
+/// (`T*`) with [`usize`]($sus::num::usize).
+///
+/// Adds a [`usize`]($sus::num::usize) to a pointer, returning the resulting
+/// pointer.
+///
+/// #[doc.overloads=ptr.add.usize]
+template <class T>
+__sus_pure_const constexpr friend T* operator+(T* t, _self offset) {
+  return t + size_t{offset};
+}
+
+/// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned primitive
+/// integers shifted by [`u64`]($sus::num::u64).
+/// #[doc.overloads=unsigned.prim.<<u64]
+template <class P>
+  requires(UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, _self r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l << u64(r).primitive_value;
+}
+
+/// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned primitive
+/// integers shifted by [`u64`]($sus::num::u64).
+/// #[doc.overloads=unsigned.prim.>>u64]
+template <class P>
+  requires(UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, _self r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l >> u64(r).primitive_value;
+}
+
+/// #[doc.overloads=signed.prim.<<u64]
+template <class P>
+  requires(SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, _self r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l << u64(r).primitive_value;
+}
+
+/// #[doc.overloads=signed.prim.>>u64]
+template <class P>
+  requires(SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>)
+[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, _self r) noexcept {
+  // No UB checks on primitive types, since there's no promotion to a Subspace
+  // return type?
+  return l >> u64(r).primitive_value;
+}
+
 #if _pointer
 
 /// Returns the address portion of the pointer.

--- a/sus/num/__private/unsigned_integer_methods.inc
+++ b/sus/num/__private/unsigned_integer_methods.inc
@@ -2114,39 +2114,27 @@ _sus_pure constexpr _self wrapping_sub(U rhs) const& noexcept {
 
 /// Returns the number of ones in the binary representation of the current
 /// value.
-_sus_pure constexpr u32 count_ones() const& noexcept {
-  return __private::count_ones(primitive_value);
-}
+_sus_pure constexpr u32 count_ones() const& noexcept;
 
 /// Returns the number of zeros in the binary representation of the current
 /// value.
-_sus_pure constexpr u32 count_zeros() const& noexcept {
-  return (~(*this)).count_ones();
-}
+_sus_pure constexpr u32 count_zeros() const& noexcept;
 
 /// Returns the number of leading ones in the binary representation of the
 /// current value.
-_sus_pure constexpr u32 leading_ones() const& noexcept {
-  return (~(*this)).leading_zeros();
-}
+_sus_pure constexpr u32 leading_ones() const& noexcept;
 
 /// Returns the number of leading zeros in the binary representation of the
 /// current value.
-_sus_pure constexpr u32 leading_zeros() const& noexcept {
-  return __private::leading_zeros(primitive_value);
-}
+_sus_pure constexpr u32 leading_zeros() const& noexcept;
 
 /// Returns the number of trailing ones in the binary representation of the
 /// current value.
-_sus_pure constexpr u32 trailing_ones() const& noexcept {
-  return (~(*this)).trailing_zeros();
-}
+_sus_pure constexpr u32 trailing_ones() const& noexcept;
 
 /// Returns the number of trailing zeros in the binary representation of the
 /// current value.
-_sus_pure constexpr u32 trailing_zeros() const& noexcept {
-  return __private::trailing_zeros(primitive_value);
-}
+_sus_pure constexpr u32 trailing_zeros() const& noexcept;
 
 /// Reverses the order of bits in the integer. The least significant bit becomes
 /// the most significant bit, second least-significant bit becomes second
@@ -2181,15 +2169,7 @@ _sus_pure constexpr _self swap_bytes() const& noexcept {
 ///
 /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
 /// behaviour.
-_sus_pure constexpr _self pow(u32 rhs) const& noexcept {
-  const auto out =
-      __private::pow_with_overflow(primitive_value, rhs.primitive_value);
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(!out.overflow,
-                              "attempt to multiply with overflow");
-  }
-  return _self(out.value);
-}
+_sus_pure constexpr _self pow(u32 rhs) const& noexcept;
 
 /// Checked exponentiation. Computes [`pow`]($sus::num::@doc.self::pow),
 /// returning `None` if overflow occurred.
@@ -2205,9 +2185,7 @@ _sus_pure constexpr ::sus::tuple_type::Tuple<_self, bool> overflowing_pow(
 
 /// Wrapping (modular) exponentiation. Computes [`pow`](
 /// $sus::num::@doc.self::pow), wrapping around at the boundary of the type.
-_sus_pure constexpr _self wrapping_pow(u32 exp) const& noexcept {
-  return _self(__private::wrapping_pow(primitive_value, exp.primitive_value));
-}
+_sus_pure constexpr _self wrapping_pow(u32 exp) const& noexcept;
 
 /// Returns the base 2 logarithm of the number, rounded down.
 ///
@@ -2273,9 +2251,7 @@ _sus_pure constexpr u32 log(U rhs) const& noexcept;
 #endif
 
 /// Returns `true` if and only if `self == 2^k` for some `k`.
-_sus_pure constexpr bool is_power_of_two() const& noexcept {
-  return count_ones() == _self(_primitive{1u});
-}
+_sus_pure constexpr bool is_power_of_two() const& noexcept;
 
 /// Calculates the smallest value greater than or equal to itself that is a
 /// multiple of `rhs`.
@@ -2444,6 +2420,9 @@ to_ne_bytes() const& noexcept;
 [[nodiscard]] _sus_pure static constexpr _self from_ne_bytes(
     const ::sus::collections::Array<u8, ::sus::mem::size_of<_primitive>()>&
         bytes) noexcept;
+
+// Stream support.
+_sus_format_to_stream(_self)
 
 #if _pointer
 

--- a/sus/num/__private/unsigned_integer_methods.inc
+++ b/sus/num/__private/unsigned_integer_methods.inc
@@ -2435,7 +2435,7 @@ _sus_format_to_stream(_self);
 /// behaviour.
 ///
 /// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] __sus_pure_const constexpr friend _self operator<<(
+[[nodiscard]] __sus_pure_const friend constexpr _self operator<<(
     _self l, std::convertible_to<u64> auto r) noexcept {
   if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
     sus_check_with_message(r < _self::BITS,
@@ -2452,7 +2452,7 @@ _sus_format_to_stream(_self);
 /// #[doc.overloads=unsignedint.<<]
 template <class U>
   requires(!std::convertible_to<U, u64>)
-constexpr friend _self operator<<(_self l, U r) noexcept = delete;
+friend constexpr _self operator<<(_self l, U r) noexcept = delete;
 
 /// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned integers.
 ///
@@ -2465,7 +2465,7 @@ constexpr friend _self operator<<(_self l, U r) noexcept = delete;
 /// behaviour.
 ///
 /// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] __sus_pure_const constexpr friend _self operator>>(
+[[nodiscard]] __sus_pure_const friend constexpr _self operator>>(
     _self l, std::convertible_to<u64> auto r) noexcept {
   if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
     sus_check_with_message(r < _self::BITS,
@@ -2482,7 +2482,7 @@ constexpr friend _self operator<<(_self l, U r) noexcept = delete;
 /// #[doc.overloads=unsignedint.>>]
 template <class U>
   requires(!std::convertible_to<U, u64>)
-constexpr friend _self operator>>(_self l, U r) noexcept = delete;
+friend constexpr _self operator>>(_self l, U r) noexcept = delete;
 
 /// Satisfies the [`Add`]($sus::num::Add) concept for pointers
 /// (`T*`) with [`usize`]($sus::num::usize).
@@ -2492,7 +2492,7 @@ constexpr friend _self operator>>(_self l, U r) noexcept = delete;
 ///
 /// #[doc.overloads=ptr.add.usize]
 template <class T>
-__sus_pure_const constexpr friend T* operator+(T* t, _self offset) {
+__sus_pure_const friend constexpr T* operator+(T* t, _self offset) {
   return t + size_t{offset};
 }
 
@@ -2501,7 +2501,7 @@ __sus_pure_const constexpr friend T* operator+(T* t, _self offset) {
 /// #[doc.overloads=unsigned.prim.<<u64]
 template <class P>
   requires(UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, _self r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator<<(P l, _self r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l << u64(r).primitive_value;
@@ -2512,7 +2512,7 @@ template <class P>
 /// #[doc.overloads=unsigned.prim.>>u64]
 template <class P>
   requires(UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, _self r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator>>(P l, _self r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l >> u64(r).primitive_value;
@@ -2521,7 +2521,7 @@ template <class P>
 /// #[doc.overloads=signed.prim.<<u64]
 template <class P>
   requires(SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator<<(P l, _self r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator<<(P l, _self r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l << u64(r).primitive_value;
@@ -2530,7 +2530,7 @@ template <class P>
 /// #[doc.overloads=signed.prim.>>u64]
 template <class P>
   requires(SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>)
-[[nodiscard]] __sus_pure_const constexpr friend P operator>>(P l, _self r) noexcept {
+[[nodiscard]] __sus_pure_const friend constexpr P operator>>(P l, _self r) noexcept {
   // No UB checks on primitive types, since there's no promotion to a Subspace
   // return type?
   return l >> u64(r).primitive_value;

--- a/sus/num/__private/unsigned_integer_methods_impl.inc
+++ b/sus/num/__private/unsigned_integer_methods_impl.inc
@@ -748,6 +748,48 @@ _sus_pure constexpr _self _self::from_ne_bytes(
   return _self(val);
 }
 
+_sus_pure constexpr u32 _self::count_ones() const& noexcept {
+  return __private::count_ones(primitive_value);
+}
+
+_sus_pure constexpr u32 _self::count_zeros() const& noexcept {
+  return (~(*this)).count_ones();
+}
+
+_sus_pure constexpr u32 _self::leading_ones() const& noexcept {
+  return (~(*this)).leading_zeros();
+}
+
+_sus_pure constexpr u32 _self::leading_zeros() const& noexcept {
+  return __private::leading_zeros(primitive_value);
+}
+
+_sus_pure constexpr u32 _self::trailing_ones() const& noexcept {
+  return (~(*this)).trailing_zeros();
+}
+
+_sus_pure constexpr u32 _self::trailing_zeros() const& noexcept {
+  return __private::trailing_zeros(primitive_value);
+}
+
+_sus_pure constexpr _self _self::pow(u32 rhs) const& noexcept {
+  const auto out =
+      __private::pow_with_overflow(primitive_value, rhs.primitive_value);
+  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+    sus_check_with_message(!out.overflow,
+                              "attempt to multiply with overflow");
+  }
+  return _self(out.value);
+}
+
+_sus_pure constexpr _self _self::wrapping_pow(u32 exp) const& noexcept {
+  return _self(__private::wrapping_pow(primitive_value, exp.primitive_value));
+}
+
+_sus_pure constexpr bool _self::is_power_of_two() const& noexcept {
+  return count_ones() == _self(_primitive{1u});
+}
+
 }  // namespace sus::num
 
 // std hash support.
@@ -781,9 +823,6 @@ struct fmt::formatter<::sus::num::_self, Char> {
  private:
   formatter<_primitive, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::num, _self);
 
 #undef _self
 #undef _primitive

--- a/sus/num/__private/unsigned_integer_methods_impl.inc
+++ b/sus/num/__private/unsigned_integer_methods_impl.inc
@@ -776,8 +776,7 @@ _sus_pure constexpr _self _self::pow(u32 rhs) const& noexcept {
   const auto out =
       __private::pow_with_overflow(primitive_value, rhs.primitive_value);
   if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(!out.overflow,
-                              "attempt to multiply with overflow");
+    sus_check_with_message(!out.overflow, "attempt to multiply with overflow");
   }
   return _self(out.value);
 }

--- a/sus/num/signed_integer.h
+++ b/sus/num/signed_integer.h
@@ -131,7 +131,7 @@ struct [[_sus_trivial_abi]] isize final {
   ///
   /// #[doc.overloads=ptr.add.isize]
   template <class T>
-  constexpr friend T*& operator+=(T*& t, isize offset) {
+  friend constexpr T*& operator+=(T*& t, isize offset) {
     t += ptrdiff_t{offset};
     return t;
   }
@@ -144,7 +144,7 @@ struct [[_sus_trivial_abi]] isize final {
   ///
   /// #[doc.overloads=ptr.sub.isize]
   template <class T>
-  __sus_pure_const constexpr friend T* operator-(T* t, isize offset) {
+  __sus_pure_const friend constexpr T* operator-(T* t, isize offset) {
     return t - ptrdiff_t{offset};
   }
 
@@ -156,7 +156,7 @@ struct [[_sus_trivial_abi]] isize final {
   ///
   /// #[doc.overloads=ptr.sub.isize]
   template <class T>
-  constexpr friend T*& operator-=(T*& t, isize offset) {
+  friend constexpr T*& operator-=(T*& t, isize offset) {
     t -= ptrdiff_t{offset};
     return t;
   }
@@ -169,7 +169,7 @@ struct [[_sus_trivial_abi]] isize final {
   ///
   /// #[doc.overloads=ptr.add.isize]
   template <class T>
-  __sus_pure_const constexpr friend T* operator+(T* t, isize offset) {
+  __sus_pure_const friend constexpr T* operator+(T* t, isize offset) {
     return t + ptrdiff_t{offset};
   }
 };

--- a/sus/num/signed_integer.h
+++ b/sus/num/signed_integer.h
@@ -38,6 +38,7 @@
 #include "sus/num/integer_concepts.h"
 #include "sus/num/try_from_int_error.h"
 #include "sus/num/unsigned_integer.h"
+#include "sus/num/unsigned_integer_consts.h"
 #include "sus/option/option.h"
 #include "sus/ptr/copy.h"
 #include "sus/result/result.h"
@@ -58,6 +59,43 @@ struct [[_sus_trivial_abi]] i32 final {
 #define _primitive int32_t
 #define _unsigned u32
 #include "sus/num/__private/signed_integer_methods.inc"
+
+  /// #[doc.overloads=signedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend i32 operator<<(
+      i32 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift left with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shl(u64(r).primitive_value);
+    }
+  }
+
+  /// #[doc.overloads=signedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i32 operator<<(i32 l, U r) noexcept = delete;
+
+  /// #[doc.overloads=signedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend i32 operator>>(
+      i32 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift right with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shr(u64(r).primitive_value);
+    }
+  }
+  /// #[doc.overloads=signedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i32 operator>>(i32 l, U r) noexcept = delete;
 };
 #define _self i32
 #define _primitive int32_t
@@ -71,6 +109,74 @@ struct [[_sus_trivial_abi]] i8 final {
 #define _primitive int8_t
 #define _unsigned u8
 #include "sus/num/__private/signed_integer_methods.inc"
+
+  /// Satisfies the [`Shl`]($sus::num::Shl) concept for signed integers.
+  ///
+  /// This operation supports shifting with primitive signed or unsigned integers
+  /// that convert to the safe numeric, as well as enums.
+  /// However enum class is excluded as they require an explicit conversion to an
+  /// integer.
+  ///
+  /// Thus the bound is `std::convertible_to` (implicit conversion) instead of
+  /// `sus::construct::From` (explicit conversion).
+  ///
+  /// # Panics
+  /// This function will panic when `r` is not less than the number of bits in `l`
+  /// if overflow checks are enabled (they are by default) and will perform a
+  /// wrapping shift if overflow checks are disabled (not the default).
+  ///
+  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+  /// behaviour.
+  ///
+  /// #[doc.overloads=signedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend i8 operator<<(
+      i8 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift left with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shl(u64(r).primitive_value);
+    }
+  }
+
+  /// #[doc.overloads=signedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i8 operator<<(i8 l, U r) noexcept = delete;
+
+  /// Satisfies the [`Shr`]($sus::num::Shr) concept for signed integers.
+  ///
+  /// Performs sign extension, copying the sign bit to the right if its set.
+  ///
+  /// # Panics
+  /// This function will panic when `r` is not less than the number of bits in `l`
+  /// if overflow checks are enabled (they are by default) and will perform a
+  /// wrapping shift if overflow checks are disabled (not the default).
+  ///
+  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+  /// behaviour.
+  ///
+  /// #[doc.overloads=signedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend i8 operator>>(
+      i8 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift right with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shr(u64(r).primitive_value);
+    }
+  }
+
+  /// #[doc.overloads=signedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i8 operator>>(i8 l, U r) noexcept = delete;
 };
 #define _self i8
 #define _primitive int8_t
@@ -84,6 +190,41 @@ struct [[_sus_trivial_abi]] i16 final {
 #define _primitive int16_t
 #define _unsigned u16
 #include "sus/num/__private/signed_integer_methods.inc"
+
+  /// #[doc.overloads=signedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend i16 operator<<(
+      i16 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift left with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shl(u64(r).primitive_value);
+    }
+  }
+  /// #[doc.overloads=signedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i16 operator<<(i16 l, U r) noexcept = delete;
+  /// #[doc.overloads=signedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend i16 operator>>(
+      i16 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift right with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shr(u64(r).primitive_value);
+    }
+  }
+  /// #[doc.overloads=signedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i16 operator>>(i16 l, U r) noexcept = delete;
 };
 #define _self i16
 #define _primitive int16_t
@@ -97,6 +238,44 @@ struct [[_sus_trivial_abi]] i64 final {
 #define _primitive int64_t
 #define _unsigned u64
 #include "sus/num/__private/signed_integer_methods.inc"
+
+  /// #[doc.overloads=signedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend i64 operator<<(
+      i64 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift left with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shl(u64(r).primitive_value);
+    }
+  }
+
+  /// #[doc.overloads=signedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i64 operator<<(i64 l, U r) noexcept = delete;
+
+  /// #[doc.overloads=signedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend i64 operator>>(
+      i64 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift right with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shr(u64(r).primitive_value);
+    }
+  }
+
+  /// #[doc.overloads=signedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend i64 operator>>(i64 l, U r) noexcept = delete;
 };
 #define _self i64
 #define _primitive int64_t
@@ -121,61 +300,98 @@ struct [[_sus_trivial_abi]] isize final {
 #define _primitive ::sus::num::__private::addr_type<>::signed_type
 #define _unsigned usize
 #include "sus/num/__private/signed_integer_methods.inc"
+
+  /// #[doc.overloads=signedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend isize operator<<(
+      isize l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift left with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shl(u64(r).primitive_value);
+    }
+  }
+
+  /// #[doc.overloads=signedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend isize operator<<(isize l, U r) noexcept = delete;
+
+  /// #[doc.overloads=signedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend isize operator>>(
+      isize l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      const auto out =
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      sus_check_with_message(!out.overflow,
+                                "attempt to shift right with overflow");
+      return out.value;
+    } else {
+      return l.wrapping_shr(u64(r).primitive_value);
+    }
+  }
+
+  /// #[doc.overloads=signedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend isize operator>>(isize l, U r) noexcept = delete;
+
+  /// Satisfies the [`AddAssign`]($sus::num::AddAssign) concept for pointers
+  /// (`T*`) with [`isize`]($sus::num::isize).
+  ///
+  /// Adds a [`isize`]($sus::num::isize) to a referenced pointer, and returns
+  /// the input reference.
+  ///
+  /// #[doc.overloads=ptr.add.isize]
+  template <class T>
+  constexpr friend T*& operator+=(T*& t, isize offset) {
+    t += ptrdiff_t{offset};
+    return t;
+  }
+
+  /// Satisfies the [`Sub`]($sus::num::Sub) concept for pointers
+  /// (`T*`) with [`isize`]($sus::num::isize).
+  ///
+  /// Subtracts a [`isize`]($sus::num::isize) from a pointer, returning the
+  /// resulting pointer.
+  ///
+  /// #[doc.overloads=ptr.sub.isize]
+  template <class T>
+  __sus_pure_const constexpr friend T* operator-(T* t, isize offset) {
+    return t - ptrdiff_t{offset};
+  }
+
+  /// Satisfies the [`SubAssign`]($sus::num::SubAssign) concept for pointers
+  /// (`T*`) with [`isize`]($sus::num::isize).
+  ///
+  /// Subtracts a [`isize`]($sus::num::isize) from a referenced pointer, and
+  /// returns the input reference.
+  ///
+  /// #[doc.overloads=ptr.sub.isize]
+  template <class T>
+  constexpr friend T*& operator-=(T*& t, isize offset) {
+    t -= ptrdiff_t{offset};
+    return t;
+  }
+
+  /// Satisfies the [`Add`]($sus::num::Add) concept for pointers
+  /// (`T*`) with [`isize`]($sus::num::isize).
+  ///
+  /// Adds a [`isize`]($sus::num::isize) to a pointer, returning the resulting
+  /// pointer.
+  ///
+  /// #[doc.overloads=ptr.add.isize]
+  template <class T>
+  __sus_pure_const constexpr friend T* operator+(T* t, isize offset) {
+    return t + ptrdiff_t{offset};
+  }
 };
 #define _self isize
 #define _primitive ::sus::num::__private::addr_type<>::signed_type
 #include "sus/num/__private/signed_integer_consts.inc"
-
-/// Satisfies the [`Add`]($sus::num::Add) concept for pointers
-/// (`T*`) with [`isize`]($sus::num::isize).
-///
-/// Adds a [`isize`]($sus::num::isize) to a pointer, returning the resulting
-/// pointer.
-///
-/// #[doc.overloads=ptr.add.isize]
-template <class T, Signed S>
-  requires(std::constructible_from<isize, S>)
-__sus_pure_const constexpr inline T* operator+(T* t, S offset) {
-  return t + ptrdiff_t{offset};
-}
-
-/// Satisfies the [`AddAssign`]($sus::num::AddAssign) concept for pointers
-/// (`T*`) with [`isize`]($sus::num::isize).
-///
-/// Adds a [`isize`]($sus::num::isize) to a referenced pointer, and returns
-/// the input reference.
-///
-/// #[doc.overloads=ptr.add.isize]
-template <class T>
-constexpr inline T*& operator+=(T*& t, isize offset) {
-  t += ptrdiff_t{offset};
-  return t;
-}
-
-/// Satisfies the [`Sub`]($sus::num::Sub) concept for pointers
-/// (`T*`) with [`isize`]($sus::num::isize).
-///
-/// Subtracts a [`isize`]($sus::num::isize) from a pointer, returning the
-/// resulting pointer.
-///
-/// #[doc.overloads=ptr.sub.isize]
-template <class T>
-__sus_pure_const constexpr inline T* operator-(T* t, isize offset) {
-  return t - ptrdiff_t{offset};
-}
-
-/// Satisfies the [`SubAssign`]($sus::num::SubAssign) concept for pointers
-/// (`T*`) with [`isize`]($sus::num::isize).
-///
-/// Subtracts a [`isize`]($sus::num::isize) from a referenced pointer, and
-/// returns the input reference.
-///
-/// #[doc.overloads=ptr.sub.isize]
-template <class T>
-constexpr inline T*& operator-=(T*& t, isize offset) {
-  t -= ptrdiff_t{offset};
-  return t;
-}
 
 /// Satisfies the [`Shl`]($sus::num::Shl) concept for signed primitive integers
 /// shifted by [`u64`]($sus::num::u64).
@@ -212,208 +428,6 @@ template <class P, Integer U>
   requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
            !std::convertible_to<U, u64>)
 constexpr inline P operator>>(P l, U r) noexcept = delete;
-
-/// Satisfies the [`Shl`]($sus::num::Shl) concept for signed integers.
-///
-/// This operation supports shifting with primitive signed or unsigned integers
-/// that convert to the safe numeric, as well as enums.
-/// However enum class is excluded as they require an explicit conversion to an
-/// integer.
-///
-/// Thus the bound is `std::convertible_to` (implicit conversion) instead of
-/// `sus::construct::From` (explicit conversion).
-///
-/// # Panics
-/// This function will panic when `r` is not less than the number of bits in `l`
-/// if overflow checks are enabled (they are by default) and will perform a
-/// wrapping shift if overflow checks are disabled (not the default).
-///
-/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-/// behaviour.
-///
-/// #[doc.overloads=signedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline i8 operator<<(
-    i8 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift left with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shl(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i8 operator<<(i8 l, U r) noexcept = delete;
-/// Satisfies the [`Shr`]($sus::num::Shr) concept for signed integers.
-///
-/// Performs sign extension, copying the sign bit to the right if its set.
-///
-/// # Panics
-/// This function will panic when `r` is not less than the number of bits in `l`
-/// if overflow checks are enabled (they are by default) and will perform a
-/// wrapping shift if overflow checks are disabled (not the default).
-///
-/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-/// behaviour.
-///
-/// #[doc.overloads=signedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline i8 operator>>(
-    i8 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift right with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shr(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i8 operator>>(i8 l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline i16 operator<<(
-    i16 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift left with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shl(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i16 operator<<(i16 l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline i16 operator>>(
-    i16 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift right with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shr(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i16 operator>>(i16 l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline i32 operator<<(
-    i32 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift left with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shl(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i32 operator<<(i32 l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline i32 operator>>(
-    i32 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift right with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shr(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i32 operator>>(i32 l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline i64 operator<<(
-    i64 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift left with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shl(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i64 operator<<(i64 l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline i64 operator>>(
-    i64 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift right with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shr(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline i64 operator>>(i64 l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline isize operator<<(
-    isize l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift left with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shl(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline isize operator<<(isize l, U r) noexcept = delete;
-/// #[doc.overloads=signedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline isize operator>>(
-    isize l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    const auto out =
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
-    sus_check_with_message(!out.overflow,
-                              "attempt to shift right with overflow");
-    return out.value;
-  } else {
-    return l.wrapping_shr(u64(r).primitive_value);
-  }
-}
-/// #[doc.overloads=signedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline isize operator>>(isize l, U r) noexcept = delete;
-
 }  // namespace sus::num
 
 /// For writing [`i8`]($sus::num::i8) literals.

--- a/sus/num/signed_integer.h
+++ b/sus/num/signed_integer.h
@@ -64,10 +64,10 @@ struct [[_sus_trivial_abi]] i32 final {
   [[nodiscard]] __sus_pure_const constexpr friend i32 operator<<(
       i32 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shl_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift left with overflow");
+                             "attempt to shift left with overflow");
       return out.value;
     } else {
       return l.wrapping_shl(u64(r).primitive_value);
@@ -83,10 +83,10 @@ struct [[_sus_trivial_abi]] i32 final {
   [[nodiscard]] __sus_pure_const constexpr friend i32 operator>>(
       i32 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shr_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return out.value;
     } else {
       return l.wrapping_shr(u64(r).primitive_value);
@@ -132,10 +132,10 @@ struct [[_sus_trivial_abi]] i8 final {
   [[nodiscard]] __sus_pure_const constexpr friend i8 operator<<(
       i8 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shl_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift left with overflow");
+                             "attempt to shift left with overflow");
       return out.value;
     } else {
       return l.wrapping_shl(u64(r).primitive_value);
@@ -163,10 +163,10 @@ struct [[_sus_trivial_abi]] i8 final {
   [[nodiscard]] __sus_pure_const constexpr friend i8 operator>>(
       i8 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shr_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return out.value;
     } else {
       return l.wrapping_shr(u64(r).primitive_value);
@@ -195,10 +195,10 @@ struct [[_sus_trivial_abi]] i16 final {
   [[nodiscard]] __sus_pure_const constexpr friend i16 operator<<(
       i16 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shl_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift left with overflow");
+                             "attempt to shift left with overflow");
       return out.value;
     } else {
       return l.wrapping_shl(u64(r).primitive_value);
@@ -212,10 +212,10 @@ struct [[_sus_trivial_abi]] i16 final {
   [[nodiscard]] __sus_pure_const constexpr friend i16 operator>>(
       i16 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shr_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return out.value;
     } else {
       return l.wrapping_shr(u64(r).primitive_value);
@@ -243,10 +243,10 @@ struct [[_sus_trivial_abi]] i64 final {
   [[nodiscard]] __sus_pure_const constexpr friend i64 operator<<(
       i64 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shl_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift left with overflow");
+                             "attempt to shift left with overflow");
       return out.value;
     } else {
       return l.wrapping_shl(u64(r).primitive_value);
@@ -262,10 +262,10 @@ struct [[_sus_trivial_abi]] i64 final {
   [[nodiscard]] __sus_pure_const constexpr friend i64 operator>>(
       i64 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shr_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return out.value;
     } else {
       return l.wrapping_shr(u64(r).primitive_value);
@@ -305,10 +305,10 @@ struct [[_sus_trivial_abi]] isize final {
   [[nodiscard]] __sus_pure_const constexpr friend isize operator<<(
       isize l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shl_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift left with overflow");
+                             "attempt to shift left with overflow");
       return out.value;
     } else {
       return l.wrapping_shl(u64(r).primitive_value);
@@ -324,10 +324,10 @@ struct [[_sus_trivial_abi]] isize final {
   [[nodiscard]] __sus_pure_const constexpr friend isize operator>>(
       isize l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out =
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value);
+      const auto out = __private::shr_with_overflow(l.primitive_value,
+                                                    u64(r).primitive_value);
       sus_check_with_message(!out.overflow,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return out.value;
     } else {
       return l.wrapping_shr(u64(r).primitive_value);

--- a/sus/num/signed_integer.h
+++ b/sus/num/signed_integer.h
@@ -59,43 +59,6 @@ struct [[_sus_trivial_abi]] i32 final {
 #define _primitive int32_t
 #define _unsigned u32
 #include "sus/num/__private/signed_integer_methods.inc"
-
-  /// #[doc.overloads=signedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend i32 operator<<(
-      i32 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shl_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift left with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shl(u64(r).primitive_value);
-    }
-  }
-
-  /// #[doc.overloads=signedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i32 operator<<(i32 l, U r) noexcept = delete;
-
-  /// #[doc.overloads=signedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend i32 operator>>(
-      i32 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shr_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift right with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shr(u64(r).primitive_value);
-    }
-  }
-  /// #[doc.overloads=signedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i32 operator>>(i32 l, U r) noexcept = delete;
 };
 #define _self i32
 #define _primitive int32_t
@@ -109,74 +72,6 @@ struct [[_sus_trivial_abi]] i8 final {
 #define _primitive int8_t
 #define _unsigned u8
 #include "sus/num/__private/signed_integer_methods.inc"
-
-  /// Satisfies the [`Shl`]($sus::num::Shl) concept for signed integers.
-  ///
-  /// This operation supports shifting with primitive signed or unsigned integers
-  /// that convert to the safe numeric, as well as enums.
-  /// However enum class is excluded as they require an explicit conversion to an
-  /// integer.
-  ///
-  /// Thus the bound is `std::convertible_to` (implicit conversion) instead of
-  /// `sus::construct::From` (explicit conversion).
-  ///
-  /// # Panics
-  /// This function will panic when `r` is not less than the number of bits in `l`
-  /// if overflow checks are enabled (they are by default) and will perform a
-  /// wrapping shift if overflow checks are disabled (not the default).
-  ///
-  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-  /// behaviour.
-  ///
-  /// #[doc.overloads=signedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend i8 operator<<(
-      i8 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shl_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift left with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shl(u64(r).primitive_value);
-    }
-  }
-
-  /// #[doc.overloads=signedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i8 operator<<(i8 l, U r) noexcept = delete;
-
-  /// Satisfies the [`Shr`]($sus::num::Shr) concept for signed integers.
-  ///
-  /// Performs sign extension, copying the sign bit to the right if its set.
-  ///
-  /// # Panics
-  /// This function will panic when `r` is not less than the number of bits in `l`
-  /// if overflow checks are enabled (they are by default) and will perform a
-  /// wrapping shift if overflow checks are disabled (not the default).
-  ///
-  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-  /// behaviour.
-  ///
-  /// #[doc.overloads=signedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend i8 operator>>(
-      i8 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shr_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift right with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shr(u64(r).primitive_value);
-    }
-  }
-
-  /// #[doc.overloads=signedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i8 operator>>(i8 l, U r) noexcept = delete;
 };
 #define _self i8
 #define _primitive int8_t
@@ -190,41 +85,6 @@ struct [[_sus_trivial_abi]] i16 final {
 #define _primitive int16_t
 #define _unsigned u16
 #include "sus/num/__private/signed_integer_methods.inc"
-
-  /// #[doc.overloads=signedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend i16 operator<<(
-      i16 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shl_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift left with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shl(u64(r).primitive_value);
-    }
-  }
-  /// #[doc.overloads=signedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i16 operator<<(i16 l, U r) noexcept = delete;
-  /// #[doc.overloads=signedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend i16 operator>>(
-      i16 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shr_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift right with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shr(u64(r).primitive_value);
-    }
-  }
-  /// #[doc.overloads=signedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i16 operator>>(i16 l, U r) noexcept = delete;
 };
 #define _self i16
 #define _primitive int16_t
@@ -238,44 +98,6 @@ struct [[_sus_trivial_abi]] i64 final {
 #define _primitive int64_t
 #define _unsigned u64
 #include "sus/num/__private/signed_integer_methods.inc"
-
-  /// #[doc.overloads=signedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend i64 operator<<(
-      i64 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shl_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift left with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shl(u64(r).primitive_value);
-    }
-  }
-
-  /// #[doc.overloads=signedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i64 operator<<(i64 l, U r) noexcept = delete;
-
-  /// #[doc.overloads=signedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend i64 operator>>(
-      i64 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shr_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift right with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shr(u64(r).primitive_value);
-    }
-  }
-
-  /// #[doc.overloads=signedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend i64 operator>>(i64 l, U r) noexcept = delete;
 };
 #define _self i64
 #define _primitive int64_t
@@ -300,44 +122,6 @@ struct [[_sus_trivial_abi]] isize final {
 #define _primitive ::sus::num::__private::addr_type<>::signed_type
 #define _unsigned usize
 #include "sus/num/__private/signed_integer_methods.inc"
-
-  /// #[doc.overloads=signedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend isize operator<<(
-      isize l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shl_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift left with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shl(u64(r).primitive_value);
-    }
-  }
-
-  /// #[doc.overloads=signedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend isize operator<<(isize l, U r) noexcept = delete;
-
-  /// #[doc.overloads=signedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend isize operator>>(
-      isize l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      const auto out = __private::shr_with_overflow(l.primitive_value,
-                                                    u64(r).primitive_value);
-      sus_check_with_message(!out.overflow,
-                             "attempt to shift right with overflow");
-      return out.value;
-    } else {
-      return l.wrapping_shr(u64(r).primitive_value);
-    }
-  }
-
-  /// #[doc.overloads=signedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend isize operator>>(isize l, U r) noexcept = delete;
 
   /// Satisfies the [`AddAssign`]($sus::num::AddAssign) concept for pointers
   /// (`T*`) with [`isize`]($sus::num::isize).
@@ -392,42 +176,6 @@ struct [[_sus_trivial_abi]] isize final {
 #define _self isize
 #define _primitive ::sus::num::__private::addr_type<>::signed_type
 #include "sus/num/__private/signed_integer_consts.inc"
-
-/// Satisfies the [`Shl`]($sus::num::Shl) concept for signed primitive integers
-/// shifted by [`u64`]($sus::num::u64).
-/// #[doc.overloads=signed.prim.<<u64]
-template <class P, Integer U>
-  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr inline P operator<<(P l, U r) noexcept {
-  // No UB checks on primitive types, since there's no promotion to a Subspace
-  // return type?
-  return l << u64(r).primitive_value;
-}
-/// #[doc.overloads=signed.prim.<<u64]
-template <class P, Integer U>
-  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u64>)
-constexpr inline P operator<<(P l, U r) noexcept = delete;
-
-/// Satisfies the [`Shr`]($sus::num::Shr) concept for signed primitive integers
-/// shifted by [`u64`]($sus::num::u64).
-///
-/// Performs sign extension, copying the sign bit to the right if its set.
-/// #[doc.overloads=signed.prim.>>u64]
-template <class P, Integer U>
-  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr inline P operator>>(P l, U r) noexcept {
-  // No UB checks on primitive types, since there's no promotion to a Subspace
-  // return type?
-  return l >> u64(r).primitive_value;
-}
-/// #[doc.overloads=signed.prim.>>u64]
-template <class P, Integer U>
-  requires((SignedPrimitiveInteger<P> || SignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u64>)
-constexpr inline P operator>>(P l, U r) noexcept = delete;
 }  // namespace sus::num
 
 /// For writing [`i8`]($sus::num::i8) literals.

--- a/sus/num/try_from_int_error.h
+++ b/sus/num/try_from_int_error.h
@@ -35,9 +35,10 @@ class TryFromIntError {
   _sus_pure constexpr Kind kind() const noexcept;
 
   /// Satisfies the [`Eq`]($sus::cmp::Eq) concept.
-  _sus_pure friend constexpr bool operator==(TryFromIntError lhs, TryFromIntError rhs) noexcept{
-  return lhs.kind_ == rhs.kind_;
-}
+  _sus_pure friend constexpr bool operator==(TryFromIntError lhs,
+                                             TryFromIntError rhs) noexcept {
+    return lhs.kind_ == rhs.kind_;
+  }
 
  private:
   enum Construct { CONSTRUCT };

--- a/sus/num/try_from_int_error.h
+++ b/sus/num/try_from_int_error.h
@@ -35,7 +35,9 @@ class TryFromIntError {
   _sus_pure constexpr Kind kind() const noexcept;
 
   /// Satisfies the [`Eq`]($sus::cmp::Eq) concept.
-  _sus_pure constexpr bool operator==(TryFromIntError rhs) const noexcept;
+  _sus_pure friend constexpr bool operator==(TryFromIntError lhs, TryFromIntError rhs) noexcept{
+  return lhs.kind_ == rhs.kind_;
+}
 
  private:
   enum Construct { CONSTRUCT };

--- a/sus/num/try_from_int_error_impl.h
+++ b/sus/num/try_from_int_error_impl.h
@@ -35,11 +35,6 @@ _sus_pure constexpr TryFromIntError::Kind TryFromIntError::kind()
   return kind_;
 }
 
-_sus_pure constexpr bool TryFromIntError::operator==(
-    TryFromIntError rhs) const noexcept {
-  return kind_ == rhs.kind_;
-}
-
 constexpr TryFromIntError::TryFromIntError(Construct, Kind k) noexcept
     : kind_(k) {}
 

--- a/sus/num/types.h
+++ b/sus/num/types.h
@@ -115,4 +115,8 @@ namespace num {}
 #include "sus/num/try_from_int_error_impl.h"
 #include "sus/num/unsigned_integer.h"
 #include "sus/num/unsigned_integer_impl.h"
+
+// Running an include tracer indicated that placing size_hint_impl.h in this
+// header should fix link-time errors when attempting to format `SizeHint`.
+#include "sus/iter/size_hint_impl.h"
 // IWYU pragma: end_exports

--- a/sus/num/unsigned_integer.h
+++ b/sus/num/unsigned_integer.h
@@ -128,7 +128,7 @@ struct [[_sus_trivial_abi]] usize final {
   ///
   /// #[doc.overloads=ptr.add.usize]
   template <class T>
-  constexpr friend T*& operator+=(T*& t, usize offset) {
+  friend constexpr T*& operator+=(T*& t, usize offset) {
     t += size_t{offset};
     return t;
   }
@@ -141,7 +141,7 @@ struct [[_sus_trivial_abi]] usize final {
   ///
   /// #[doc.overloads=ptr.sub.usize]
   template <class T>
-  __sus_pure_const constexpr friend T* operator-(T* t, usize offset) {
+  __sus_pure_const friend constexpr T* operator-(T* t, usize offset) {
     return t - size_t{offset};
   }
 
@@ -154,7 +154,7 @@ struct [[_sus_trivial_abi]] usize final {
   ///
   /// #[doc.overloads=ptr.sub.usize]
   template <class T>
-  constexpr friend T*& operator-=(T*& t, usize offset) {
+  friend constexpr T*& operator-=(T*& t, usize offset) {
     t -= size_t{offset};
     return t;
   }

--- a/sus/num/unsigned_integer.h
+++ b/sus/num/unsigned_integer.h
@@ -61,13 +61,14 @@ struct [[_sus_trivial_abi]] u64 final {
   [[nodiscard]] __sus_pure_const constexpr friend u64 operator<<(
       u64 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u64::BITS, "attempt to shift left with overflow");
+      sus_check_with_message(r < u64::BITS,
+                             "attempt to shift left with overflow");
       return u64(
           __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u64(
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u64(__private::shl_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                     .value);
     }
   }
 
@@ -81,13 +82,13 @@ struct [[_sus_trivial_abi]] u64 final {
       u64 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
       sus_check_with_message(r < u64::BITS,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return u64(
           __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u64(
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u64(__private::shr_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                     .value);
     }
   }
 
@@ -112,13 +113,14 @@ struct [[_sus_trivial_abi]] u32 final {
   [[nodiscard]] __sus_pure_const constexpr friend u32 operator<<(
       u32 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u32::BITS, "attempt to shift left with overflow");
+      sus_check_with_message(r < u32::BITS,
+                             "attempt to shift left with overflow");
       return u32(
           __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u32(
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u32(__private::shl_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                     .value);
     }
   }
 
@@ -132,13 +134,13 @@ struct [[_sus_trivial_abi]] u32 final {
       u32 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
       sus_check_with_message(r < u32::BITS,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return u32(
           __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u32(
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u32(__private::shr_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                     .value);
     }
   }
 
@@ -174,13 +176,13 @@ struct [[_sus_trivial_abi]] u8 final {
       u8 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
       sus_check_with_message(r < u8::BITS,
-                                "attempt to shift left with overflow");
+                             "attempt to shift left with overflow");
       return u8(
           __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u8(
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u8(__private::shl_with_overflow(l.primitive_value,
+                                             u64(r).primitive_value)
+                    .value);
     }
   }
   /// #[doc.overloads=unsignedint.<<]
@@ -203,13 +205,13 @@ struct [[_sus_trivial_abi]] u8 final {
       u8 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
       sus_check_with_message(r < u8::BITS,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return u8(
           __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u8(
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u8(__private::shr_with_overflow(l.primitive_value,
+                                             u64(r).primitive_value)
+                    .value);
     }
   }
   /// #[doc.overloads=unsignedint.>>]
@@ -234,13 +236,13 @@ struct [[_sus_trivial_abi]] u16 final {
       u16 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
       sus_check_with_message(r < u16::BITS,
-                                "attempt to shift left with overflow");
+                             "attempt to shift left with overflow");
       return u16(
           __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u16(
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u16(__private::shl_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                     .value);
     }
   }
 
@@ -254,13 +256,13 @@ struct [[_sus_trivial_abi]] u16 final {
       u16 l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
       sus_check_with_message(r < u16::BITS,
-                                "attempt to shift right with overflow");
+                             "attempt to shift right with overflow");
       return u16(
           __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
     } else {
-      return u16(
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return u16(__private::shr_with_overflow(l.primitive_value,
+                                              u64(r).primitive_value)
+                     .value);
     }
   }
 
@@ -300,13 +302,14 @@ struct [[_sus_trivial_abi]] usize final {
   [[nodiscard]] __sus_pure_const constexpr friend usize operator<<(
       usize l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < usize::BITS, "attempt to shift left with overflow");
+      sus_check_with_message(r < usize::BITS,
+                             "attempt to shift left with overflow");
       return usize(
           __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
     } else {
-      return usize(
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return usize(__private::shl_with_overflow(l.primitive_value,
+                                                u64(r).primitive_value)
+                       .value);
     }
   }
 
@@ -319,13 +322,14 @@ struct [[_sus_trivial_abi]] usize final {
   [[nodiscard]] __sus_pure_const constexpr friend usize operator>>(
       usize l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < usize::BITS, "attempt to shift right with overflow");
+      sus_check_with_message(r < usize::BITS,
+                             "attempt to shift right with overflow");
       return usize(
           __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
     } else {
-      return usize(
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return usize(__private::shr_with_overflow(l.primitive_value,
+                                                u64(r).primitive_value)
+                       .value);
     }
   }
 
@@ -372,13 +376,14 @@ struct [[_sus_trivial_abi]] uptr final {
   [[nodiscard]] __sus_pure_const constexpr friend uptr operator<<(
       uptr l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < uptr::BITS, "attempt to shift left with overflow");
+      sus_check_with_message(r < uptr::BITS,
+                             "attempt to shift left with overflow");
       return uptr(
           __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
     } else {
-      return uptr(
-          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return uptr(__private::shl_with_overflow(l.primitive_value,
+                                               u64(r).primitive_value)
+                      .value);
     }
   }
 
@@ -391,13 +396,14 @@ struct [[_sus_trivial_abi]] uptr final {
   [[nodiscard]] __sus_pure_const constexpr friend uptr operator>>(
       uptr l, std::convertible_to<u64> auto r) noexcept {
     if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < uptr::BITS, "attempt to shift right with overflow");
+      sus_check_with_message(r < uptr::BITS,
+                             "attempt to shift right with overflow");
       return uptr(
           __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
     } else {
-      return uptr(
-          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-              .value);
+      return uptr(__private::shr_with_overflow(l.primitive_value,
+                                               u64(r).primitive_value)
+                      .value);
     }
   }
 

--- a/sus/num/unsigned_integer.h
+++ b/sus/num/unsigned_integer.h
@@ -46,6 +46,57 @@ namespace sus::num {
 
 // TODO: from_str_radix(). Need Result typ`e and Errors.
 
+/// A 64-bit unsigned integer.
+///
+/// See the [namespace level documentation]($sus::num) for more.
+struct [[_sus_trivial_abi]] u64 final {
+#define _self u64
+#define _pointer false
+#define _pointer_sized
+#define _primitive uint64_t
+#define _signed i64
+#include "sus/num/__private/unsigned_integer_methods.inc"
+
+  /// #[doc.overloads=unsignedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend u64 operator<<(
+      u64 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u64::BITS, "attempt to shift left with overflow");
+      return u64(
+          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u64(
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u64 operator<<(u64 l, U r) noexcept = delete;
+
+  /// #[doc.overloads=unsignedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend u64 operator>>(
+      u64 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u64::BITS,
+                                "attempt to shift right with overflow");
+      return u64(
+          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u64(
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u64 operator>>(u64 l, U r) noexcept = delete;
+};
+
 /// A 32-bit unsigned integer.
 ///
 /// See the [namespace level documentation]($sus::num) for more.
@@ -56,11 +107,46 @@ struct [[_sus_trivial_abi]] u32 final {
 #define _primitive uint32_t
 #define _signed i32
 #include "sus/num/__private/unsigned_integer_methods.inc"
+
+  /// #[doc.overloads=unsignedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend u32 operator<<(
+      u32 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u32::BITS, "attempt to shift left with overflow");
+      return u32(
+          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u32(
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u32 operator<<(u32 l, U r) noexcept = delete;
+
+  /// #[doc.overloads=unsignedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend u32 operator>>(
+      u32 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u32::BITS,
+                                "attempt to shift right with overflow");
+      return u32(
+          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u32(
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u32 operator>>(u32 l, U r) noexcept = delete;
 };
-#define _self u32
-#define _pointer false
-#define _primitive uint32_t
-#include "sus/num/__private/unsigned_integer_consts.inc"
 
 /// An 8-bit unsigned integer.
 ///
@@ -72,11 +158,65 @@ struct [[_sus_trivial_abi]] u8 final {
 #define _primitive uint8_t
 #define _signed i8
 #include "sus/num/__private/unsigned_integer_methods.inc"
+
+  /// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned integers.
+  ///
+  /// # Panics
+  /// This function will panic when `r` is not less than the number of bits in `l`
+  /// if overflow checks are enabled (they are by default) and will perform a
+  /// wrapping shift if overflow checks are disabled (not the default).
+  ///
+  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+  /// behaviour.
+  ///
+  /// #[doc.overloads=unsignedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend u8 operator<<(
+      u8 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u8::BITS,
+                                "attempt to shift left with overflow");
+      return u8(
+          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u8(
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+  /// #[doc.overloads=unsignedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u8 operator<<(u8 l, U r) noexcept = delete;
+
+  /// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned integers.
+  ///
+  /// # Panics
+  /// This function will panic when `r` is not less than the number of bits in `l`
+  /// if overflow checks are enabled (they are by default) and will perform a
+  /// wrapping shift if overflow checks are disabled (not the default).
+  ///
+  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
+  /// behaviour.
+  ///
+  /// #[doc.overloads=unsignedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend u8 operator>>(
+      u8 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u8::BITS,
+                                "attempt to shift right with overflow");
+      return u8(
+          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u8(
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+  /// #[doc.overloads=unsignedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u8 operator>>(u8 l, U r) noexcept = delete;
 };
-#define _self u8
-#define _pointer false
-#define _primitive uint8_t
-#include "sus/num/__private/unsigned_integer_consts.inc"
 
 /// A 16-bit unsigned integer.
 ///
@@ -88,27 +228,47 @@ struct [[_sus_trivial_abi]] u16 final {
 #define _primitive uint16_t
 #define _signed i16
 #include "sus/num/__private/unsigned_integer_methods.inc"
-};
-#define _self u16
-#define _pointer false
-#define _primitive uint16_t
-#include "sus/num/__private/unsigned_integer_consts.inc"
 
-/// A 64-bit unsigned integer.
-///
-/// See the [namespace level documentation]($sus::num) for more.
-struct [[_sus_trivial_abi]] u64 final {
-#define _self u64
-#define _pointer false
-#define _pointer_sized
-#define _primitive uint64_t
-#define _signed i64
-#include "sus/num/__private/unsigned_integer_methods.inc"
+  /// #[doc.overloads=unsignedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend u16 operator<<(
+      u16 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u16::BITS,
+                                "attempt to shift left with overflow");
+      return u16(
+          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u16(
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u16 operator<<(u16 l, U r) noexcept = delete;
+
+  /// #[doc.overloads=unsignedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend u16 operator>>(
+      u16 l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < u16::BITS,
+                                "attempt to shift right with overflow");
+      return u16(
+          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return u16(
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend u16 operator>>(u16 l, U r) noexcept = delete;
 };
-#define _self u64
-#define _pointer false
-#define _primitive uint64_t
-#include "sus/num/__private/unsigned_integer_consts.inc"
 
 /// An address-sized unsigned integer.
 ///
@@ -135,12 +295,45 @@ struct [[_sus_trivial_abi]] usize final {
   ::sus::num::__private::ptr_type<::sus::mem::size_of<size_t>()>::unsigned_type
 #define _signed isize
 #include "sus/num/__private/unsigned_integer_methods.inc"
+
+  /// #[doc.overloads=unsignedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend usize operator<<(
+      usize l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < usize::BITS, "attempt to shift left with overflow");
+      return usize(
+          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return usize(
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend usize operator<<(usize l, U r) noexcept = delete;
+
+  /// #[doc.overloads=unsignedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend usize operator>>(
+      usize l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < usize::BITS, "attempt to shift right with overflow");
+      return usize(
+          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return usize(
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend usize operator>>(usize l, U r) noexcept = delete;
 };
-#define _self usize
-#define _pointer false
-#define _primitive \
-  ::sus::num::__private::ptr_type<::sus::mem::size_of<size_t>()>::unsigned_type
-#include "sus/num/__private/unsigned_integer_consts.inc"
 
 /// A pointer-sized unsigned integer.
 ///
@@ -174,13 +367,45 @@ struct [[_sus_trivial_abi]] uptr final {
   ::sus::num::__private::ptr_type< \
       ::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_methods.inc"
+
+  /// #[doc.overloads=unsignedint.<<]
+  [[nodiscard]] __sus_pure_const constexpr friend uptr operator<<(
+      uptr l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < uptr::BITS, "attempt to shift left with overflow");
+      return uptr(
+          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return uptr(
+          __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.<<]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend uptr operator<<(uptr l, U r) noexcept = delete;
+
+  /// #[doc.overloads=unsignedint.>>]
+  [[nodiscard]] __sus_pure_const constexpr friend uptr operator>>(
+      uptr l, std::convertible_to<u64> auto r) noexcept {
+    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
+      sus_check_with_message(r < uptr::BITS, "attempt to shift right with overflow");
+      return uptr(
+          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
+    } else {
+      return uptr(
+          __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
+              .value);
+    }
+  }
+
+  /// #[doc.overloads=unsignedint.>>]
+  template <class U>
+    requires(!std::convertible_to<U, u64>)
+  constexpr friend uptr operator>>(uptr l, U r) noexcept = delete;
 };
-#define _self uptr
-#define _pointer true
-#define _primitive                 \
-  ::sus::num::__private::ptr_type< \
-      ::sus::mem::size_of<uintptr_t>()>::unsigned_type
-#include "sus/num/__private/unsigned_integer_consts.inc"
 
 /// Satisfies the [`Add`]($sus::num::Add) concept for pointers
 /// (`T*`) with [`usize`]($sus::num::usize).
@@ -267,238 +492,6 @@ template <class P, Integer U>
   requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
            !std::convertible_to<U, u64>)
 constexpr inline P operator>>(P l, U r) noexcept = delete;
-
-/// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned integers.
-///
-/// # Panics
-/// This function will panic when `r` is not less than the number of bits in `l`
-/// if overflow checks are enabled (they are by default) and will perform a
-/// wrapping shift if overflow checks are disabled (not the default).
-///
-/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-/// behaviour.
-///
-/// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline u8 operator<<(
-    u8 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u8::BITS,
-                              "attempt to shift left with overflow");
-    return u8(
-        __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u8(
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u8 operator<<(u8 l, U r) noexcept = delete;
-/// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned integers.
-///
-/// # Panics
-/// This function will panic when `r` is not less than the number of bits in `l`
-/// if overflow checks are enabled (they are by default) and will perform a
-/// wrapping shift if overflow checks are disabled (not the default).
-///
-/// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-/// behaviour.
-///
-/// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline u8 operator>>(
-    u8 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u8::BITS,
-                              "attempt to shift right with overflow");
-    return u8(
-        __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u8(
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u8 operator>>(u8 l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline u16 operator<<(
-    u16 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u16::BITS,
-                              "attempt to shift left with overflow");
-    return u16(
-        __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u16(
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u16 operator<<(u16 l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline u16 operator>>(
-    u16 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u16::BITS,
-                              "attempt to shift right with overflow");
-    return u16(
-        __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u16(
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u16 operator>>(u16 l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline u32 operator<<(
-    u32 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u32::BITS, "attempt to shift left with overflow");
-    return u32(
-        __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u32(
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u32 operator<<(u32 l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline u32 operator>>(
-    u32 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u32::BITS,
-                              "attempt to shift right with overflow");
-    return u32(
-        __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u32(
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u32 operator>>(u32 l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline u64 operator<<(
-    u64 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u64::BITS, "attempt to shift left with overflow");
-    return u64(
-        __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u64(
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u64 operator<<(u64 l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline u64 operator>>(
-    u64 l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < u64::BITS,
-                              "attempt to shift right with overflow");
-    return u64(
-        __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return u64(
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline u64 operator>>(u64 l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline usize operator<<(
-    usize l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < usize::BITS, "attempt to shift left with overflow");
-    return usize(
-        __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return usize(
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline usize operator<<(usize l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline usize operator>>(
-    usize l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < usize::BITS, "attempt to shift right with overflow");
-    return usize(
-        __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return usize(
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline usize operator>>(usize l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.<<]
-[[nodiscard]] __sus_pure_const constexpr inline uptr operator<<(
-    uptr l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < uptr::BITS, "attempt to shift left with overflow");
-    return uptr(
-        __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return uptr(
-        __private::shl_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.<<]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline uptr operator<<(uptr l, U r) noexcept = delete;
-/// #[doc.overloads=unsignedint.>>]
-[[nodiscard]] __sus_pure_const constexpr inline uptr operator>>(
-    uptr l, std::convertible_to<u64> auto r) noexcept {
-  if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-    sus_check_with_message(r < uptr::BITS, "attempt to shift right with overflow");
-    return uptr(
-        __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-  } else {
-    return uptr(
-        __private::shr_with_overflow(l.primitive_value, u64(r).primitive_value)
-            .value);
-  }
-}
-/// #[doc.overloads=unsignedint.>>]
-template <class U>
-  requires(!std::convertible_to<U, u64>)
-constexpr inline uptr operator>>(uptr l, U r) noexcept = delete;
-
 }  // namespace sus::num
 
 /// For writing [`u8`]($sus::num::u8) literals.

--- a/sus/num/unsigned_integer.h
+++ b/sus/num/unsigned_integer.h
@@ -56,46 +56,6 @@ struct [[_sus_trivial_abi]] u64 final {
 #define _primitive uint64_t
 #define _signed i64
 #include "sus/num/__private/unsigned_integer_methods.inc"
-
-  /// #[doc.overloads=unsignedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend u64 operator<<(
-      u64 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u64::BITS,
-                             "attempt to shift left with overflow");
-      return u64(
-          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u64(__private::shl_with_overflow(l.primitive_value,
-                                              u64(r).primitive_value)
-                     .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u64 operator<<(u64 l, U r) noexcept = delete;
-
-  /// #[doc.overloads=unsignedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend u64 operator>>(
-      u64 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u64::BITS,
-                             "attempt to shift right with overflow");
-      return u64(
-          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u64(__private::shr_with_overflow(l.primitive_value,
-                                              u64(r).primitive_value)
-                     .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u64 operator>>(u64 l, U r) noexcept = delete;
 };
 
 /// A 32-bit unsigned integer.
@@ -108,46 +68,6 @@ struct [[_sus_trivial_abi]] u32 final {
 #define _primitive uint32_t
 #define _signed i32
 #include "sus/num/__private/unsigned_integer_methods.inc"
-
-  /// #[doc.overloads=unsignedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend u32 operator<<(
-      u32 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u32::BITS,
-                             "attempt to shift left with overflow");
-      return u32(
-          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u32(__private::shl_with_overflow(l.primitive_value,
-                                              u64(r).primitive_value)
-                     .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u32 operator<<(u32 l, U r) noexcept = delete;
-
-  /// #[doc.overloads=unsignedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend u32 operator>>(
-      u32 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u32::BITS,
-                             "attempt to shift right with overflow");
-      return u32(
-          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u32(__private::shr_with_overflow(l.primitive_value,
-                                              u64(r).primitive_value)
-                     .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u32 operator>>(u32 l, U r) noexcept = delete;
 };
 
 /// An 8-bit unsigned integer.
@@ -160,64 +80,6 @@ struct [[_sus_trivial_abi]] u8 final {
 #define _primitive uint8_t
 #define _signed i8
 #include "sus/num/__private/unsigned_integer_methods.inc"
-
-  /// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned integers.
-  ///
-  /// # Panics
-  /// This function will panic when `r` is not less than the number of bits in `l`
-  /// if overflow checks are enabled (they are by default) and will perform a
-  /// wrapping shift if overflow checks are disabled (not the default).
-  ///
-  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-  /// behaviour.
-  ///
-  /// #[doc.overloads=unsignedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend u8 operator<<(
-      u8 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u8::BITS,
-                             "attempt to shift left with overflow");
-      return u8(
-          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u8(__private::shl_with_overflow(l.primitive_value,
-                                             u64(r).primitive_value)
-                    .value);
-    }
-  }
-  /// #[doc.overloads=unsignedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u8 operator<<(u8 l, U r) noexcept = delete;
-
-  /// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned integers.
-  ///
-  /// # Panics
-  /// This function will panic when `r` is not less than the number of bits in `l`
-  /// if overflow checks are enabled (they are by default) and will perform a
-  /// wrapping shift if overflow checks are disabled (not the default).
-  ///
-  /// See [overflow checks]($sus::num#overflow-behaviour) for controlling this
-  /// behaviour.
-  ///
-  /// #[doc.overloads=unsignedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend u8 operator>>(
-      u8 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u8::BITS,
-                             "attempt to shift right with overflow");
-      return u8(
-          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u8(__private::shr_with_overflow(l.primitive_value,
-                                             u64(r).primitive_value)
-                    .value);
-    }
-  }
-  /// #[doc.overloads=unsignedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u8 operator>>(u8 l, U r) noexcept = delete;
 };
 
 /// A 16-bit unsigned integer.
@@ -230,46 +92,6 @@ struct [[_sus_trivial_abi]] u16 final {
 #define _primitive uint16_t
 #define _signed i16
 #include "sus/num/__private/unsigned_integer_methods.inc"
-
-  /// #[doc.overloads=unsignedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend u16 operator<<(
-      u16 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u16::BITS,
-                             "attempt to shift left with overflow");
-      return u16(
-          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u16(__private::shl_with_overflow(l.primitive_value,
-                                              u64(r).primitive_value)
-                     .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u16 operator<<(u16 l, U r) noexcept = delete;
-
-  /// #[doc.overloads=unsignedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend u16 operator>>(
-      u16 l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < u16::BITS,
-                             "attempt to shift right with overflow");
-      return u16(
-          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return u16(__private::shr_with_overflow(l.primitive_value,
-                                              u64(r).primitive_value)
-                     .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend u16 operator>>(u16 l, U r) noexcept = delete;
 };
 
 /// An address-sized unsigned integer.
@@ -298,45 +120,44 @@ struct [[_sus_trivial_abi]] usize final {
 #define _signed isize
 #include "sus/num/__private/unsigned_integer_methods.inc"
 
-  /// #[doc.overloads=unsignedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend usize operator<<(
-      usize l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < usize::BITS,
-                             "attempt to shift left with overflow");
-      return usize(
-          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return usize(__private::shl_with_overflow(l.primitive_value,
-                                                u64(r).primitive_value)
-                       .value);
-    }
+  /// Satisfies the [`AddAssign`]($sus::num::AddAssign) concept for pointers
+  /// (`T*`) with [`usize`]($sus::num::usize).
+  ///
+  /// Adds a [`usize`]($sus::num::usize) to a referenced pointer, and returns the
+  /// input reference.
+  ///
+  /// #[doc.overloads=ptr.add.usize]
+  template <class T>
+  constexpr friend T*& operator+=(T*& t, usize offset) {
+    t += size_t{offset};
+    return t;
   }
 
-  /// #[doc.overloads=unsignedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend usize operator<<(usize l, U r) noexcept = delete;
-
-  /// #[doc.overloads=unsignedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend usize operator>>(
-      usize l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < usize::BITS,
-                             "attempt to shift right with overflow");
-      return usize(
-          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return usize(__private::shr_with_overflow(l.primitive_value,
-                                                u64(r).primitive_value)
-                       .value);
-    }
+  /// Satisfies the [`Sub`]($sus::num::Sub) concept for pointers
+  /// (`T*`) with [`usize`]($sus::num::usize).
+  ///
+  /// Subtracts a [`usize`]($sus::num::usize) from a pointer, returning the
+  /// resulting pointer.
+  ///
+  /// #[doc.overloads=ptr.sub.usize]
+  template <class T>
+  __sus_pure_const constexpr friend T* operator-(T* t, usize offset) {
+    return t - size_t{offset};
   }
 
-  /// #[doc.overloads=unsignedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend usize operator>>(usize l, U r) noexcept = delete;
+  /// Satisfies the [`SubAssign`]($sus::num::SubAssign) concept for pointers
+  /// (`T*`) with [`usize`]($sus::num::usize).
+  ///
+  /// Subtracts a [`usize`]($sus::num::usize) from a referenced pointer, and
+  /// returns the input
+  /// reference.
+  ///
+  /// #[doc.overloads=ptr.sub.usize]
+  template <class T>
+  constexpr friend T*& operator-=(T*& t, usize offset) {
+    t -= size_t{offset};
+    return t;
+  }
 };
 
 /// A pointer-sized unsigned integer.
@@ -371,133 +192,8 @@ struct [[_sus_trivial_abi]] uptr final {
   ::sus::num::__private::ptr_type< \
       ::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_methods.inc"
-
-  /// #[doc.overloads=unsignedint.<<]
-  [[nodiscard]] __sus_pure_const constexpr friend uptr operator<<(
-      uptr l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < uptr::BITS,
-                             "attempt to shift left with overflow");
-      return uptr(
-          __private::unchecked_shl(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return uptr(__private::shl_with_overflow(l.primitive_value,
-                                               u64(r).primitive_value)
-                      .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.<<]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend uptr operator<<(uptr l, U r) noexcept = delete;
-
-  /// #[doc.overloads=unsignedint.>>]
-  [[nodiscard]] __sus_pure_const constexpr friend uptr operator>>(
-      uptr l, std::convertible_to<u64> auto r) noexcept {
-    if constexpr (SUS_CHECK_INTEGER_OVERFLOW) {
-      sus_check_with_message(r < uptr::BITS,
-                             "attempt to shift right with overflow");
-      return uptr(
-          __private::unchecked_shr(l.primitive_value, u64(r).primitive_value));
-    } else {
-      return uptr(__private::shr_with_overflow(l.primitive_value,
-                                               u64(r).primitive_value)
-                      .value);
-    }
-  }
-
-  /// #[doc.overloads=unsignedint.>>]
-  template <class U>
-    requires(!std::convertible_to<U, u64>)
-  constexpr friend uptr operator>>(uptr l, U r) noexcept = delete;
 };
 
-/// Satisfies the [`Add`]($sus::num::Add) concept for pointers
-/// (`T*`) with [`usize`]($sus::num::usize).
-///
-/// Adds a [`usize`]($sus::num::usize) to a pointer, returning the resulting
-/// pointer.
-///
-/// #[doc.overloads=ptr.add.usize]
-template <class T, Unsigned U>
-  requires(std::constructible_from<usize, U>)
-__sus_pure_const constexpr inline T* operator+(T* t, U offset) {
-  return t + size_t{offset};
-}
-
-/// Satisfies the [`AddAssign`]($sus::num::AddAssign) concept for pointers
-/// (`T*`) with [`usize`]($sus::num::usize).
-///
-/// Adds a [`usize`]($sus::num::usize) to a referenced pointer, and returns the
-/// input reference.
-///
-/// #[doc.overloads=ptr.add.usize]
-template <class T>
-constexpr inline T*& operator+=(T*& t, usize offset) {
-  t += size_t{offset};
-  return t;
-}
-
-/// Satisfies the [`Sub`]($sus::num::Sub) concept for pointers
-/// (`T*`) with [`usize`]($sus::num::usize).
-///
-/// Subtracts a [`usize`]($sus::num::usize) from a pointer, returning the
-/// resulting pointer.
-///
-/// #[doc.overloads=ptr.sub.usize]
-template <class T>
-__sus_pure_const constexpr inline T* operator-(T* t, usize offset) {
-  return t - size_t{offset};
-}
-
-/// Satisfies the [`SubAssign`]($sus::num::SubAssign) concept for pointers
-/// (`T*`) with [`usize`]($sus::num::usize).
-///
-/// Subtracts a [`usize`]($sus::num::usize) from a referenced pointer, and
-/// returns the input
-/// reference.
-///
-/// #[doc.overloads=ptr.sub.usize]
-template <class T>
-constexpr inline T*& operator-=(T*& t, usize offset) {
-  t -= size_t{offset};
-  return t;
-}
-
-/// Satisfies the [`Shl`]($sus::num::Shl) concept for unsigned primitive
-/// integers shifted by [`u64`]($sus::num::u64).
-/// #[doc.overloads=unsigned.prim.<<u64]
-template <class P, Integer U>
-  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr inline P operator<<(P l, U r) noexcept {
-  // No UB checks on primitive types, since there's no promotion to a Subspace
-  // return type?
-  return l << u64(r).primitive_value;
-}
-/// #[doc.overloads=unsigned.prim.<<u64]
-template <class P, Integer U>
-  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u64>)
-constexpr inline P operator<<(P l, U r) noexcept = delete;
-
-/// Satisfies the [`Shr`]($sus::num::Shr) concept for unsigned primitive
-/// integers shifted by [`u64`]($sus::num::u64).
-/// #[doc.overloads=unsigned.prim.>>u64]
-template <class P, Integer U>
-  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           std::convertible_to<U, u64>)
-[[nodiscard]] __sus_pure_const constexpr inline P operator>>(P l, U r) noexcept {
-  // No UB checks on primitive types, since there's no promotion to a Subspace
-  // return type?
-  return l >> u64(r).primitive_value;
-}
-/// #[doc.overloads=unsigned.prim.>>u64]
-template <class P, Integer U>
-  requires((UnsignedPrimitiveInteger<P> || UnsignedPrimitiveEnum<P>) &&
-           !std::convertible_to<U, u64>)
-constexpr inline P operator>>(P l, U r) noexcept = delete;
 }  // namespace sus::num
 
 /// For writing [`u8`]($sus::num::u8) literals.

--- a/sus/num/unsigned_integer_consts.h
+++ b/sus/num/unsigned_integer_consts.h
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/sus/num/unsigned_integer_consts.h
+++ b/sus/num/unsigned_integer_consts.h
@@ -1,0 +1,56 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// IWYU pragma: private, include "sus/num/types.h"
+// IWYU pragma: friend "sus/.*"
+#pragma once
+
+#include "sus/num/unsigned_integer.h"
+
+namespace sus::num {
+
+#define _self u32
+#define _pointer false
+#define _primitive uint32_t
+#include "sus/num/__private/unsigned_integer_consts.inc"
+
+#define _self u8
+#define _pointer false
+#define _primitive uint8_t
+#include "sus/num/__private/unsigned_integer_consts.inc"
+
+#define _self u16
+#define _pointer false
+#define _primitive uint16_t
+#include "sus/num/__private/unsigned_integer_consts.inc"
+
+#define _self u64
+#define _pointer false
+#define _primitive uint64_t
+#include "sus/num/__private/unsigned_integer_consts.inc"
+
+#define _self usize
+#define _pointer false
+#define _primitive \
+  ::sus::num::__private::ptr_type<::sus::mem::size_of<size_t>()>::unsigned_type
+#include "sus/num/__private/unsigned_integer_consts.inc"
+
+#define _self uptr
+#define _pointer true
+#define _primitive                 \
+  ::sus::num::__private::ptr_type< \
+      ::sus::mem::size_of<uintptr_t>()>::unsigned_type
+#include "sus/num/__private/unsigned_integer_consts.inc"
+
+}  // namespace sus::num

--- a/sus/num/unsigned_integer_impl.h
+++ b/sus/num/unsigned_integer_impl.h
@@ -60,5 +60,5 @@
 #define _pointer 1
 #define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_methods_impl.inc"
-
+// Comment to prevent clang-format from deleting this line and sorting includes
 #include "sus/num/unsigned_integer_consts.h"

--- a/sus/num/unsigned_integer_impl.h
+++ b/sus/num/unsigned_integer_impl.h
@@ -60,3 +60,5 @@
 #define _pointer 1
 #define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_methods_impl.inc"
+
+#include "sus/num/unsigned_integer_consts.h"

--- a/sus/num/unsigned_integer_impl.h
+++ b/sus/num/unsigned_integer_impl.h
@@ -60,5 +60,6 @@
 #define _pointer 1
 #define _primitive ::sus::num::__private::ptr_type<::sus::mem::size_of<uintptr_t>()>::unsigned_type
 #include "sus/num/__private/unsigned_integer_methods_impl.inc"
-// Comment to prevent clang-format from deleting this line and sorting includes
+
+// This must come last, after the types are fully defined.
 #include "sus/num/unsigned_integer_consts.h"

--- a/sus/ops/range.h
+++ b/sus/ops/range.h
@@ -218,14 +218,17 @@ class Range final : public __private::RangeIter<Range<T>, T> {
 
   /// Compares two `Range` for equality, satisfying the [`Eq`]($sus::cmp::Eq)
   /// concept if `T` satisfies [`Eq`]($sus::cmp::Eq).
-  constexpr bool operator==(const Range& rhs) const noexcept
+  constexpr friend bool operator==(const Range& lhs, const Range& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
-    return start == rhs.start && finish == rhs.finish;
+    return lhs.start == rhs.start && lhs.finish == rhs.finish;
   }
 
   sus_class_trivially_relocatable_if_types(::sus::marker::unsafe_fn,
                                            decltype(start), decltype(finish));
+
+  // Stream support.
+  _sus_format_to_stream(Range)
 };
 
 /// A range only bounded inclusively below (`start..`).
@@ -299,14 +302,17 @@ class RangeFrom final : public __private::RangeFromIter<RangeFrom<T>, T> {
   }
 
   // sus::cmp::Eq trait
-  constexpr bool operator==(const RangeFrom& rhs) const noexcept
+  constexpr friend bool operator==(const RangeFrom& lhs, const RangeFrom& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
-    return start == rhs.start;
+    return lhs.start == rhs.start;
   }
 
   sus_class_trivially_relocatable_if_types(::sus::marker::unsafe_fn,
                                            decltype(start));
+
+  // Stream support.
+  _sus_format_to_stream(RangeFrom)
 };
 
 /// A range only bounded exclusively above (`..end`).
@@ -370,14 +376,17 @@ class RangeTo final {
   constexpr RangeTo end_at(T t) && noexcept { return RangeTo(::sus::move(t)); }
 
   // sus::cmp::Eq trait
-  constexpr bool operator==(const RangeTo& rhs) const noexcept
+  constexpr friend bool operator==(const RangeTo& lhs, const RangeTo& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
-    return finish == rhs.finish;
+    return lhs.finish == rhs.finish;
   }
 
   sus_class_trivially_relocatable_if_types(::sus::marker::unsafe_fn,
                                            decltype(finish));
+
+  // Stream support.
+  _sus_format_to_stream(RangeTo)
 };
 
 /// An unbounded range (`..`).
@@ -435,13 +444,16 @@ class [[_sus_trivial_abi]] RangeFull final {
   }
 
   // sus::cmp::Eq trait
-  constexpr bool operator==(const RangeFull& rhs) const noexcept
+  constexpr friend bool operator==(const RangeFull&, const RangeFull&) noexcept
     requires(::sus::cmp::Eq<T>)
   {
     return true;
   }
 
   sus_class_trivially_relocatable(::sus::marker::unsafe_fn);
+
+  // Stream support.
+  _sus_format_to_stream(RangeFull)
 };
 
 /// Return a new Range that starts at `start` and ends at `end`.
@@ -487,9 +499,6 @@ struct fmt::formatter<::sus::ops::Range<T>, Char> {
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
 
-// Stream support.
-_sus_format_to_stream(sus::ops, Range, T);
-
 // fmt support.
 template <class T, class Char>
 struct fmt::formatter<::sus::ops::RangeFrom<T>, Char> {
@@ -511,9 +520,6 @@ struct fmt::formatter<::sus::ops::RangeFrom<T>, Char> {
  private:
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::ops, RangeFrom, T);
 
 // fmt support.
 template <class T, class Char>
@@ -537,9 +543,6 @@ struct fmt::formatter<::sus::ops::RangeTo<T>, Char> {
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
 
-// Stream support.
-_sus_format_to_stream(sus::ops, RangeTo, T);
-
 // fmt support.
 template <class T, class Char>
 struct fmt::formatter<::sus::ops::RangeFull<T>, Char> {
@@ -560,6 +563,3 @@ struct fmt::formatter<::sus::ops::RangeFull<T>, Char> {
  private:
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::ops, RangeFull, T);

--- a/sus/ops/range.h
+++ b/sus/ops/range.h
@@ -228,7 +228,7 @@ class Range final : public __private::RangeIter<Range<T>, T> {
                                            decltype(start), decltype(finish));
 
   // Stream support.
-  _sus_format_to_stream(Range)
+  _sus_format_to_stream(Range);
 };
 
 /// A range only bounded inclusively below (`start..`).
@@ -302,7 +302,8 @@ class RangeFrom final : public __private::RangeFromIter<RangeFrom<T>, T> {
   }
 
   // sus::cmp::Eq trait
-  constexpr friend bool operator==(const RangeFrom& lhs, const RangeFrom& rhs) noexcept
+  constexpr friend bool operator==(const RangeFrom& lhs,
+                                   const RangeFrom& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
     return lhs.start == rhs.start;
@@ -312,7 +313,7 @@ class RangeFrom final : public __private::RangeFromIter<RangeFrom<T>, T> {
                                            decltype(start));
 
   // Stream support.
-  _sus_format_to_stream(RangeFrom)
+  _sus_format_to_stream(RangeFrom);
 };
 
 /// A range only bounded exclusively above (`..end`).
@@ -376,7 +377,8 @@ class RangeTo final {
   constexpr RangeTo end_at(T t) && noexcept { return RangeTo(::sus::move(t)); }
 
   // sus::cmp::Eq trait
-  constexpr friend bool operator==(const RangeTo& lhs, const RangeTo& rhs) noexcept
+  constexpr friend bool operator==(const RangeTo& lhs,
+                                   const RangeTo& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
     return lhs.finish == rhs.finish;
@@ -386,7 +388,7 @@ class RangeTo final {
                                            decltype(finish));
 
   // Stream support.
-  _sus_format_to_stream(RangeTo)
+  _sus_format_to_stream(RangeTo);
 };
 
 /// An unbounded range (`..`).
@@ -453,7 +455,7 @@ class [[_sus_trivial_abi]] RangeFull final {
   sus_class_trivially_relocatable(::sus::marker::unsafe_fn);
 
   // Stream support.
-  _sus_format_to_stream(RangeFull)
+  _sus_format_to_stream(RangeFull);
 };
 
 /// Return a new Range that starts at `start` and ends at `end`.

--- a/sus/ops/range.h
+++ b/sus/ops/range.h
@@ -218,7 +218,7 @@ class Range final : public __private::RangeIter<Range<T>, T> {
 
   /// Compares two `Range` for equality, satisfying the [`Eq`]($sus::cmp::Eq)
   /// concept if `T` satisfies [`Eq`]($sus::cmp::Eq).
-  constexpr friend bool operator==(const Range& lhs, const Range& rhs) noexcept
+  friend constexpr bool operator==(const Range& lhs, const Range& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
     return lhs.start == rhs.start && lhs.finish == rhs.finish;
@@ -302,7 +302,7 @@ class RangeFrom final : public __private::RangeFromIter<RangeFrom<T>, T> {
   }
 
   // sus::cmp::Eq trait
-  constexpr friend bool operator==(const RangeFrom& lhs,
+  friend constexpr bool operator==(const RangeFrom& lhs,
                                    const RangeFrom& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
@@ -377,7 +377,7 @@ class RangeTo final {
   constexpr RangeTo end_at(T t) && noexcept { return RangeTo(::sus::move(t)); }
 
   // sus::cmp::Eq trait
-  constexpr friend bool operator==(const RangeTo& lhs,
+  friend constexpr bool operator==(const RangeTo& lhs,
                                    const RangeTo& rhs) noexcept
     requires(::sus::cmp::Eq<T>)
   {
@@ -446,7 +446,7 @@ class [[_sus_trivial_abi]] RangeFull final {
   }
 
   // sus::cmp::Eq trait
-  constexpr friend bool operator==(const RangeFull&, const RangeFull&) noexcept
+  friend constexpr bool operator==(const RangeFull&, const RangeFull&) noexcept
     requires(::sus::cmp::Eq<T>)
   {
     return true;

--- a/sus/option/option.h
+++ b/sus/option/option.h
@@ -365,7 +365,7 @@ namespace sus {
 /// another [`Option`]($sus::option::Option) as input, and produce an
 /// [`Option`]($sus::option::Option) as output.
 /// Only the [`and_that`]($sus::option::Option::and_that)
-/// method can produce an [`Option<U>`]($sus::option::Option) value having a 
+/// method can produce an [`Option<U>`]($sus::option::Option) value having a
 /// different inner type `U` than [`Option<T>`]($sus::option::Option).
 ///
 /// | method                                               | self    | input     | output  |
@@ -1933,6 +1933,9 @@ class Option final {
     }
   }
 
+  // Stream support.
+  _sus_format_to_stream(Option)
+
  private:
   template <class U>
   friend class Option;
@@ -2096,9 +2099,6 @@ struct fmt::formatter<::sus::option::Option<T>, Char> {
  private:
   ::sus::string::__private::AnyFormatter<T, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::option, Option, T);
 
 // Promote Option and its enum values into the `sus` namespace.
 namespace sus {

--- a/sus/option/option.h
+++ b/sus/option/option.h
@@ -1934,7 +1934,7 @@ class Option final {
   }
 
   // Stream support.
-  _sus_format_to_stream(Option)
+  _sus_format_to_stream(Option);
 
  private:
   template <class U>

--- a/sus/ptr/nonnull.h
+++ b/sus/ptr/nonnull.h
@@ -155,7 +155,7 @@ class [[_sus_trivial_abi]] NonNull {
   /// pointers are comparable and thus satisfy `Eq` as well.
   template <class U>
     requires(::sus::cmp::Eq<const T*, const U*>)
-  constexpr friend bool operator==(const NonNull& l,
+  friend constexpr bool operator==(const NonNull& l,
                                    const NonNull<U>& r) noexcept {
     return l.as_ptr() == r.as_ptr();
   }
@@ -164,7 +164,7 @@ class [[_sus_trivial_abi]] NonNull {
   /// pointers are comparable and thus satisfy `StrongOrd` as well.
   template <class U>
     requires(::sus::cmp::StrongOrd<const T*, const U*>)
-  constexpr friend std::strong_ordering operator<=>(
+  friend constexpr std::strong_ordering operator<=>(
       const NonNull& l, const NonNull<U>& r) noexcept {
     return l.as_ptr() <=> r.as_ptr();
   }

--- a/sus/ptr/nonnull.h
+++ b/sus/ptr/nonnull.h
@@ -155,7 +155,8 @@ class [[_sus_trivial_abi]] NonNull {
   /// pointers are comparable and thus satisfy `Eq` as well.
   template <class U>
     requires(::sus::cmp::Eq<const T*, const U*>)
-  constexpr friend bool operator==(const NonNull& l, const NonNull<U>& r) noexcept {
+  constexpr friend bool operator==(const NonNull& l,
+                                   const NonNull<U>& r) noexcept {
     return l.as_ptr() == r.as_ptr();
   }
 
@@ -163,12 +164,13 @@ class [[_sus_trivial_abi]] NonNull {
   /// pointers are comparable and thus satisfy `StrongOrd` as well.
   template <class U>
     requires(::sus::cmp::StrongOrd<const T*, const U*>)
-  constexpr friend std::strong_ordering operator<=>(const NonNull& l, const NonNull<U>& r) noexcept {
+  constexpr friend std::strong_ordering operator<=>(
+      const NonNull& l, const NonNull<U>& r) noexcept {
     return l.as_ptr() <=> r.as_ptr();
   }
 
   // Stream support.
-  _sus_format_to_stream(NonNull)
+  _sus_format_to_stream(NonNull);
 
  private:
   T* ptr_;

--- a/sus/ptr/nonnull.h
+++ b/sus/ptr/nonnull.h
@@ -151,6 +151,25 @@ class [[_sus_trivial_abi]] NonNull {
                                           static_cast<U*>(ptr_));
   }
 
+  /// Satisfies the [`Eq<NonNull<T>, NonNull<U>>`]($sus::cmp::Eq) concept if the
+  /// pointers are comparable and thus satisfy `Eq` as well.
+  template <class U>
+    requires(::sus::cmp::Eq<const T*, const U*>)
+  constexpr friend bool operator==(const NonNull& l, const NonNull<U>& r) noexcept {
+    return l.as_ptr() == r.as_ptr();
+  }
+
+  /// Satisfies the [`StrongOrd<NonNull<T>>`]($sus::cmp::StrongOrd) concept if the
+  /// pointers are comparable and thus satisfy `StrongOrd` as well.
+  template <class U>
+    requires(::sus::cmp::StrongOrd<const T*, const U*>)
+  constexpr friend std::strong_ordering operator<=>(const NonNull& l, const NonNull<U>& r) noexcept {
+    return l.as_ptr() <=> r.as_ptr();
+  }
+
+  // Stream support.
+  _sus_format_to_stream(NonNull)
+
  private:
   T* ptr_;
 
@@ -165,24 +184,6 @@ class [[_sus_trivial_abi]] NonNull {
   explicit constexpr NonNull(::sus::mem::NeverValueConstructor) noexcept
       : ptr_(nullptr) {}
 };
-
-/// Satisfies the [`Eq<NonNull<T>, NonNull<U>>`]($sus::cmp::Eq) concept if the
-/// pointers are comparable and thus satisfy `Eq` as well.
-template <class T, class U>
-  requires(::sus::cmp::Eq<const T*, const U*>)
-constexpr inline bool operator==(const NonNull<T>& l,
-                                 const NonNull<U>& r) noexcept {
-  return l.as_ptr() == r.as_ptr();
-}
-
-/// Satisfies the [`StrongOrd<NonNull<T>>`]($sus::cmp::StrongOrd) concept if the
-/// pointers are comparable and thus satisfy `StrongOrd` as well.
-template <class T, class U>
-  requires(::sus::cmp::StrongOrd<const T*, const U*>)
-constexpr inline std::strong_ordering operator<=>(
-    const NonNull<T>& l, const NonNull<U>& r) noexcept {
-  return l.as_ptr() <=> r.as_ptr();
-}
 
 }  // namespace sus::ptr
 
@@ -203,6 +204,3 @@ struct fmt::formatter<::sus::ptr::NonNull<T>, Char> {
  private:
   formatter<const void*, Char> underlying_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::ptr, NonNull, T);

--- a/sus/result/result.h
+++ b/sus/result/result.h
@@ -775,6 +775,7 @@ class [[nodiscard]] Result final {
   {
     return eq(l, r);
   }
+
   template <class U, class F>
     requires(VoidOrEq<T, U> && ::sus::cmp::Eq<E, F>)
   friend constexpr bool operator==(const Result& l,
@@ -847,6 +848,9 @@ class [[nodiscard]] Result final {
     requires(!VoidOrPartialOrd<T, U> || !::sus::cmp::PartialOrd<E, F>)
   friend constexpr auto operator<=>(const Result& l,
                                     const Result<U, F>& r) noexcept = delete;
+
+  // Stream support.
+  _sus_format_to_stream(Result)
 
  private:
   template <class U, class V>
@@ -1140,9 +1144,6 @@ struct fmt::formatter<::sus::result::Result<T, E>, Char> {
   ::sus::string::__private::AnyOrVoidFormatter<T, Char> underlying_ok_;
   ::sus::string::__private::AnyFormatter<E, Char> underlying_err_;
 };
-
-// Stream support.
-_sus_format_to_stream(sus::result, Result, T, E);
 
 namespace sus {
 using ::sus::result::Err;

--- a/sus/result/result.h
+++ b/sus/result/result.h
@@ -775,7 +775,6 @@ class [[nodiscard]] Result final {
   {
     return eq(l, r);
   }
-
   template <class U, class F>
     requires(VoidOrEq<T, U> && ::sus::cmp::Eq<E, F>)
   friend constexpr bool operator==(const Result& l,

--- a/sus/result/result.h
+++ b/sus/result/result.h
@@ -850,7 +850,7 @@ class [[nodiscard]] Result final {
                                     const Result<U, F>& r) noexcept = delete;
 
   // Stream support.
-  _sus_format_to_stream(Result)
+  _sus_format_to_stream(Result);
 
  private:
   template <class U, class V>

--- a/sus/string/__private/format_to_stream.h
+++ b/sus/string/__private/format_to_stream.h
@@ -24,7 +24,6 @@
 #include "sus/macros/compiler.h"
 #include "sus/macros/for_each.h"
 
-
 namespace sus::string::__private {
 
 template <class To, class From>
@@ -32,13 +31,13 @@ concept ConvertibleFrom = std::convertible_to<From, To>;
 
 template <class T, class Char, class U>
 concept StreamCanReceiveString =
-  !std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>> &&
-  requires(T& t, const std::basic_string<Char> s) {
-    // Check ConvertibleFrom as std streams return std::basic_ostream&, which the
-    // input type `T&` is convertible to. The concept ordering means we want
-    // `ConvertibleFrom<..the output type.., T&>` to be true then.
-    { t << s } -> ConvertibleFrom<T&>;
-  };
+    !std::same_as<std::remove_cvref_t<T>, std::remove_cvref_t<U>> &&
+    requires(T& t, const std::basic_string<Char> s) {
+      // Check ConvertibleFrom as std streams return std::basic_ostream&, which the
+      // input type `T&` is convertible to. The concept ordering means we want
+      // `ConvertibleFrom<..the output type.., T&>` to be true then.
+      { t << s } -> ConvertibleFrom<T&>;
+    };
 
 /// Consumes the string `s` and streams it to the output stream `os`.
 template <class Char, StreamCanReceiveString<Char, void> S>
@@ -95,4 +94,5 @@ S& format_to_stream(S& os, const std::basic_string<Char>& s) {
     static_assert(fmt::is_formattable<U>::value);                                     \
     return ::sus::string::__private::format_to_stream(stream, fmt::to_string(value)); \
   }                                                                                   \
+  static_assert(true)
 // clang-format on

--- a/sus/string/__private/format_to_stream_unittest.cc
+++ b/sus/string/__private/format_to_stream_unittest.cc
@@ -25,7 +25,9 @@
 #include "sus/tuple/tuple.h"
 
 namespace {
-struct Streamable {};
+struct Streamable {
+  _sus_format_to_stream(Streamable)
+};
 }  // namespace
 
 template <>
@@ -40,8 +42,6 @@ struct fmt::formatter<Streamable, char> {
     return fmt::format_to(ctx.out(), "hello");
   }
 };
-
-_sus_format_to_stream(, Streamable);
 
 namespace {
 

--- a/sus/string/__private/format_to_stream_unittest.cc
+++ b/sus/string/__private/format_to_stream_unittest.cc
@@ -26,7 +26,7 @@
 
 namespace {
 struct Streamable {
-  _sus_format_to_stream(Streamable)
+  _sus_format_to_stream(Streamable);
 };
 }  // namespace
 

--- a/sus/tuple/tuple.h
+++ b/sus/tuple/tuple.h
@@ -252,7 +252,7 @@ class Tuple final {
   /// # Implementation Note
   /// The non-template overload allows tuple() marker types to convert to
   /// Tuple for comparison.
-  constexpr friend bool operator==(const Tuple& l, const Tuple& r) noexcept
+  friend constexpr bool operator==(const Tuple& l, const Tuple& r) noexcept
     requires((::sus::cmp::Eq<T> && ... && ::sus::cmp::Eq<Ts>))
   {
     return __private::storage_eq(
@@ -261,7 +261,7 @@ class Tuple final {
   template <class U, class... Us>
     requires(sizeof...(Us) == sizeof...(Ts) &&
              (::sus::cmp::Eq<T, U> && ... && ::sus::cmp::Eq<Ts, Us>))
-  constexpr friend bool operator==(const Tuple& l,
+  friend constexpr bool operator==(const Tuple& l,
                                    const Tuple<U, Us...>& r) noexcept {
     return __private::storage_eq(
         l.storage_, r.storage_, std::make_index_sequence<1u + sizeof...(Ts)>());
@@ -277,7 +277,7 @@ class Tuple final {
   /// Tuple for comparison.
   //
   // sus::cmp::StrongOrd<Tuple<U...>> trait.
-  constexpr friend std::strong_ordering operator<=>(const Tuple& l,
+  friend constexpr std::strong_ordering operator<=>(const Tuple& l,
                                                     const Tuple& r) noexcept
     requires((::sus::cmp::StrongOrd<T> && ... && ::sus::cmp::StrongOrd<Ts>))
   {
@@ -289,7 +289,7 @@ class Tuple final {
     requires(sizeof...(Us) == sizeof...(Ts) &&
              (::sus::cmp::StrongOrd<T, U> && ... &&
               ::sus::cmp::StrongOrd<Ts, Us>))
-  constexpr friend std::strong_ordering operator<=>(
+  friend constexpr std::strong_ordering operator<=>(
       const Tuple& l, const Tuple<U, Us...>& r) noexcept {
     return __private::storage_cmp(
         std::strong_ordering::equal, l.storage_, r.storage_,
@@ -297,7 +297,7 @@ class Tuple final {
   }
 
   // sus::cmp::Ord<Tuple<U...>> trait.
-  constexpr friend std::weak_ordering operator<=>(const Tuple& l,
+  friend constexpr std::weak_ordering operator<=>(const Tuple& l,
                                                   const Tuple& r) noexcept
     requires(!(::sus::cmp::StrongOrd<T> && ... && ::sus::cmp::StrongOrd<Ts>) &&
              (::sus::cmp::Ord<T> && ... && ::sus::cmp::Ord<Ts>))
@@ -311,7 +311,7 @@ class Tuple final {
              !(::sus::cmp::StrongOrd<T, U> && ... &&
                ::sus::cmp::StrongOrd<Ts, Us>) &&
              (::sus::cmp::Ord<T, U> && ... && ::sus::cmp::Ord<Ts, Us>))
-  constexpr friend std::weak_ordering operator<=>(
+  friend constexpr std::weak_ordering operator<=>(
       const Tuple& l, const Tuple<U, Us...>& r) noexcept {
     return __private::storage_cmp(
         std::weak_ordering::equivalent, l.storage_, r.storage_,
@@ -319,7 +319,7 @@ class Tuple final {
   }
 
   // sus::cmp::PartialOrd<Tuple<U...>> trait.
-  constexpr friend std::partial_ordering operator<=>(const Tuple& l,
+  friend constexpr std::partial_ordering operator<=>(const Tuple& l,
                                                      const Tuple& r) noexcept
     requires(!(::sus::cmp::Ord<T> && ... && ::sus::cmp::Ord<Ts>) &&
              (::sus::cmp::PartialOrd<T> && ... && ::sus::cmp::PartialOrd<Ts>))
@@ -333,7 +333,7 @@ class Tuple final {
              !(::sus::cmp::Ord<T, U> && ... && ::sus::cmp::Ord<Ts, Us>) &&
              (::sus::cmp::PartialOrd<T, U> && ... &&
               ::sus::cmp::PartialOrd<Ts, Us>))
-  constexpr friend std::partial_ordering operator<=>(
+  friend constexpr std::partial_ordering operator<=>(
       const Tuple& l, const Tuple<U, Us...>& r) noexcept {
     return __private::storage_cmp(
         std::partial_ordering::equivalent, l.storage_, r.storage_,

--- a/sus/tuple/tuple.h
+++ b/sus/tuple/tuple.h
@@ -261,7 +261,8 @@ class Tuple final {
   template <class U, class... Us>
     requires(sizeof...(Us) == sizeof...(Ts) &&
              (::sus::cmp::Eq<T, U> && ... && ::sus::cmp::Eq<Ts, Us>))
-  constexpr friend bool operator==(const Tuple& l, const Tuple<U, Us...>& r) noexcept {
+  constexpr friend bool operator==(const Tuple& l,
+                                   const Tuple<U, Us...>& r) noexcept {
     return __private::storage_eq(
         l.storage_, r.storage_, std::make_index_sequence<1u + sizeof...(Ts)>());
   }
@@ -276,7 +277,8 @@ class Tuple final {
   /// Tuple for comparison.
   //
   // sus::cmp::StrongOrd<Tuple<U...>> trait.
-  constexpr friend std::strong_ordering operator<=>(const Tuple& l, const Tuple& r) noexcept
+  constexpr friend std::strong_ordering operator<=>(const Tuple& l,
+                                                    const Tuple& r) noexcept
     requires((::sus::cmp::StrongOrd<T> && ... && ::sus::cmp::StrongOrd<Ts>))
   {
     return __private::storage_cmp(
@@ -288,15 +290,15 @@ class Tuple final {
              (::sus::cmp::StrongOrd<T, U> && ... &&
               ::sus::cmp::StrongOrd<Ts, Us>))
   constexpr friend std::strong_ordering operator<=>(
-      const Tuple& l,
-      const Tuple<U, Us...>& r) noexcept {
+      const Tuple& l, const Tuple<U, Us...>& r) noexcept {
     return __private::storage_cmp(
         std::strong_ordering::equal, l.storage_, r.storage_,
         std::make_index_sequence<1u + sizeof...(Ts)>());
   }
 
   // sus::cmp::Ord<Tuple<U...>> trait.
-  constexpr friend std::weak_ordering operator<=>(const Tuple& l, const Tuple& r) noexcept
+  constexpr friend std::weak_ordering operator<=>(const Tuple& l,
+                                                  const Tuple& r) noexcept
     requires(!(::sus::cmp::StrongOrd<T> && ... && ::sus::cmp::StrongOrd<Ts>) &&
              (::sus::cmp::Ord<T> && ... && ::sus::cmp::Ord<Ts>))
   {
@@ -310,15 +312,15 @@ class Tuple final {
                ::sus::cmp::StrongOrd<Ts, Us>) &&
              (::sus::cmp::Ord<T, U> && ... && ::sus::cmp::Ord<Ts, Us>))
   constexpr friend std::weak_ordering operator<=>(
-      const Tuple& l,
-      const Tuple<U, Us...>& r) noexcept {
+      const Tuple& l, const Tuple<U, Us...>& r) noexcept {
     return __private::storage_cmp(
         std::weak_ordering::equivalent, l.storage_, r.storage_,
         std::make_index_sequence<1u + sizeof...(Ts)>());
   }
 
   // sus::cmp::PartialOrd<Tuple<U...>> trait.
-  constexpr friend std::partial_ordering operator<=>(const Tuple& l, const Tuple& r) noexcept
+  constexpr friend std::partial_ordering operator<=>(const Tuple& l,
+                                                     const Tuple& r) noexcept
     requires(!(::sus::cmp::Ord<T> && ... && ::sus::cmp::Ord<Ts>) &&
              (::sus::cmp::PartialOrd<T> && ... && ::sus::cmp::PartialOrd<Ts>))
   {
@@ -332,8 +334,7 @@ class Tuple final {
              (::sus::cmp::PartialOrd<T, U> && ... &&
               ::sus::cmp::PartialOrd<Ts, Us>))
   constexpr friend std::partial_ordering operator<=>(
-      const Tuple& l,
-      const Tuple<U, Us...>& r) noexcept {
+      const Tuple& l, const Tuple<U, Us...>& r) noexcept {
     return __private::storage_cmp(
         std::partial_ordering::equivalent, l.storage_, r.storage_,
         std::make_index_sequence<1u + sizeof...(Ts)>());
@@ -377,7 +378,7 @@ class Tuple final {
     }
   }
 
-  _sus_format_to_stream(Tuple)
+  _sus_format_to_stream(Tuple);
 
  private:
   template <class U, class... Us>


### PR DESCRIPTION
This ensures that they're not placed in their function names' respective overload sets, which has a considerable impact on build times and on compiler diagnostics (as they're not listed as failed candidates when overload resolution fails).