### PR TITLE
changes Git config to be local and to use the GitHub Actions ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,8 @@ jobs:
 
       - name: Set up user details in Git
         run: |
-          git config --global user.email "ci.subspace.workflows@github.com" # This email doesn't exist
-          git config --global user.name "Subspace GitHub CI workflow"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Configure
         shell: cmake -P {0}

--- a/.github/workflows/clang-doc.yml
+++ b/.github/workflows/clang-doc.yml
@@ -54,8 +54,9 @@ jobs:
 
       - name: Set up user details in Git
         run: |
-          git config --global user.email "clang-doc.subspace.workflows@github.com" # This email doesn't exist
-          git config --global user.name "Subspace GitHub clang-doc workflow"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Configure
         run: |
           # Path to LLVM+Clang nightly that we have installed.

--- a/.github/workflows/subdoc.yml
+++ b/.github/workflows/subdoc.yml
@@ -88,8 +88,9 @@ jobs:
 
       - name: Set up user details in Git
         run: |
-          git config --global user.email "subdoc.subspace.workflows@github.com" # This email doesn't exist
-          git config --global user.name "Subspace GitHub Subdoc workflow"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Configure
         shell: cmake -P {0}
         run: |

--- a/.github/workflows/try.yml
+++ b/.github/workflows/try.yml
@@ -212,8 +212,8 @@ jobs:
 
       - name: Set up user details in Git
         run: |
-          git config --global user.email try.subspace.workflows@github.com # This email doesn't exist
-          git config --global user.name "Subspace GitHub Try workflow"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Configure
         shell: cmake -P {0}


### PR DESCRIPTION
The Git configuration should apparently be set locally to remain in tact after VM changes. The values have changed to match what GitHub uses, so that we're not advertising fake email addresses.